### PR TITLE
shortcutting result checks for non-optimization stage

### DIFF
--- a/src/core/psi_container.jl
+++ b/src/core/psi_container.jl
@@ -490,6 +490,7 @@ function get_parameters_value(psi_container::PSIContainer)
 end
 
 function is_milp(container::PSIContainer)
+    isnothing(container.JuMPmodel) && return false
     type_of_optimizer = typeof(container.JuMPmodel.moi_backend.optimizer.model)
     supports_milp = hasfield(type_of_optimizer, :last_solved_by_mip)
     !supports_milp && return false


### PR DESCRIPTION
avoids MILP check when stage doesn't have a JuMP model.