### PR TITLE
Change instances of Int64 to Int

### DIFF
--- a/src/core/feedforward.jl
+++ b/src/core/feedforward.jl
@@ -28,8 +28,8 @@ struct Consecutive <: FeedForwardChronology end
 struct FullHorizon <: FeedForwardChronology end
 
 struct Range <: FeedForwardChronology
-    range::UnitRange{Int64}
-    function Range(; range::UnitRange{Int64})
+    range::UnitRange{Int}
+    function Range(; range::UnitRange{Int})
         new(range)
     end
 end

--- a/src/core/simulation_sequence.jl
+++ b/src/core/simulation_sequence.jl
@@ -177,7 +177,7 @@ mutable struct SimulationSequence
     ini_cond_chronology::InitialConditionChronology
     cache::Dict{Tuple, AbstractCache}
     execution_order::Vector{Int}
-    current_execution_index::Int64
+    current_execution_index::Int
 
     function SimulationSequence(;
         horizons::Dict{String, Int},

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -245,7 +245,7 @@ function Base.show(io::IO, ::MIME"text/plain", sim_results::SimulationResultsRef
 end
 
 function _count_stages(sequence::Array)
-    stages = Dict{Int64, Int64}()
+    stages = Dict{Int, Int}()
     stage = 1
     count = 0
     for i in 1:length(sequence)
@@ -315,7 +315,7 @@ function _print_feedforward(io::IO, feed_forward::Dict, to::Array, from::Any)
         end
     end
 end
-function _print_inter_stages(io::IO, stages::Dict{Int64, Int64})
+function _print_inter_stages(io::IO, stages::Dict{Int, Int})
     list = sort!(collect(keys(stages)))
     for i in list
         num = stages[i]
@@ -365,7 +365,7 @@ function _print_inter_stages(io::IO, stages::Dict{Int64, Int64})
     end
 end
 
-function _print_intra_stages(io::IO, stages::Dict{Int64, Int64})
+function _print_intra_stages(io::IO, stages::Dict{Int, Int})
     list = sort!(collect(keys(stages)))
     for i in list
         num = stages[i]

--- a/test/test_utils/operations_problem_templates.jl
+++ b/test/test_utils/operations_problem_templates.jl
@@ -108,7 +108,7 @@ devices = Dict(
 template_pwl_ed =
     OperationsProblemTemplate(CopperPlatePowerModel, devices, branches, services)
 
-function PSI._jump_value(int::Int64)
+function PSI._jump_value(int::Int)
     @warn("This is for testing purposes only.")
     return int
 end
@@ -134,7 +134,7 @@ function _test_html_print_methods(list::Array)
 end
 
 struct FakeStagesStruct
-    stages::Dict{Int64, Int64}
+    stages::Dict{Int, Int}
 end
 function Base.show(io::IO, struct_stages::FakeStagesStruct)
     PSI._print_inter_stages(io, struct_stages.stages)


### PR DESCRIPTION
Is there any reason for the occurrences of `Int64` in the code? Having them as `Int` would be good. We have a small test running which is failing for 32-bit runners and this might be the issue.