### PR TITLE
Updates for FixedOutput model

### DIFF
--- a/src/devices_models/devices/hydro_generation.jl
+++ b/src/devices_models/devices/hydro_generation.jl
@@ -368,6 +368,20 @@ end
 
 function NodalExpressionSpec(
     ::Type{T},
+    ::Type{<:PM.AbstractPowerModel},
+    use_forecasts::Bool,
+) where {T <: PSY.HydroGen}
+    return NodalExpressionSpec(
+        "get_max_active_power",
+        REACTIVE_POWER,
+        use_forecasts ? x -> PSY.get_max_reactive_power(x) : x -> PSY.get_reactive_power(x),
+        1.0,
+        T,
+    )
+end
+
+function NodalExpressionSpec(
+    ::Type{T},
     ::Type{<:PM.AbstractActivePowerModel},
     use_forecasts::Bool,
 ) where {T <: PSY.HydroGen}


### PR DESCRIPTION
The following change follows the same logic of FixedOutput for Renewables.

However, this idea is not correct. Basically, we are using the same forecast for active power for reactive power.

The solution here is essentially make Q = 0 all times, or use a constant power factor, that depending on P, will update Q. Any ideas here on how to move forward? 