### PR TITLE
PSIMA-145:Automating cache creation using initial conditions

### DIFF
--- a/src/core/simulation.jl
+++ b/src/core/simulation.jl
@@ -122,46 +122,47 @@ function _add_initial_condition_caches(
     return
 end
 
-function _create_cache(ic_key::ICKey,
-    caches::Union{Nothing, Vector{<:AbstractCache}},
-)
+function _create_cache(ic_key::ICKey, caches::Union{Nothing, Vector{<:AbstractCache}})
     return
 end
 
-function _create_cache(ic_key::ICKey{Type{T}, TimeDurationON}, 
+function _create_cache(
+    ic_key::ICKey{TimeDurationON, Type{T}},
     caches::Union{Nothing, Vector{<:AbstractCache}},
-) where {T<: PSY.Device}
+) where {T <: PSY.Device}
 
     cache_keys = CacheKey.(caches)
     if isempty(cache_keys) || !in(CacheKey(TimeStatusChange, Type{T}), cache_keys)
         cache = TimeStatusChange(T, PSI.ON)
         push!(caches, cache)
     end
-    return 
+    return
 end
 
-function _create_cache(ic_key::ICKey{TimeDurationOFF, Type{T}}, 
+function _create_cache(
+    ic_key::ICKey{TimeDurationOFF, Type{T}},
     caches::Union{Nothing, Vector{<:AbstractCache}},
-) where {T<: PSY.Device}
+) where {T <: PSY.Device}
 
     cache_keys = CacheKey.(caches)
     if isempty(cache_keys) || !in(CacheKey(TimeStatusChange, Type{T}), cache_keys)
         cache = TimeStatusChange(T, PSI.ON)
         push!(caches, cache)
     end
-    return 
+    return
 end
 
-function _create_cache(ic_key::ICKey{EnergyLevel, Type{T}}, 
+function _create_cache(
+    ic_key::ICKey{EnergyLevel, Type{T}},
     caches::Union{Nothing, Vector{<:AbstractCache}},
-) where {T<: PSY.Device}
+) where {T <: PSY.Device}
 
     cache_keys = CacheKey.(caches)
     if isempty(cache_keys) || !in(CacheKey(StoredEnergy, Type{T}), cache_keys)
         cache = TimeStatusChange(T, PSI.ENERGY)
         push!(caches, cache)
     end
-    return 
+    return
 end
 
 function _set_internal_caches(

--- a/src/core/simulation.jl
+++ b/src/core/simulation.jl
@@ -116,7 +116,7 @@ function _add_initial_condition_caches(
     caches::Union{Nothing, Vector{<:AbstractCache}},
 )
     initial_conditions = stage.internal.psi_container.initial_conditions
-    for (ic_key, init_conds) in initial_conditions
+    for (ic_key, init_conds) in initial_conditions.data
         _create_cache(ic_key, caches)
     end
     return

--- a/src/core/simulation.jl
+++ b/src/core/simulation.jl
@@ -141,7 +141,7 @@ end
 
 function _create_cache(
     ic_key::ICKey{TimeDurationOFF, T},
-    caches::Union{Nothing, Vector{<:AbstractCache}},
+    caches::Vector{<:AbstractCache},
 ) where {T <: PSY.Device}
 
     cache_keys = CacheKey.(caches)
@@ -154,7 +154,7 @@ end
 
 function _create_cache(
     ic_key::ICKey{EnergyLevel, T},
-    caches::Union{Nothing, Vector{<:AbstractCache}},
+    caches::Vector{<:AbstractCache},
 ) where {T <: PSY.Device}
 
     cache_keys = CacheKey.(caches)

--- a/src/core/simulation.jl
+++ b/src/core/simulation.jl
@@ -127,12 +127,12 @@ function _create_cache(ic_key::ICKey, caches::Union{Nothing, Vector{<:AbstractCa
 end
 
 function _create_cache(
-    ic_key::ICKey{TimeDurationON, Type{T}},
+    ic_key::ICKey{TimeDurationON, T},
     caches::Union{Nothing, Vector{<:AbstractCache}},
 ) where {T <: PSY.Device}
 
     cache_keys = CacheKey.(caches)
-    if isempty(cache_keys) || !in(CacheKey(TimeStatusChange, Type{T}), cache_keys)
+    if isempty(cache_keys) || !in(CacheKey(TimeStatusChange, T), cache_keys)
         cache = TimeStatusChange(T, PSI.ON)
         push!(caches, cache)
     end
@@ -140,12 +140,12 @@ function _create_cache(
 end
 
 function _create_cache(
-    ic_key::ICKey{TimeDurationOFF, Type{T}},
+    ic_key::ICKey{TimeDurationOFF, T},
     caches::Union{Nothing, Vector{<:AbstractCache}},
 ) where {T <: PSY.Device}
 
     cache_keys = CacheKey.(caches)
-    if isempty(cache_keys) || !in(CacheKey(TimeStatusChange, Type{T}), cache_keys)
+    if isempty(cache_keys) || !in(CacheKey(TimeStatusChange, T), cache_keys)
         cache = TimeStatusChange(T, PSI.ON)
         push!(caches, cache)
     end
@@ -153,12 +153,12 @@ function _create_cache(
 end
 
 function _create_cache(
-    ic_key::ICKey{EnergyLevel, Type{T}},
+    ic_key::ICKey{EnergyLevel, T},
     caches::Union{Nothing, Vector{<:AbstractCache}},
 ) where {T <: PSY.Device}
 
     cache_keys = CacheKey.(caches)
-    if isempty(cache_keys) || !in(CacheKey(StoredEnergy, Type{T}), cache_keys)
+    if isempty(cache_keys) || !in(CacheKey(StoredEnergy, T), cache_keys)
         cache = TimeStatusChange(T, PSI.ENERGY)
         push!(caches, cache)
     end

--- a/test/test_simulation_build.jl
+++ b/test/test_simulation_build.jl
@@ -245,7 +245,9 @@ function test_sequence_build(file_path::String)
             stages_sequence = sequence_no_cache,
             simulation_folder = file_path,
         )
-        @test_throws ArgumentError build!(sim)
+        build!(sim)
+        
+        @test !isempty(sim.internal.simulation_cache)
 
         stages_definition = create_stages(template_standard_uc)
         sequence = SimulationSequence(

--- a/test/test_simulation_build.jl
+++ b/test/test_simulation_build.jl
@@ -246,7 +246,7 @@ function test_sequence_build(file_path::String)
             simulation_folder = file_path,
         )
         build!(sim)
-        
+
         @test !isempty(sim.internal.simulation_cache)
 
         stages_definition = create_stages(template_standard_uc)


### PR DESCRIPTION
That to make few changes to the existing methods
- Changed `get_stage_cache_definition`  to return an empty cache vector instead of nothing. (It is easier to populate empty array than a nothing)
- Added `_add_initial_condition_caches` that loops over the initial condition keys and checks if a cache is passed by the use, if not creates it.
- Changed `test_simulation_build` test to check for cache instead of error thrown