### PR TITLE
Update System constructor calls, apply coding standards

### DIFF
--- a/src/devices_models/device_constructors/hydrogeneration_constructor.jl
+++ b/src/devices_models/device_constructors/hydrogeneration_constructor.jl
@@ -38,23 +38,23 @@ function construct_device!(
     end
 
     #Variables
-    add_variables!(ActivePowerVariable, psi_container, devices)
-    add_variables!(ReactivePowerVariable, psi_container, devices)
+    add_variables!(psi_container, ActivePowerVariable, devices)
+    add_variables!(psi_container, ReactivePowerVariable, devices)
 
     #Constraints
     add_constraints!(
+        psi_container,
         RangeConstraint,
         ActivePowerVariable,
-        psi_container,
         devices,
         model,
         S,
         get_feedforward(model),
     )
     add_constraints!(
+        psi_container,
         RangeConstraint,
         ReactivePowerVariable,
-        psi_container,
         devices,
         model,
         S,
@@ -89,13 +89,13 @@ function construct_device!(
     end
 
     #Variables
-    add_variables!(ActivePowerVariable, psi_container, devices)
+    add_variables!(psi_container, ActivePowerVariable, devices)
 
     #Constraints
     add_constraints!(
+        psi_container,
         RangeConstraint,
         ActivePowerVariable,
-        psi_container,
         devices,
         model,
         S,
@@ -125,8 +125,8 @@ function construct_device!(
     end
 
     #Variables
-    add_variables!(ActivePowerVariable, psi_container, devices)
-    add_variables!(ReactivePowerVariable, psi_container, devices)
+    add_variables!(psi_container, ActivePowerVariable, devices)
+    add_variables!(psi_container, ReactivePowerVariable, devices)
 
     #Energy Budget Constraint
     energy_budget_constraints!(psi_container, devices, model, S, get_feedforward(model))
@@ -156,7 +156,7 @@ function construct_device!(
     end
 
     #Variables
-    add_variables!(ActivePowerVariable, psi_container, devices)
+    add_variables!(psi_container, ActivePowerVariable, devices)
 
     #Energy Budget Constraint
     energy_budget_constraints!(psi_container, devices, model, S, get_feedforward(model))
@@ -185,10 +185,10 @@ function construct_device!(
     end
 
     #Variables
-    add_variables!(ActivePowerVariable, psi_container, devices)
-    add_variables!(ReactivePowerVariable, psi_container, devices)
-    add_variables!(EnergyVariable, psi_container, devices)
-    add_variables!(SpillageVariable, psi_container, devices)
+    add_variables!(psi_container, ActivePowerVariable, devices)
+    add_variables!(psi_container, ReactivePowerVariable, devices)
+    add_variables!(psi_container, EnergyVariable, devices)
+    add_variables!(psi_container, SpillageVariable, devices)
 
     #Initial Conditions
     storage_energy_init(psi_container, devices)
@@ -220,9 +220,9 @@ function construct_device!(
     end
 
     #Variables
-    add_variables!(ActivePowerVariable, psi_container, devices)
-    add_variables!(EnergyVariable, psi_container, devices)
-    add_variables!(SpillageVariable, psi_container, devices)
+    add_variables!(psi_container, ActivePowerVariable, devices)
+    add_variables!(psi_container, EnergyVariable, devices)
+    add_variables!(psi_container, SpillageVariable, devices)
 
     #Initial Conditions
     storage_energy_init(psi_container, devices)
@@ -252,15 +252,15 @@ function construct_device!(
     end
 
     #Variables
-    add_variables!(ActivePowerVariable, psi_container, devices)
-    add_variables!(ReactivePowerVariable, psi_container, devices)
-    add_variables!(OnVariable, psi_container, devices)
+    add_variables!(psi_container, ActivePowerVariable, devices)
+    add_variables!(psi_container, ReactivePowerVariable, devices)
+    add_variables!(psi_container, OnVariable, devices)
 
     #Constraints
     add_constraints!(
+        psi_container,
         RangeConstraint,
         ActivePowerVariable,
-        psi_container,
         devices,
         model,
         S,
@@ -268,9 +268,9 @@ function construct_device!(
     )
     #Constraints
     add_constraints!(
+        psi_container,
         RangeConstraint,
         ReactivePowerVariable,
-        psi_container,
         devices,
         model,
         S,
@@ -306,14 +306,14 @@ function construct_device!(
     end
 
     #Variables
-    add_variables!(ActivePowerVariable, psi_container, devices)
-    add_variables!(OnVariable, psi_container, devices)
+    add_variables!(psi_container, ActivePowerVariable, devices)
+    add_variables!(psi_container, OnVariable, devices)
 
     #Constraints
     add_constraints!(
+        psi_container,
         RangeConstraint,
         ActivePowerVariable,
-        psi_container,
         devices,
         model,
         S,
@@ -344,24 +344,24 @@ function construct_device!(
     end
 
     #Variables
-    add_variables!(ActivePowerVariable, psi_container, devices)
-    add_variables!(ReactivePowerVariable, psi_container, devices)
-    add_variables!(OnVariable, psi_container, devices)
+    add_variables!(psi_container, ActivePowerVariable, devices)
+    add_variables!(psi_container, ReactivePowerVariable, devices)
+    add_variables!(psi_container, OnVariable, devices)
 
     #Constraints
     add_constraints!(
+        psi_container,
         RangeConstraint,
         ActivePowerVariable,
-        psi_container,
         devices,
         model,
         S,
         get_feedforward(model),
     )
     add_constraints!(
+        psi_container,
         RangeConstraint,
         ReactivePowerVariable,
-        psi_container,
         devices,
         model,
         S,
@@ -399,14 +399,14 @@ function construct_device!(
     end
 
     #Variables
-    add_variables!(ActivePowerVariable, psi_container, devices)
-    add_variables!(OnVariable, psi_container, devices)
+    add_variables!(psi_container, ActivePowerVariable, devices)
+    add_variables!(psi_container, OnVariable, devices)
 
     #Constraints
     add_constraints!(
+        psi_container,
         RangeConstraint,
         ActivePowerVariable,
-        psi_container,
         devices,
         model,
         S,
@@ -439,26 +439,26 @@ function construct_device!(
     end
 
     #Variables
-    add_variables!(ActivePowerVariable, psi_container, devices)
-    add_variables!(ReactivePowerVariable, psi_container, devices)
-    add_variables!(OnVariable, psi_container, devices)
-    add_variables!(EnergyVariable, psi_container, devices)
-    add_variables!(SpillageVariable, psi_container, devices)
+    add_variables!(psi_container, ActivePowerVariable, devices)
+    add_variables!(psi_container, ReactivePowerVariable, devices)
+    add_variables!(psi_container, OnVariable, devices)
+    add_variables!(psi_container, EnergyVariable, devices)
+    add_variables!(psi_container, SpillageVariable, devices)
 
     #Constraints
     add_constraints!(
+        psi_container,
         RangeConstraint,
         ActivePowerVariable,
-        psi_container,
         devices,
         model,
         S,
         get_feedforward(model),
     )
     add_constraints!(
+        psi_container,
         RangeConstraint,
         ReactivePowerVariable,
-        psi_container,
         devices,
         model,
         S,
@@ -495,16 +495,16 @@ function construct_device!(
     end
 
     #Variables
-    add_variables!(ActivePowerVariable, psi_container, devices)
-    add_variables!(OnVariable, psi_container, devices)
-    add_variables!(EnergyVariable, psi_container, devices)
-    add_variables!(SpillageVariable, psi_container, devices)
+    add_variables!(psi_container, ActivePowerVariable, devices)
+    add_variables!(psi_container, OnVariable, devices)
+    add_variables!(psi_container, EnergyVariable, devices)
+    add_variables!(psi_container, SpillageVariable, devices)
 
     #Constraints
     add_constraints!(
+        psi_container,
         RangeConstraint,
         ActivePowerVariable,
-        psi_container,
         devices,
         model,
         S,

--- a/src/devices_models/device_constructors/load_constructor.jl
+++ b/src/devices_models/device_constructors/load_constructor.jl
@@ -15,23 +15,23 @@ function construct_device!(
     end
 
     #Variables
-    add_variables!(ActivePowerVariable, psi_container, devices)
-    add_variables!(ReactivePowerVariable, psi_container, devices)
+    add_variables!(psi_container, ActivePowerVariable, devices)
+    add_variables!(psi_container, ReactivePowerVariable, devices)
 
     #Constraints
     add_constraints!(
+        psi_container,
         RangeConstraint,
         ActivePowerVariable,
-        psi_container,
         devices,
         model,
         S,
         get_feedforward(model),
     )
     add_constraints!(
+        psi_container,
         RangeConstraint,
         ReactivePowerVariable,
-        psi_container,
         devices,
         model,
         S,
@@ -63,13 +63,13 @@ function construct_device!(
     end
 
     #Variables
-    add_variables!(ActivePowerVariable, psi_container, devices)
+    add_variables!(psi_container, ActivePowerVariable, devices)
 
     #Constraints
     add_constraints!(
+        psi_container,
         RangeConstraint,
         ActivePowerVariable,
-        psi_container,
         devices,
         model,
         S,
@@ -96,24 +96,24 @@ function construct_device!(
     end
 
     #Variables
-    add_variables!(ActivePowerVariable, psi_container, devices)
-    add_variables!(ReactivePowerVariable, psi_container, devices)
-    add_variables!(OnVariable, psi_container, devices)
+    add_variables!(psi_container, ActivePowerVariable, devices)
+    add_variables!(psi_container, ReactivePowerVariable, devices)
+    add_variables!(psi_container, OnVariable, devices)
 
     #Constraints
     add_constraints!(
+        psi_container,
         RangeConstraint,
         ActivePowerVariable,
-        psi_container,
         devices,
         model,
         S,
         get_feedforward(model),
     )
     add_constraints!(
+        psi_container,
         RangeConstraint,
         ReactivePowerVariable,
-        psi_container,
         devices,
         model,
         S,
@@ -140,14 +140,14 @@ function construct_device!(
     end
 
     #Variables
-    add_variables!(ActivePowerVariable, psi_container, devices)
-    add_variables!(OnVariable, psi_container, devices)
+    add_variables!(psi_container, ActivePowerVariable, devices)
+    add_variables!(psi_container, OnVariable, devices)
 
     #Constraints
     add_constraints!(
+        psi_container,
         RangeConstraint,
         ActivePowerVariable,
-        psi_container,
         devices,
         model,
         S,

--- a/src/devices_models/device_constructors/regulationdevice_constructor.jl
+++ b/src/devices_models/device_constructors/regulationdevice_constructor.jl
@@ -18,26 +18,26 @@ function construct_device!(
     end
 
     #Variables
-    add_variables!(DeltaActivePowerUpVariable, psi_container, devices)
-    add_variables!(DeltaActivePowerDownVariable, psi_container, devices)
-    add_variables!(AdditionalDeltaActivePowerUpVariable, psi_container, devices)
-    add_variables!(AdditionalDeltaActivePowerDownVariable, psi_container, devices)
+    add_variables!(psi_container, DeltaActivePowerUpVariable, devices)
+    add_variables!(psi_container, DeltaActivePowerDownVariable, devices)
+    add_variables!(psi_container, AdditionalDeltaActivePowerUpVariable, devices)
+    add_variables!(psi_container, AdditionalDeltaActivePowerDownVariable, devices)
 
     #Constraints
     nodal_expression!(psi_container, devices, S)
     add_constraints!(
+        psi_container,
         RangeConstraint,
         DeltaActivePowerUpVariable,
-        psi_container,
         devices,
         model,
         S,
         get_feedforward(model),
     )
     add_constraints!(
+        psi_container,
         RangeConstraint,
         DeltaActivePowerDownVariable,
-        psi_container,
         devices,
         model,
         S,
@@ -69,26 +69,26 @@ function construct_device!(
     end
 
     #Variables
-    add_variables!(DeltaActivePowerUpVariable, psi_container, devices)
-    add_variables!(DeltaActivePowerDownVariable, psi_container, devices)
-    add_variables!(AdditionalDeltaActivePowerUpVariable, psi_container, devices)
-    add_variables!(AdditionalDeltaActivePowerDownVariable, psi_container, devices)
+    add_variables!(psi_container, DeltaActivePowerUpVariable, devices)
+    add_variables!(psi_container, DeltaActivePowerDownVariable, devices)
+    add_variables!(psi_container, AdditionalDeltaActivePowerUpVariable, devices)
+    add_variables!(psi_container, AdditionalDeltaActivePowerDownVariable, devices)
 
     #Constraints
     nodal_expression!(psi_container, devices, S)
     add_constraints!(
+        psi_container,
         RangeConstraint,
         DeltaActivePowerUpVariable,
-        psi_container,
         devices,
         model,
         S,
         get_feedforward(model),
     )
     add_constraints!(
+        psi_container,
         RangeConstraint,
         DeltaActivePowerDownVariable,
-        psi_container,
         devices,
         model,
         S,

--- a/src/devices_models/device_constructors/renewablegeneration_constructor.jl
+++ b/src/devices_models/device_constructors/renewablegeneration_constructor.jl
@@ -15,23 +15,23 @@ function construct_device!(
     end
 
     #Variables
-    add_variables!(ActivePowerVariable, psi_container, devices)
-    add_variables!(ReactivePowerVariable, psi_container, devices)
+    add_variables!(psi_container, ActivePowerVariable, devices)
+    add_variables!(psi_container, ReactivePowerVariable, devices)
 
     #Constraints
     add_constraints!(
+        psi_container,
         RangeConstraint,
         ActivePowerVariable,
-        psi_container,
         devices,
         model,
         S,
         get_feedforward(model),
     )
     add_constraints!(
+        psi_container,
         RangeConstraint,
         ReactivePowerVariable,
-        psi_container,
         devices,
         model,
         S,
@@ -62,13 +62,13 @@ function construct_device!(
     end
 
     #Variables
-    add_variables!(ActivePowerVariable, psi_container, devices)
+    add_variables!(psi_container, ActivePowerVariable, devices)
 
     #Constraints
     add_constraints!(
+        psi_container,
         RangeConstraint,
         ActivePowerVariable,
-        psi_container,
         devices,
         model,
         S,

--- a/src/devices_models/device_constructors/storage_constructor.jl
+++ b/src/devices_models/device_constructors/storage_constructor.jl
@@ -11,37 +11,37 @@ function construct_device!(
     end
 
     #Variables
-    add_variables!(ActivePowerInVariable, psi_container, devices)
-    add_variables!(ActivePowerOutVariable, psi_container, devices)
-    add_variables!(ReactivePowerVariable, psi_container, devices)
-    add_variables!(EnergyVariable, psi_container, devices)
+    add_variables!(psi_container, ActivePowerInVariable, devices)
+    add_variables!(psi_container, ActivePowerOutVariable, devices)
+    add_variables!(psi_container, ReactivePowerVariable, devices)
+    add_variables!(psi_container, EnergyVariable, devices)
 
     #Initial Conditions
     initial_conditions!(psi_container, devices, D)
 
     #Constraints
     add_constraints!(
+        psi_container,
         RangeConstraint,
         ActivePowerOutVariable,
-        psi_container,
         devices,
         model,
         S,
         get_feedforward(model),
     )
     add_constraints!(
+        psi_container,
         RangeConstraint,
         ActivePowerInVariable,
-        psi_container,
         devices,
         model,
         S,
         get_feedforward(model),
     )
     add_constraints!(
+        psi_container,
         RangeConstraint,
         ReactivePowerVariable,
-        psi_container,
         devices,
         model,
         S,
@@ -74,27 +74,27 @@ function construct_device!(
     end
 
     #Variables
-    add_variables!(ActivePowerInVariable, psi_container, devices)
-    add_variables!(ActivePowerOutVariable, psi_container, devices)
-    add_variables!(EnergyVariable, psi_container, devices)
+    add_variables!(psi_container, ActivePowerInVariable, devices)
+    add_variables!(psi_container, ActivePowerOutVariable, devices)
+    add_variables!(psi_container, EnergyVariable, devices)
 
     #Initial Conditions
     initial_conditions!(psi_container, devices, D)
 
     #Constraints
     add_constraints!(
+        psi_container,
         RangeConstraint,
         ActivePowerOutVariable,
-        psi_container,
         devices,
         model,
         S,
         get_feedforward(model),
     )
     add_constraints!(
+        psi_container,
         RangeConstraint,
         ActivePowerInVariable,
-        psi_container,
         devices,
         model,
         S,
@@ -122,38 +122,38 @@ function construct_device!(
     end
 
     #Variables
-    add_variables!(ActivePowerInVariable, psi_container, devices)
-    add_variables!(ActivePowerOutVariable, psi_container, devices)
-    add_variables!(ReactivePowerVariable, psi_container, devices)
-    add_variables!(EnergyVariable, psi_container, devices)
-    add_variables!(ReserveVariable, psi_container, devices)
+    add_variables!(psi_container, ActivePowerInVariable, devices)
+    add_variables!(psi_container, ActivePowerOutVariable, devices)
+    add_variables!(psi_container, ReactivePowerVariable, devices)
+    add_variables!(psi_container, EnergyVariable, devices)
+    add_variables!(psi_container, ReserveVariable, devices)
 
     #Initial Conditions
     initial_conditions!(psi_container, devices, model.formulation)
 
     #Constraints
     add_constraints!(
+        psi_container,
         RangeConstraint,
         ActivePowerOutVariable,
-        psi_container,
         devices,
         model,
         S,
         get_feedforward(model),
     )
     add_constraints!(
+        psi_container,
         RangeConstraint,
         ActivePowerInVariable,
-        psi_container,
         devices,
         model,
         S,
         get_feedforward(model),
     )
     add_constraints!(
+        psi_container,
         RangeConstraint,
         ReactivePowerVariable,
-        psi_container,
         devices,
         model,
         S,
@@ -187,28 +187,28 @@ function construct_device!(
     end
 
     #Variables
-    add_variables!(ActivePowerInVariable, psi_container, devices)
-    add_variables!(ActivePowerOutVariable, psi_container, devices)
-    add_variables!(EnergyVariable, psi_container, devices)
-    add_variables!(ReserveVariable, psi_container, devices)
+    add_variables!(psi_container, ActivePowerInVariable, devices)
+    add_variables!(psi_container, ActivePowerOutVariable, devices)
+    add_variables!(psi_container, EnergyVariable, devices)
+    add_variables!(psi_container, ReserveVariable, devices)
 
     #Initial Conditions
     initial_conditions!(psi_container, devices, model.formulation)
 
     #Constraints
     add_constraints!(
+        psi_container,
         RangeConstraint,
         ActivePowerOutVariable,
-        psi_container,
         devices,
         model,
         S,
         get_feedforward(model),
     )
     add_constraints!(
+        psi_container,
         RangeConstraint,
         ActivePowerInVariable,
-        psi_container,
         devices,
         model,
         S,

--- a/src/devices_models/device_constructors/thermalgeneration_constructor.jl
+++ b/src/devices_models/device_constructors/thermalgeneration_constructor.jl
@@ -14,29 +14,29 @@ function construct_device!(
     end
 
     #Variables
-    add_variables!(ActivePowerVariable, psi_container, devices)
-    add_variables!(ReactivePowerVariable, psi_container, devices)
-    add_variables!(OnVariable, psi_container, devices)
-    add_variables!(StartVariable, psi_container, devices)
-    add_variables!(StopVariable, psi_container, devices)
+    add_variables!(psi_container, ActivePowerVariable, devices)
+    add_variables!(psi_container, ReactivePowerVariable, devices)
+    add_variables!(psi_container, OnVariable, devices)
+    add_variables!(psi_container, StartVariable, devices)
+    add_variables!(psi_container, StopVariable, devices)
 
     #Initial Conditions
     initial_conditions!(psi_container, devices, D)
 
     #Constraints
     add_constraints!(
+        psi_container,
         RangeConstraint,
         ActivePowerVariable,
-        psi_container,
         devices,
         model,
         S,
         get_feedforward(model),
     )
     add_constraints!(
+        psi_container,
         RangeConstraint,
         ReactivePowerVariable,
-        psi_container,
         devices,
         model,
         S,
@@ -73,19 +73,19 @@ function construct_device!(
     end
 
     #Variables
-    add_variables!(ActivePowerVariable, psi_container, devices)
-    add_variables!(OnVariable, psi_container, devices)
-    add_variables!(StartVariable, psi_container, devices)
-    add_variables!(StopVariable, psi_container, devices)
+    add_variables!(psi_container, ActivePowerVariable, devices)
+    add_variables!(psi_container, OnVariable, devices)
+    add_variables!(psi_container, StartVariable, devices)
+    add_variables!(psi_container, StopVariable, devices)
 
     #Initial Conditions
     initial_conditions!(psi_container, devices, D)
 
     #Constraints
     add_constraints!(
+        psi_container,
         RangeConstraint,
         ActivePowerVariable,
-        psi_container,
         devices,
         model,
         S,
@@ -118,29 +118,29 @@ function construct_device!(
     end
 
     #Variables
-    add_variables!(ActivePowerVariable, psi_container, devices)
-    add_variables!(ReactivePowerVariable, psi_container, devices)
-    add_variables!(OnVariable, psi_container, devices)
-    add_variables!(StartVariable, psi_container, devices)
-    add_variables!(StopVariable, psi_container, devices)
+    add_variables!(psi_container, ActivePowerVariable, devices)
+    add_variables!(psi_container, ReactivePowerVariable, devices)
+    add_variables!(psi_container, OnVariable, devices)
+    add_variables!(psi_container, StartVariable, devices)
+    add_variables!(psi_container, StopVariable, devices)
 
     #Initial Conditions
     initial_conditions!(psi_container, devices, model.formulation)
 
     #Constraints
     add_constraints!(
+        psi_container,
         RangeConstraint,
         ActivePowerVariable,
-        psi_container,
         devices,
         model,
         S,
         get_feedforward(model),
     )
     add_constraints!(
+        psi_container,
         RangeConstraint,
         ReactivePowerVariable,
-        psi_container,
         devices,
         model,
         S,
@@ -171,19 +171,19 @@ function construct_device!(
     end
 
     #Variables
-    add_variables!(ActivePowerVariable, psi_container, devices)
-    add_variables!(OnVariable, psi_container, devices)
-    add_variables!(StartVariable, psi_container, devices)
-    add_variables!(StopVariable, psi_container, devices)
+    add_variables!(psi_container, ActivePowerVariable, devices)
+    add_variables!(psi_container, OnVariable, devices)
+    add_variables!(psi_container, StartVariable, devices)
+    add_variables!(psi_container, StopVariable, devices)
 
     #Initial Conditions
     initial_conditions!(psi_container, devices, model.formulation)
 
     #Constraints
     add_constraints!(
+        psi_container,
         RangeConstraint,
         ActivePowerVariable,
-        psi_container,
         devices,
         model,
         S,
@@ -214,26 +214,26 @@ function construct_device!(
     end
 
     #Variables
-    add_variables!(ActivePowerVariable, psi_container, devices)
-    add_variables!(ReactivePowerVariable, psi_container, devices)
+    add_variables!(psi_container, ActivePowerVariable, devices)
+    add_variables!(psi_container, ReactivePowerVariable, devices)
 
     #Initial Conditions
     initial_conditions!(psi_container, devices, model.formulation)
 
     #Constraints
     add_constraints!(
+        psi_container,
         RangeConstraint,
         ActivePowerVariable,
-        psi_container,
         devices,
         model,
         S,
         get_feedforward(model),
     )
     add_constraints!(
+        psi_container,
         RangeConstraint,
         ReactivePowerVariable,
-        psi_container,
         devices,
         model,
         S,
@@ -264,16 +264,16 @@ function construct_device!(
     end
 
     #Variables
-    add_variables!(ActivePowerVariable, psi_container, devices)
+    add_variables!(psi_container, ActivePowerVariable, devices)
 
     #Initial Conditions
     initial_conditions!(psi_container, devices, model.formulation)
 
     #Constraints
     add_constraints!(
+        psi_container,
         RangeConstraint,
         ActivePowerVariable,
-        psi_container,
         devices,
         model,
         S,
@@ -305,25 +305,25 @@ function construct_device!(
     end
 
     #Variables
-    add_variables!(ActivePowerVariable, psi_container, devices)
-    add_variables!(ReactivePowerVariable, psi_container, devices)
+    add_variables!(psi_container, ActivePowerVariable, devices)
+    add_variables!(psi_container, ReactivePowerVariable, devices)
 
     #Initial Conditions
 
     #Constraints
     add_constraints!(
+        psi_container,
         RangeConstraint,
         ActivePowerVariable,
-        psi_container,
         devices,
         model,
         S,
         get_feedforward(model),
     )
     add_constraints!(
+        psi_container,
         RangeConstraint,
         ReactivePowerVariable,
-        psi_container,
         devices,
         model,
         S,
@@ -354,15 +354,15 @@ function construct_device!(
     end
 
     #Variables
-    add_variables!(ActivePowerVariable, psi_container, devices)
+    add_variables!(psi_container, ActivePowerVariable, devices)
 
     #Initial Conditions
 
     #Constraints
     add_constraints!(
+        psi_container,
         RangeConstraint,
         ActivePowerVariable,
-        psi_container,
         devices,
         model,
         S,
@@ -407,30 +407,30 @@ function construct_device!(
     end
 
     #Variables
-    add_variables!(ActivePowerVariable, psi_container, devices)
-    add_variables!(ReactivePowerVariable, psi_container, devices)
+    add_variables!(psi_container, ActivePowerVariable, devices)
+    add_variables!(psi_container, ReactivePowerVariable, devices)
     commitment_variables!(psi_container, devices)
-    add_variables!(ColdStartVariable, psi_container, devices)
-    add_variables!(WarmStartVariable, psi_container, devices)
-    add_variables!(HotStartVariable, psi_container, devices)
+    add_variables!(psi_container, ColdStartVariable, devices)
+    add_variables!(psi_container, WarmStartVariable, devices)
+    add_variables!(psi_container, HotStartVariable, devices)
 
     #Initial Conditions
     initial_conditions!(psi_container, devices, model.formulation)
 
     #Constraints
     add_constraints!(
+        psi_container,
         RangeConstraint,
         ActivePowerVariable,
-        psi_container,
         devices,
         model,
         S,
         get_feedforward(model),
     )
     add_constraints!(
+        psi_container,
         RangeConstraint,
         ReactivePowerVariable,
-        psi_container,
         devices,
         model,
         S,
@@ -471,20 +471,20 @@ function construct_device!(
     end
 
     #Variables
-    add_variables!(ActivePowerVariable, psi_container, devices)
+    add_variables!(psi_container, ActivePowerVariable, devices)
     commitment_variables!(psi_container, devices)
-    add_variables!(ColdStartVariable, psi_container, devices)
-    add_variables!(WarmStartVariable, psi_container, devices)
-    add_variables!(HotStartVariable, psi_container, devices)
+    add_variables!(psi_container, ColdStartVariable, devices)
+    add_variables!(psi_container, WarmStartVariable, devices)
+    add_variables!(psi_container, HotStartVariable, devices)
 
     #Initial Conditions
     initial_conditions!(psi_container, devices, model.formulation)
 
     #Constraints
     add_constraints!(
+        psi_container,
         RangeConstraint,
         ActivePowerVariable,
-        psi_container,
         devices,
         model,
         S,

--- a/src/devices_models/devices/AC_branches.jl
+++ b/src/devices_models/devices/AC_branches.jl
@@ -86,7 +86,7 @@ function branch_rate_constraints!(
     feedforward::Nothing,
 ) where {B <: PSY.ACBranch}
     constraint_infos = _get_constraint_data(devices)
-    device_range(
+    device_range!(
         psi_container,
         RangeConstraintSpecInternal(
             constraint_infos,
@@ -148,7 +148,7 @@ function branch_flow_constraints!(
         minmax = (min = -1 * limit, max = limit)
         constraint_infos[ix] = DeviceRangeConstraintInfo(PSY.get_name(d), minmax)
     end
-    device_range(
+    device_range!(
         psi_container,
         RangeConstraintSpecInternal(
             constraint_infos,
@@ -185,7 +185,7 @@ function branch_flow_constraints!(
         from[ix] = DeviceRangeConstraintInfo(names[ix], limit_values_TF[ix])
     end
 
-    device_range(
+    device_range!(
         psi_container,
         RangeConstraintSpecInternal(
             to,
@@ -193,7 +193,7 @@ function branch_flow_constraints!(
             make_variable_name(FLOW_ACTIVE_POWER_FROM_TO, PSY.MonitoredLine),
         ),
     )
-    device_range(
+    device_range!(
         psi_container,
         RangeConstraintSpecInternal(
             from,

--- a/src/devices_models/devices/common/add_variable.jl
+++ b/src/devices_models/devices/common/add_variable.jl
@@ -48,8 +48,8 @@ end
 Add variables to the PSIContainer for any component.
 """
 function add_variables!(
-    ::Type{T},
     psi_container::PSIContainer,
+    ::Type{T},
     devices::Union{Vector{U}, IS.FlattenIteratorWrapper{U}},
 ) where {T <: VariableType, U <: PSY.Component}
     _add_variables!(psi_container, devices, AddVariableSpec(T, U, psi_container))
@@ -59,8 +59,8 @@ end
 Add variables to the PSIContainer for a service.
 """
 function add_variables!(
-    ::Type{T},
     psi_container::PSIContainer,
+    ::Type{T},
     service::U,
     contributing_devices::Vector{V},
 ) where {T <: VariableType, U <: PSY.Reserve, V <: PSY.Device}

--- a/src/devices_models/devices/common/device_range_constraints.jl
+++ b/src/devices_models/devices/common/device_range_constraints.jl
@@ -73,9 +73,9 @@ Users of this function must implement a method for
 Users may also implement custom active_power_constraints! methods.
 """
 function add_constraints!(
+    psi_container::PSIContainer,
     ::Type{T},
     ::Type{U},
-    psi_container::PSIContainer,
     devices::IS.FlattenIteratorWrapper{V},
     model::DeviceModel{V, W},
     ::Type{X},
@@ -143,9 +143,9 @@ function device_range_constraints!(
     end
 
     if !isnothing(range_constraint_spec)
-        _apply_range_constraint_spec(
-            range_constraint_spec,
+        _apply_range_constraint_spec!(
             psi_container,
+            range_constraint_spec,
             devices,
             model,
             ff_affected_variables,
@@ -153,9 +153,9 @@ function device_range_constraints!(
     end
 
     if !isnothing(timeseries_range_constraint_spec)
-        _apply_timeseries_range_constraint_spec(
-            timeseries_range_constraint_spec,
+        _apply_timeseries_range_constraint_spec!(
             psi_container,
+            timeseries_range_constraint_spec,
             devices,
             model,
             ff_affected_variables,
@@ -167,9 +167,9 @@ function device_range_constraints!(
     end
 end
 
-function _apply_range_constraint_spec(
-    spec,
+function _apply_range_constraint_spec!(
     psi_container,
+    spec,
     devices::IS.FlattenIteratorWrapper{T},
     model,
     ff_affected_variables,
@@ -215,9 +215,9 @@ function _apply_range_constraint_spec(
     return
 end
 
-function _apply_timeseries_range_constraint_spec(
-    spec,
+function _apply_timeseries_range_constraint_spec!(
     psi_container,
+    spec,
     devices::IS.FlattenIteratorWrapper{T},
     model,
     ff_affected_variables,

--- a/src/devices_models/devices/common/range_constraint.jl
+++ b/src/devices_models/devices/common/range_constraint.jl
@@ -38,7 +38,7 @@ where limits in constraint_infos.
 
 `` limits^{min} \leq x \leq limits^{max}, \text{ otherwise } ``
 """
-function device_range(psi_container::PSIContainer, inputs::RangeConstraintSpecInternal)
+function device_range!(psi_container::PSIContainer, inputs::RangeConstraintSpecInternal)
     time_steps = model_time_steps(psi_container)
     variable = get_variable(psi_container, inputs.variable_name)
     ub_name = middle_rename(inputs.constraint_name, PSI_NAME_DELIMITER, "ub")
@@ -101,7 +101,7 @@ where limits in constraint_infos.
 
 `` limits^{min} x^{bin} \leq x^{cts} \leq limits^{max} x^{bin}, \text{ otherwise } ``
 """
-function device_semicontinuousrange(
+function device_semicontinuousrange!(
     psi_container::PSIContainer,
     inputs::RangeConstraintSpecInternal,
 )
@@ -175,7 +175,7 @@ where limits in constraint_infos.
 
 `` limits^{min} (1 - x^{bin} ) \leq x^{cts} \leq limits^{max} (1 - x^{bin} ), \text{ otherwise } ``
 """
-function reserve_device_semicontinuousrange(
+function reserve_device_semicontinuousrange!(
     psi_container::PSIContainer,
     inputs::RangeConstraintSpecInternal,
 )
@@ -251,7 +251,7 @@ where limits and lag_ramp_limits is in range_data.
 * var_name::Symbol : the name of the continuous variable
 * binvar_names::Symbol : the names of the binary variables
 """
-function device_multistart_range(
+function device_multistart_range!(
     psi_container::PSIContainer,
     inputs::RangeConstraintSpecInternal,
 )
@@ -327,7 +327,7 @@ where limits in range_data.
 * cons_name::Symbol : name of the constraint
 * var_name::Symbol : name of the shutdown variable
 """
-function device_multistart_range_ic(
+function device_multistart_range_ic!(
     psi_container::PSIContainer,
     range_data::Vector{DeviceMultiStartRangeConstraintsInfo},
     initial_conditions::Matrix{InitialCondition},## 1 is initial power, 2 is initial status

--- a/src/devices_models/devices/electric_loads.jl
+++ b/src/devices_models/devices/electric_loads.jl
@@ -100,7 +100,7 @@ function DeviceRangeConstraintSpec(
                 ),
                 variable_name = make_variable_name(ActivePowerVariable, T),
                 limits_func = x -> (min = 0.0, max = PSY.get_active_power(x)),
-                constraint_func = device_range,
+                constraint_func = device_range!,
                 constraint_struct = DeviceRangeConstraintInfo,
             ),
         )
@@ -140,7 +140,7 @@ function DeviceRangeConstraintSpec(
                 variable_name = make_variable_name(ActivePowerVariable, T),
                 bin_variable_names = [make_variable_name(OnVariable, T)],
                 limits_func = x -> (min = 0.0, max = PSY.get_active_power(x)),
-                constraint_func = device_semicontinuousrange,
+                constraint_func = device_semicontinuousrange!,
                 constraint_struct = DeviceRangeConstraintInfo,
             ),
         )

--- a/src/devices_models/devices/hydro_generation.jl
+++ b/src/devices_models/devices/hydro_generation.jl
@@ -113,7 +113,7 @@ function DeviceRangeConstraintSpec(
             ),
             variable_name = make_variable_name(ReactivePowerVariable, T),
             limits_func = x -> PSY.get_reactive_power_limits(x),
-            constraint_func = device_range,
+            constraint_func = device_range!,
             constraint_struct = DeviceRangeConstraintInfo,
         ),
     )
@@ -143,7 +143,7 @@ function DeviceRangeConstraintSpec(
                 ),
                 variable_name = make_variable_name(ActivePowerVariable, T),
                 limits_func = x -> (min = 0.0, max = PSY.get_active_power(x)),
-                constraint_func = device_range,
+                constraint_func = device_range!,
                 constraint_struct = DeviceRangeConstraintInfo,
             ),
         )
@@ -181,7 +181,7 @@ function DeviceRangeConstraintSpec(
             constraint_name = make_constraint_name(RangeConstraint, ActivePowerVariable, T),
             variable_name = make_variable_name(ActivePowerVariable, T),
             limits_func = x -> PSY.get_active_power_limits(x),
-            constraint_func = device_range,
+            constraint_func = device_range!,
             constraint_struct = DeviceRangeConstraintInfo,
         ),
     )
@@ -207,7 +207,7 @@ function DeviceRangeConstraintSpec(
             variable_name = make_variable_name(ActivePowerVariable, T),
             bin_variable_names = [make_variable_name(OnVariable, T)],
             limits_func = x -> PSY.get_active_power_limits(x),
-            constraint_func = device_semicontinuousrange,
+            constraint_func = device_semicontinuousrange!,
             constraint_struct = DeviceRangeConstraintInfo,
         ),
     )
@@ -237,7 +237,7 @@ function DeviceRangeConstraintSpec(
             variable_name = make_variable_name(ReactivePowerVariable, T),
             bin_variable_names = [make_variable_name(OnVariable, T)],
             limits_func = x -> PSY.get_active_power_limits(x),
-            constraint_func = device_semicontinuousrange,
+            constraint_func = device_semicontinuousrange!,
             constraint_struct = DeviceRangeConstraintInfo,
         ),
     )

--- a/src/devices_models/devices/regulation_device.jl
+++ b/src/devices_models/devices/regulation_device.jl
@@ -63,9 +63,9 @@ function AddVariableSpec(
 end
 
 function add_constraints!(
+    psi_container::PSIContainer,
     ::Type{RangeConstraint},
     ::Type{DeltaActivePowerUpVariable},
-    psi_container::PSIContainer,
     devices::IS.FlattenIteratorWrapper{PSY.RegulationDevice{T}},
     ::DeviceModel{PSY.RegulationDevice{T}, DeviceLimitedRegulation},
     ::Type{AreaBalancePowerModel},
@@ -116,9 +116,9 @@ function add_constraints!(
 end
 
 function add_constraints!(
+    psi_container::PSIContainer,
     ::Type{RangeConstraint},
     ::Type{DeltaActivePowerDownVariable},
-    psi_container::PSIContainer,
     devices::IS.FlattenIteratorWrapper{PSY.RegulationDevice{T}},
     ::DeviceModel{PSY.RegulationDevice{T}, DeviceLimitedRegulation},
     ::Type{AreaBalancePowerModel},
@@ -169,9 +169,9 @@ function add_constraints!(
 end
 
 function add_constraints!(
+    psi_container::PSIContainer,
     ::Type{RangeConstraint},
     ::Type{DeltaActivePowerUpVariable},
-    psi_container::PSIContainer,
     devices::IS.FlattenIteratorWrapper{PSY.RegulationDevice{T}},
     ::DeviceModel{PSY.RegulationDevice{T}, ReserveLimitedRegulation},
     ::Type{AreaBalancePowerModel},
@@ -198,9 +198,9 @@ function add_constraints!(
 end
 
 function add_constraints!(
+    psi_container::PSIContainer,
     ::Type{RangeConstraint},
     ::Type{DeltaActivePowerDownVariable},
-    psi_container::PSIContainer,
     devices::IS.FlattenIteratorWrapper{PSY.RegulationDevice{T}},
     ::DeviceModel{PSY.RegulationDevice{T}, ReserveLimitedRegulation},
     ::Type{AreaBalancePowerModel},

--- a/src/devices_models/devices/renewable_generation.jl
+++ b/src/devices_models/devices/renewable_generation.jl
@@ -50,7 +50,7 @@ function DeviceRangeConstraintSpec(
             ),
             variable_name = make_variable_name(ReactivePowerVariable, T),
             limits_func = x -> PSY.get_reactive_power_limits(x),
-            constraint_func = device_range,
+            constraint_func = device_range!,
             constraint_struct = DeviceRangeConstraintInfo,
         ),
     )
@@ -111,7 +111,7 @@ function DeviceRangeConstraintSpec(
                 ),
                 variable_name = make_variable_name(ActivePowerVariable, T),
                 limits_func = x -> (min = 0.0, max = PSY.get_active_power(x)),
-                constraint_func = device_range,
+                constraint_func = device_range!,
                 constraint_struct = DeviceRangeConstraintInfo,
             ),
         )

--- a/src/devices_models/devices/storage.jl
+++ b/src/devices_models/devices/storage.jl
@@ -83,7 +83,7 @@ function DeviceRangeConstraintSpec(
             ),
             variable_name = make_variable_name(ActivePowerOutVariable, T),
             limits_func = x -> PSY.get_output_active_power_limits(x),
-            constraint_func = device_range,
+            constraint_func = device_range!,
             constraint_struct = DeviceRangeConstraintInfo,
         ),
     )
@@ -108,7 +108,7 @@ function DeviceRangeConstraintSpec(
             ),
             variable_name = make_variable_name(ActivePowerInVariable, T),
             limits_func = x -> PSY.get_input_active_power_limits(x),
-            constraint_func = device_range,
+            constraint_func = device_range!,
             constraint_struct = DeviceRangeConstraintInfo,
         ),
     )
@@ -134,7 +134,7 @@ function DeviceRangeConstraintSpec(
             variable_name = make_variable_name(ActivePowerOutVariable, T),
             bin_variable_names = [make_variable_name(ReserveVariable, T)],
             limits_func = x -> PSY.get_output_active_power_limits(x),
-            constraint_func = reserve_device_semicontinuousrange,
+            constraint_func = reserve_device_semicontinuousrange!,
             constraint_struct = DeviceRangeConstraintInfo,
         ),
     )
@@ -160,7 +160,7 @@ function DeviceRangeConstraintSpec(
             variable_name = make_variable_name(ActivePowerInVariable, T),
             bin_variable_names = [make_variable_name(ReserveVariable, T)],
             limits_func = x -> PSY.get_input_active_power_limits(x),
-            constraint_func = reserve_device_semicontinuousrange,
+            constraint_func = reserve_device_semicontinuousrange!,
             constraint_struct = DeviceRangeConstraintInfo,
         ),
     )
@@ -170,9 +170,9 @@ end
 This function adds the reactive  power limits of generators when there are CommitmentVariables
 """
 function add_constraints!(
+    psi_container::PSIContainer,
     ::Type{<:RangeConstraint},
     ::Type{ReactivePowerVariable},
-    psi_container::PSIContainer,
     devices::IS.FlattenIteratorWrapper{St},
     model::DeviceModel{St, D},
     ::Type{S},
@@ -185,7 +185,7 @@ function add_constraints!(
         constraint_infos[ix] = DeviceRangeConstraintInfo(name, limits)
     end
 
-    device_range(
+    device_range!(
         psi_container,
         RangeConstraintSpecInternal(
             constraint_infos,
@@ -224,7 +224,7 @@ function energy_capacity_constraints!(
         constraint_infos[ix] = constraint_info
     end
 
-    device_range(
+    device_range!(
         psi_container,
         RangeConstraintSpecInternal(
             constraint_infos,

--- a/src/devices_models/devices/thermal_generation.jl
+++ b/src/devices_models/devices/thermal_generation.jl
@@ -201,7 +201,7 @@ function DeviceRangeConstraintSpec(
             constraint_name = make_constraint_name(RangeConstraint, ActivePowerVariable, T),
             variable_name = make_variable_name(ActivePowerVariable, T),
             limits_func = x -> PSY.get_active_power_limits(x),
-            constraint_func = device_range,
+            constraint_func = device_range!,
             constraint_struct = DeviceRangeConstraintInfo,
         ),
     )
@@ -226,7 +226,7 @@ function DeviceRangeConstraintSpec(
             variable_name = make_variable_name(ActivePowerVariable, T),
             bin_variable_names = [make_variable_name(OnVariable, T)],
             limits_func = x -> PSY.get_active_power_limits(x),
-            constraint_func = device_semicontinuousrange,
+            constraint_func = device_semicontinuousrange!,
             constraint_struct = DeviceRangeConstraintInfo,
         ),
     )
@@ -251,7 +251,7 @@ function DeviceRangeConstraintSpec(
             constraint_name = make_constraint_name(RangeConstraint, ActivePowerVariable, T),
             variable_name = make_variable_name(ActivePowerVariable, T),
             limits_func = x -> (min = 0.0, max = PSY.get_active_power_limits(x).max),
-            constraint_func = device_range,
+            constraint_func = device_range!,
             constraint_struct = DeviceRangeConstraintInfo,
         ),
         custom_psi_container_func = custom_active_power_constraints!,
@@ -300,7 +300,7 @@ function DeviceRangeConstraintSpec(
                 make_variable_name(StartVariable, T),
                 make_variable_name(StopVariable, T),
             ],
-            constraint_func = device_multistart_range,
+            constraint_func = device_multistart_range!,
             constraint_struct = DeviceMultiStartRangeConstraintsInfo,
             lag_limits_func = PSY.get_power_trajectory,
         ),
@@ -357,7 +357,7 @@ function initial_range_constraints!(
     end
 
     if !isempty(ini_conds)
-        device_multistart_range_ic(
+        device_multistart_range_ic!(
             psi_container,
             constraint_data,
             ini_conds,
@@ -392,7 +392,7 @@ function DeviceRangeConstraintSpec(
             ),
             variable_name = make_variable_name(ReactivePowerVariable, T),
             limits_func = x -> PSY.get_reactive_power_limits(x),
-            constraint_func = device_range,
+            constraint_func = device_range!,
             constraint_struct = DeviceRangeConstraintInfo,
         ),
     )
@@ -421,7 +421,7 @@ function DeviceRangeConstraintSpec(
             variable_name = make_variable_name(ReactivePowerVariable, T),
             bin_variable_names = [make_variable_name(OnVariable, T)],
             limits_func = x -> PSY.get_reactive_power_limits(x),
-            constraint_func = device_semicontinuousrange,
+            constraint_func = device_semicontinuousrange!,
             constraint_struct = DeviceRangeConstraintInfo,
         ),
     )

--- a/src/services_models/agc.jl
+++ b/src/services_models/agc.jl
@@ -4,7 +4,7 @@ struct PIDSmoothACE <: AbstractAGCFormulation end
 """
 Steady State deviation of the frequency
 """
-function add_variables!(::Type{SteadyStateFrequencyDeviation}, psi_container::PSIContainer)
+function add_variables!(psi_container::PSIContainer, ::Type{SteadyStateFrequencyDeviation})
     variable_name = make_variable_name(SteadyStateFrequencyDeviation)
     time_steps = model_time_steps(psi_container)
     variable = add_var_container!(psi_container, variable_name, time_steps)

--- a/src/services_models/services_constructor.jl
+++ b/src/services_models/services_constructor.jl
@@ -92,7 +92,7 @@ function construct_service!(
         #Services without contributing devices should have been filtered out in the validation
         @assert !isempty(contributing_devices)
         #Variables
-        add_variables!(ActiveServiceVariable, psi_container, service, contributing_devices)
+        add_variables!(psi_container, ActiveServiceVariable, service, contributing_devices)
         # Constraints
         service_requirement_constraint!(psi_container, service, model)
         modify_device_model!(devices_template, model, contributing_devices)
@@ -114,7 +114,7 @@ function construct_service!(
     services_mapping = PSY.get_contributing_device_mapping(sys)
     time_steps = model_time_steps(psi_container)
     names = [PSY.get_name(s) for s in services]
-    add_variables!(ServiceRequirementVariable, psi_container, services)
+    add_variables!(psi_container, ServiceRequirementVariable, services)
     add_cons_container!(
         psi_container,
         make_constraint_name(REQUIREMENT, SR),
@@ -133,7 +133,7 @@ function construct_service!(
                 [d for d in contributing_devices if typeof(d) ∉ incompatible_device_types]
         end
         #Variables
-        add_variables!(ActiveServiceVariable, psi_container, service, contributing_devices)
+        add_variables!(psi_container, ActiveServiceVariable, service, contributing_devices)
         # Constraints
         service_requirement_constraint!(psi_container, service, model)
         modify_device_model!(devices_template, model, contributing_devices)
@@ -163,15 +163,15 @@ function construct_service!(
             #    throw(IS.ConflictingInputsError("All area most have an AGC service assigned in order to model the System's Frequency regulation"))
         end
     end
-    add_variables!(SteadyStateFrequencyDeviation, psi_container)
-    add_variables!(AreaMismatchVariable, psi_container, areas)
-    add_variables!(SmoothACE, psi_container, areas)
-    add_variables!(LiftVariable, psi_container, areas)
-    add_variables!(ActivePowerVariable, psi_container, areas)
-    add_variables!(DeltaActivePowerUpVariable, psi_container, areas)
-    add_variables!(DeltaActivePowerDownVariable, psi_container, areas)
-    #add_variables!(AdditionalDeltaActivePowerUpVariable, psi_container, areas)
-    #add_variables!(AdditionalDeltaActivePowerDownVariable, psi_container, areas)
+    add_variables!(psi_container, SteadyStateFrequencyDeviation)
+    add_variables!(psi_container, AreaMismatchVariable, areas)
+    add_variables!(psi_container, SmoothACE, areas)
+    add_variables!(psi_container, LiftVariable, areas)
+    add_variables!(psi_container, ActivePowerVariable, areas)
+    add_variables!(psi_container, DeltaActivePowerUpVariable, areas)
+    add_variables!(psi_container, DeltaActivePowerDownVariable, areas)
+    #add_variables!(psi_container, AdditionalDeltaActivePowerUpVariable, areas)
+    #add_variables!(psi_container, AdditionalDeltaActivePowerDownVariable, areas)
     balancing_auxiliary_variables!(psi_container, sys)
 
     absolute_value_lift(psi_container, areas)

--- a/test/test_services_constructor.jl
+++ b/test/test_services_constructor.jl
@@ -247,7 +247,15 @@ end
     off_service = VariableReserve{ReserveUp}("Reserveoff", true, 0.6, 10)
     push!(groupservice.contributing_services, off_service)
 
-    @test_throws InfrastructureSystems.InvalidValue op_problem =
-        OperationsProblem(TestOpProblem, model_template, c_sys5_uc; use_parameters = false)
+    @test_logs(
+        (:error, r"is not stored"),
+        match_mode = :any,
+        @test_throws InfrastructureSystems.InvalidValue op_problem = OperationsProblem(
+            TestOpProblem,
+            model_template,
+            c_sys5_uc;
+            use_parameters = false,
+        )
+    )
 
 end

--- a/test/test_utils/get_test_data.jl
+++ b/test/test_utils/get_test_data.jl
@@ -101,16 +101,8 @@ end
 
 function build_c_sys5(; kwargs...)
     nodes = nodes5()
-    c_sys5 = System(
-        nodes,
-        thermal_generators5(nodes),
-        loads5(nodes),
-        branches5(nodes),
-        nothing,
-        100.0,
-        nothing,
-        nothing,
-    )
+    c_sys5 =
+        System(100.0, nodes, thermal_generators5(nodes), loads5(nodes), branches5(nodes))
 
     if get(kwargs, :add_forecasts, true)
         for t in 1:2
@@ -130,14 +122,11 @@ end
 function build_c_sys5_ml(; kwargs...)
     nodes = nodes5()
     c_sys5_ml = System(
+        100.0,
         nodes,
         thermal_generators5(nodes),
         loads5(nodes),
-        branches5(nodes),
-        nothing,
-        100.0,
-        nothing,
-        nothing;
+        branches5(nodes);
         time_series_in_memory = get(kwargs, :time_series_in_memory, true),
     )
 
@@ -159,14 +148,11 @@ end
 function build_c_sys14(; kwargs...)
     nodes = nodes14()
     c_sys14 = System(
+        100.0,
         nodes,
         thermal_generators14(nodes),
         loads14(nodes),
-        branches14(nodes),
-        nothing,
-        100.0,
-        nothing,
-        nothing;
+        branches14(nodes);
         time_series_in_memory = get(kwargs, :time_series_in_memory, true),
     )
 
@@ -186,14 +172,12 @@ end
 function build_c_sys5_re(; kwargs...)
     nodes = nodes5()
     c_sys5_re = System(
-        nodes,
-        vcat(thermal_generators5(nodes), renewable_generators5(nodes)),
-        loads5(nodes),
-        branches5(nodes),
-        nothing,
         100.0,
-        nothing,
-        nothing;
+        nodes,
+        thermal_generators5(nodes),
+        renewable_generators5(nodes),
+        loads5(nodes),
+        branches5(nodes);
         time_series_in_memory = get(kwargs, :time_series_in_memory, true),
     )
 
@@ -243,14 +227,11 @@ end
 function build_c_sys5_re_only(; kwargs...)
     nodes = nodes5()
     c_sys5_re_only = System(
+        100.0,
         nodes,
         renewable_generators5(nodes),
         loads5(nodes),
-        branches5(nodes),
-        nothing,
-        100.0,
-        nothing,
-        nothing;
+        branches5(nodes);
         time_series_in_memory = get(kwargs, :time_series_in_memory, true),
     )
 
@@ -279,14 +260,12 @@ end
 function build_c_sys5_hy(; kwargs...)
     nodes = nodes5()
     c_sys5_hy = System(
-        nodes,
-        vcat(thermal_generators5(nodes), hydro_generators5(nodes)[1]),
-        loads5(nodes),
-        branches5(nodes),
-        nothing,
         100.0,
-        nothing,
-        nothing;
+        nodes,
+        thermal_generators5(nodes),
+        [hydro_generators5(nodes)[1]],
+        loads5(nodes),
+        branches5(nodes);
         time_series_in_memory = get(kwargs, :time_series_in_memory, true),
     )
 
@@ -315,14 +294,12 @@ end
 function build_c_sys5_hyd(; kwargs...)
     nodes = nodes5()
     c_sys5_hyd = System(
-        nodes,
-        vcat(thermal_generators5(nodes), hydro_generators5(nodes)[2]),
-        loads5(nodes),
-        branches5(nodes),
-        nothing,
         100.0,
-        nothing,
-        nothing;
+        nodes,
+        thermal_generators5(nodes),
+        [hydro_generators5(nodes)[2]],
+        loads5(nodes),
+        branches5(nodes);
         time_series_in_memory = get(kwargs, :time_series_in_memory, true),
     )
 
@@ -395,14 +372,13 @@ function build_c_sys5_bat(; kwargs...)
     time_series_in_memory = get(kwargs, :time_series_in_memory, true)
     nodes = nodes5()
     c_sys5_bat = System(
+        100.0,
         nodes,
-        vcat(thermal_generators5(nodes), renewable_generators5(nodes)),
+        thermal_generators5(nodes),
+        renewable_generators5(nodes),
         loads5(nodes),
         branches5(nodes),
-        battery5(nodes),
-        100.0,
-        nothing,
-        nothing;
+        battery5(nodes);
         time_series_in_memory = time_series_in_memory,
     )
 
@@ -444,14 +420,12 @@ end
 function build_c_sys5_il(; kwargs...)
     nodes = nodes5()
     c_sys5_il = System(
+        100.0,
         nodes,
         thermal_generators5(nodes),
-        vcat(loads5(nodes), interruptible(nodes)),
-        branches5(nodes),
-        nothing,
-        100.0,
-        nothing,
-        nothing;
+        loads5(nodes),
+        interruptible(nodes),
+        branches5(nodes);
         time_series_in_memory = get(kwargs, :time_series_in_memory, true),
     )
 
@@ -501,14 +475,12 @@ end
 function build_c_sys5_dc(; kwargs...)
     nodes = nodes5()
     c_sys5_dc = System(
-        nodes,
-        vcat(thermal_generators5(nodes), renewable_generators5(nodes)),
-        loads5(nodes),
-        branches5_dc(nodes),
-        nothing,
         100.0,
-        nothing,
-        nothing;
+        nodes,
+        thermal_generators5(nodes),
+        renewable_generators5(nodes),
+        loads5(nodes),
+        branches5_dc(nodes);
         time_series_in_memory = get(kwargs, :time_series_in_memory, true),
     )
 
@@ -537,14 +509,11 @@ end
 function build_c_sys14_dc(; kwargs...)
     nodes = nodes14()
     c_sys14_dc = System(
+        100.0,
         nodes,
         thermal_generators14(nodes),
         loads14(nodes),
-        branches14_dc(nodes),
-        nothing,
-        100.0,
-        nothing,
-        nothing;
+        branches14_dc(nodes);
         time_series_in_memory = get(kwargs, :time_series_in_memory, true),
     )
 
@@ -564,16 +533,8 @@ end
 function build_c_sys5_reg(; kwargs...)
     nodes = nodes5()
 
-    c_sys5_reg = System(
-        nodes,
-        thermal_generators5(nodes),
-        loads5(nodes),
-        branches5(nodes),
-        nothing,
-        100.0,
-        nothing,
-        nothing,
-    )
+    c_sys5_reg =
+        System(100.0, nodes, thermal_generators5(nodes), loads5(nodes), branches5(nodes))
 
     area = Area("1")
     add_component!(c_sys5_reg, area)
@@ -777,14 +738,11 @@ end
 function build_c_sys5_uc(; kwargs...)
     nodes = nodes5()
     c_sys5_uc = System(
+        100.0,
         nodes,
         thermal_generators5_uc_testing(nodes),
         loads5(nodes),
-        branches5(nodes),
-        nothing,
-        100.0,
-        nothing,
-        nothing;
+        branches5(nodes);
         time_series_in_memory = get(kwargs, :time_series_in_memory, true),
     )
 
@@ -852,14 +810,13 @@ end
 function build_c_sys5_ed(; kwargs...)
     nodes = nodes5()
     c_sys5_ed = System(
-        nodes,
-        vcat(thermal_generators5_uc_testing(nodes), renewable_generators5(nodes)),
-        vcat(loads5(nodes), interruptible(nodes)),
-        branches5(nodes),
-        nothing,
         100.0,
-        nothing,
-        nothing;
+        nodes,
+        thermal_generators5_uc_testing(nodes),
+        renewable_generators5(nodes),
+        loads5(nodes),
+        interruptible(nodes),
+        branches5(nodes);
         time_series_in_memory = get(kwargs, :time_series_in_memory, true),
     )
 
@@ -933,18 +890,13 @@ end
 function build_c_sys5_hy_uc(; kwargs...)
     nodes = nodes5()
     c_sys5_hy_uc = System(
-        nodes,
-        vcat(
-            thermal_generators5_uc_testing(nodes),
-            hydro_generators5(nodes),
-            renewable_generators5(nodes),
-        ),
-        loads5(nodes),
-        branches5(nodes),
-        nothing,
         100.0,
-        nothing,
-        nothing;
+        nodes,
+        thermal_generators5_uc_testing(nodes),
+        hydro_generators5(nodes),
+        renewable_generators5(nodes),
+        loads5(nodes),
+        branches5(nodes);
         time_series_in_memory = get(kwargs, :time_series_in_memory, true),
     )
 
@@ -1008,18 +960,14 @@ end
 function build_c_sys5_hy_ed(; kwargs...)
     nodes = nodes5()
     c_sys5_hy_ed = System(
-        nodes,
-        vcat(
-            thermal_generators5_uc_testing(nodes),
-            hydro_generators5(nodes),
-            renewable_generators5(nodes),
-        ),
-        vcat(loads5(nodes), interruptible(nodes)),
-        branches5(nodes),
-        nothing,
         100.0,
-        nothing,
-        nothing;
+        nodes,
+        thermal_generators5_uc_testing(nodes),
+        hydro_generators5(nodes),
+        renewable_generators5(nodes),
+        loads5(nodes),
+        interruptible(nodes),
+        branches5(nodes);
         time_series_in_memory = get(kwargs, :time_series_in_memory, true),
     )
 
@@ -1114,14 +1062,12 @@ end
 function build_c_sys5_pglib(; kwargs...)
     nodes = nodes5()
     c_sys5_uc = System(
-        nodes,
-        vcat(thermal_generators5_uc_testing(nodes), thermal_pglib_generators5(nodes)),
-        loads5(nodes),
-        branches5(nodes),
-        nothing,
         100.0,
-        nothing,
-        nothing;
+        nodes,
+        thermal_generators5_uc_testing(nodes),
+        thermal_pglib_generators5(nodes),
+        loads5(nodes),
+        branches5(nodes);
         time_series_in_memory = get(kwargs, :time_series_in_memory, true),
     )
 


### PR DESCRIPTION
1. Updates PSY.System constructor calls per https://github.com/NREL-SIIP/PowerSystems.jl/pull/593.
2. Applies Julia coding standards to cases where function argument order was incorrect or where a mutating function did not end with `!`.
3. Suppresses an expected error log message in a test.

The diff is large, but there is no real logic change.