### PR TITLE
Cb/status ic

### DIFF
--- a/src/core/simulation.jl
+++ b/src/core/simulation.jl
@@ -603,6 +603,8 @@ function initial_condition_update!(
             get_stage_interval_chronology(sim.sequence, get_stage_name(sim, stage))
         var_value =
             get_stage_variable(interval_chronology, (stage => stage), name, ic.update_ref)
+
+        @debug var_value, ic.update_ref
         if isnothing(ic.cache_type)
             cache = nothing
         else


### PR DESCRIPTION
 - calculates status initial conditions based on the status field and "ON" variables rather than the "P" varaibles now that we have  a status field
 - So far, I've only tested on a single stage simulation. Before merging, we need to confirm that everything works in a simulation with multiple stages, including one without the "on" variables