### PR TITLE
ORDC implementation

### DIFF
--- a/src/devices_models/devices/common/add_variable.jl
+++ b/src/devices_models/devices/common/add_variable.jl
@@ -46,7 +46,7 @@ function add_variable(
     expression_name::Union{Nothing, Symbol} = nothing,
     sign::Float64 = 1.0;
     kwargs...,
-) where {D <: Union{Vector{<:PSY.Device}, IS.FlattenIteratorWrapper{<:PSY.Device}}}
+) where {D <: Union{Vector{<:PSY.Component}, IS.FlattenIteratorWrapper{<:PSY.Component}}}
     time_steps = model_time_steps(psi_container)
     variable = add_var_container!(
         psi_container,

--- a/src/devices_models/devices/common/cost_functions.jl
+++ b/src/devices_models/devices/common/cost_functions.jl
@@ -390,7 +390,7 @@ function add_to_cost(
     var_name::Symbol,
     cost_symbol::Symbol,
     sign::Float64 = 1.0,
-) where {D <: IS.FlattenIteratorWrapper{<:PSY.Device}}
+) where {D <: IS.FlattenIteratorWrapper{<:PSY.Component}}
     resolution = model_resolution(psi_container)
     dt = Dates.value(Dates.Minute(resolution)) / 60
     variable = get_variable(psi_container, var_name)

--- a/src/services_models/reserves.jl
+++ b/src/services_models/reserves.jl
@@ -124,7 +124,7 @@ end
 
 function modify_device_model!(
     devices_template::Dict{Symbol, DeviceModel},
-    service_model::ServiceModel{<:PSY.Reserve, RangeReserve},
+    service_model::ServiceModel{<:PSY.Reserve, <:AbstractReservesFormulation},
     contributing_devices::Vector{<:PSY.Device},
 )
     device_types = unique(typeof.(contributing_devices))

--- a/src/services_models/reserves.jl
+++ b/src/services_models/reserves.jl
@@ -1,6 +1,6 @@
 abstract type AbstractReservesFormulation <: AbstractServiceFormulation end
 struct RangeReserve <: AbstractReservesFormulation end
-struct OperatingReserveDemandCurve <: AbstractReservesFormulation
+struct OperatingReserveDemandCurve <: AbstractReservesFormulation end
 ############################### Reserve Variables` #########################################
 """
 This function add the variables for reserves to the model


### PR DESCRIPTION
For this implementation, I had to make the following changes over the RangeReserve Formulation
- Adding `ORDC` PSY struct & new formulation `OperatingReserveDemandCurve`
- Instead of adding a parameter or forecast for requirement there is new variable for the RHS
   - Changed `add_variable`  to accept any subtype of `Component` as Services are not under `Device`
- This requirement variable has a PWL cost 
    - Changed  `add_to_cost`  to accept any subtype of `Component` as Services are not under `Device`
- Change `modify_device_model!` to accept any type of reserve formulation. This is probably not right but didn't want to repeat the as function for ORDC formulation.

These are just draft change