### PR TITLE
Change reserves formulations to abstract

### DIFF
--- a/src/services_models/reserves.jl
+++ b/src/services_models/reserves.jl
@@ -1,6 +1,6 @@
 abstract type AbstractReservesFormulation <: AbstractServiceFormulation end
-struct RangeReserve <: AbstractReservesFormulation end
-struct StepwiseCostReserve <: AbstractReservesFormulation end
+abstract type RangeReserve <: AbstractReservesFormulation end
+abstract type StepwiseCostReserve <: AbstractReservesFormulation end
 ############################### Reserve Variables` #########################################
 """
 This function add the variables for reserves to the model


### PR DESCRIPTION
Changes reserves formulations (RangeReserve and StepwiseCostReserve) to abstract.
This pattern will help type 2 users reuser most of the structure existing and won't imply any breaking changes or big refactoring.