### PR TITLE
add aqua tests

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 Cbc = "9961bab8-2fa3-5c5a-9d89-47fab24efd76"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,10 @@ using ParameterJuMP
 using TestSetExtensions
 using DataFrames
 import UUIDs
+import Aqua
+Aqua.test_unbound_args(PowerSimulations)
+Aqua.test_undefined_exports(PowerSimulations)
+Aqua.test_ambiguities(PowerSimulations)
 
 import PowerSystems.UtilsData: TestData
 download(TestData; branch = "master")


### PR DESCRIPTION
There are several ambiguities in the code right now. I added the Package Aqua to detect them. This is the current output 

```
6 ambiguities found
Ambiguity #1
branch_rate_constraints!(psi_container::PowerSimulations.PSIContainer, devices::InfrastructureSystems.FlattenIteratorWrapper{B}, model::PowerSimulations.DeviceModel{B,#s512} where #s512<:PowerSimulations.AbstractDCLineFormulation, system_formulation::Type{#s511} where #s511<:PowerModels.AbstractDCPModel, feedforward::Union{Nothing, PowerSimulations.AbstractAffectFeedForward}) where B<:PowerSystems.DCBranch in PowerSimulations at /Users/jdlara/.julia/packages/PowerSimulations/tDRLp/src/devices_models/devices/DC_branches.jl:67
branch_rate_constraints!(psi_container::PowerSimulations.PSIContainer, devices::InfrastructureSystems.FlattenIteratorWrapper{B}, model::PowerSimulations.DeviceModel{B,PowerSimulations.HVDCLossless}, system_formulation::Type{#s511} where #s511<:PowerModels.AbstractPowerModel, feedforward::Union{Nothing, PowerSimulations.AbstractAffectFeedForward}) where B<:PowerSystems.DCBranch in PowerSimulations at /Users/jdlara/.julia/packages/PowerSimulations/tDRLp/src/devices_models/devices/DC_branches.jl:95

Ambiguity #2
construct_device!(psi_container::PowerSimulations.PSIContainer, sys::PowerSystems.System, model::PowerSimulations.DeviceModel{#s512,#s511} where #s511<:PowerSimulations.AbstractBranchFormulation where #s512<:PowerSystems.ACBranch, ::Type{PowerSimulations.CopperPlatePowerModel}) in PowerSimulations at /Users/jdlara/.julia/packages/PowerSimulations/tDRLp/src/devices_models/device_constructors/branch_constructor.jl:6
construct_device!(psi_container::PowerSimulations.PSIContainer, sys::PowerSystems.System, model::PowerSimulations.DeviceModel{PowerSystems.MonitoredLine,PowerSimulations.FlowMonitoredLine}, ::Type{S}) where S<:PowerModels.AbstractActivePowerModel in PowerSimulations at /Users/jdlara/.julia/packages/PowerSimulations/tDRLp/src/devices_models/device_constructors/branch_constructor.jl:96

Ambiguity #3
(::PowerSimulations.var"#construct_device!##kw")(::Any, ::typeof(PowerSimulations.construct_device!), psi_container::PowerSimulations.PSIContainer, sys::PowerSystems.System, model::PowerSimulations.DeviceModel{R,D}, ::Type{S}) where {R<:PowerSystems.RenewableGen, D<:PowerSimulations.AbstractRenewableDispatchFormulation, S<:PowerModels.AbstractActivePowerModel} in PowerSimulations at /Users/jdlara/.julia/packages/PowerSimulations/tDRLp/src/devices_models/device_constructors/renewablegeneration_constructor.jl:44
(::PowerSimulations.var"#construct_device!##kw")(::Any, ::typeof(PowerSimulations.construct_device!), psi_container::PowerSimulations.PSIContainer, sys::PowerSystems.System, model::PowerSimulations.DeviceModel{PowerSystems.RenewableFix,D}, system_formulation::Type{S}) where {D<:PowerSimulations.AbstractRenewableDispatchFormulation, S<:PowerModels.AbstractPowerModel} in PowerSimulations at /Users/jdlara/.julia/packages/PowerSimulations/tDRLp/src/devices_models/device_constructors/renewablegeneration_constructor.jl:88

Ambiguity #4
construct_device!(psi_container::PowerSimulations.PSIContainer, sys::PowerSystems.System, model::PowerSimulations.DeviceModel{#s512,#s511} where #s511<:PowerSimulations.AbstractBranchFormulation where #s512<:PowerSystems.ACBranch, ::Type{PowerSimulations.CopperPlatePowerModel}) in PowerSimulations at /Users/jdlara/.julia/packages/PowerSimulations/tDRLp/src/devices_models/device_constructors/branch_constructor.jl:6
construct_device!(psi_container::PowerSimulations.PSIContainer, sys::PowerSystems.System, model::PowerSimulations.DeviceModel{PowerSystems.MonitoredLine,PowerSimulations.FlowMonitoredLine}, ::Type{S}) where S<:PowerModels.AbstractPowerModel in PowerSimulations at /Users/jdlara/.julia/packages/PowerSimulations/tDRLp/src/devices_models/device_constructors/branch_constructor.jl:110

Ambiguity #5
construct_device!(psi_container::PowerSimulations.PSIContainer, sys::PowerSystems.System, model::PowerSimulations.DeviceModel{#s512,#s511} where #s511<:PowerSimulations.AbstractBranchFormulation where #s512<:PowerSystems.ACBranch, ::Type{PowerSimulations.CopperPlatePowerModel}) in PowerSimulations at /Users/jdlara/.julia/packages/PowerSimulations/tDRLp/src/devices_models/device_constructors/branch_constructor.jl:6
construct_device!(psi_container::PowerSimulations.PSIContainer, sys::PowerSystems.System, model::PowerSimulations.DeviceModel{B,Br}, ::Type{S}) where {B<:PowerSystems.ACBranch, Br<:PowerSimulations.AbstractBoundedBranchFormulation, S<:PowerModels.AbstractActivePowerModel} in PowerSimulations at /Users/jdlara/.julia/packages/PowerSimulations/tDRLp/src/devices_models/device_constructors/branch_constructor.jl:34

Ambiguity #6
construct_device!(psi_container::PowerSimulations.PSIContainer, sys::PowerSystems.System, model::PowerSimulations.DeviceModel{R,D}, ::Type{S}; kwargs...) where {R<:PowerSystems.RenewableGen, D<:PowerSimulations.AbstractRenewableDispatchFormulation, S<:PowerModels.AbstractActivePowerModel} in PowerSimulations at /Users/jdlara/.julia/packages/PowerSimulations/tDRLp/src/devices_models/device_constructors/renewablegeneration_constructor.jl:44
construct_device!(psi_container::PowerSimulations.PSIContainer, sys::PowerSystems.System, model::PowerSimulations.DeviceModel{PowerSystems.RenewableFix,D}, system_formulation::Type{S}; kwargs...) where {D<:PowerSimulations.AbstractRenewableDispatchFormulation, S<:PowerModels.AbstractPowerModel} in PowerSimulations at /Users/jdlara/.julia/packages/PowerSimulations/tDRLp/src/devices_models/device_constructors/renewablegeneration_constructor.jl:88

```