### PR TITLE
Fix TimeSeries for GroupReserve

### DIFF
--- a/src/services_models/GroupReserve.jl
+++ b/src/services_models/GroupReserve.jl
@@ -24,7 +24,6 @@ function service_requirement_constraint!(
     contributing_services::Vector{<:PSY.Service},
 ) where {SR <: PSY.StaticReserveGroup}
     parameters = model_has_parameters(psi_container)
-    use_forecast_data = model_uses_forecasts(psi_container)
     initial_time = model_initial_time(psi_container)
     @debug initial_time
     time_steps = model_time_steps(psi_container)
@@ -36,39 +35,20 @@ function service_requirement_constraint!(
         for r in contributing_services
     ]
 
-    ts_vector = get_time_series(psi_container, service, "requirement")
-
     requirement = PSY.get_requirement(service)
-    if parameters
-        param = get_parameter_array(
-            psi_container,
-            UpdateRef{SR}(SERVICE_REQUIREMENT, "requirement"),
+    for t in time_steps
+        resource_expression = JuMP.GenericAffExpr{Float64, JuMP.VariableRef}()
+        for reserve_variable in reserve_variables
+            JuMP.add_to_expression!(resource_expression, sum(reserve_variable[:, t]))
+        end
+        if use_slacks
+            resource_expression += slack_vars[t]
+        end
+        constraint[name, t] = JuMP.@constraint(
+            psi_container.JuMPmodel,
+            resource_expression >= requirement
         )
-        for t in time_steps
-            param[name, t] = PJ.add_parameter(psi_container.JuMPmodel, ts_vector[t])
-            resource_expression = JuMP.GenericAffExpr{Float64, JuMP.VariableRef}()
-            for reserve_variable in reserve_variables
-                JuMP.add_to_expression!(resource_expression, sum(reserve_variable[:, t]))
-            end
-            if use_slacks
-                resource_expression += slack_vars[t]
-            end
-            constraint[name, t] = JuMP.@constraint(
-                psi_container.JuMPmodel,
-                resource_expression >= param[name, t] * requirement
-            )
-        end
-    else
-        for t in time_steps
-            resource_expression = JuMP.GenericAffExpr{Float64, JuMP.VariableRef}()
-            for reserve_variable in reserve_variables
-                JuMP.add_to_expression!(resource_expression, sum(reserve_variable[:, t]))
-            end
-            constraint[name, t] = JuMP.@constraint(
-                psi_container.JuMPmodel,
-                resource_expression >= ts_vector[t] * requirement
-            )
-        end
     end
+    
     return
 end

--- a/src/services_models/GroupReserve.jl
+++ b/src/services_models/GroupReserve.jl
@@ -36,10 +36,7 @@ function service_requirement_constraint!(
         for r in contributing_services
     ]
 
-    # TODO: should we make a get_time_series method for the StaticReserveGroup that handles the following two lines?
-    ts_vectors =
-        [get_time_series(psi_container, s, "requirement") for s in contributing_services]
-    ts_vector = sum(hcat(ts_vectors...), dims = 2)
+    ts_vector = get_time_series(psi_container, service, "requirement")
 
     requirement = PSY.get_requirement(service)
     if parameters

--- a/src/services_models/GroupReserve.jl
+++ b/src/services_models/GroupReserve.jl
@@ -44,11 +44,9 @@ function service_requirement_constraint!(
         if use_slacks
             resource_expression += slack_vars[t]
         end
-        constraint[name, t] = JuMP.@constraint(
-            psi_container.JuMPmodel,
-            resource_expression >= requirement
-        )
+        constraint[name, t] =
+            JuMP.@constraint(psi_container.JuMPmodel, resource_expression >= requirement)
     end
-    
+
     return
 end

--- a/test/test_services_constructor.jl
+++ b/test/test_services_constructor.jl
@@ -208,7 +208,7 @@ end
     for p in [true, false]
         op_problem =
             OperationsProblem(TestOpProblem, model_template, c_sys5_uc; use_parameters = p)
-        moi_tests(op_problem, p, 648, 0, 120, 240, 72, false)
+        moi_tests(op_problem, p, 384, 0, 120, 216, 24, false)
     end
 end
 


### PR DESCRIPTION
Fixes TimeSeries handling for `GroupReserve`. The requirement in a `GroupReserve` is supposed to be an extra constraint and shouldn't be affected by the requirements of the contributing services.

EX: `GroupReserve` is composed of Regulation and Spinning.

The market operator sets the requirement for Regulation to be 100 MWh (contributing generators should reserve together this amount, let's call their summed contribution R_reg) and Spinning to be 50 MWh (let's call their summed contribution R_spin). For security, the operator creates a new requirement of 200 MW (a `GroupReserve`) for the sum of Regulation and Spinning reserves. The constraints should be:
 1) R_reg >= 100
 2) R_spin >= 50
 3) R_reg + R_spin >= 200