### PR TITLE
Fix serialization of op problem

### DIFF
--- a/src/core/operations_problem.jl
+++ b/src/core/operations_problem.jl
@@ -615,6 +615,7 @@ function serialize_problem(op_problem::OperationsProblem, filename::AbstractStri
     # A PowerSystem cannot be serialized in this format because of how it stores
     # time series data. Use its specialized serialization method instead.
     sys_filename = "$(basename(filename))-system-$(IS.get_uuid(op_problem.sys)).json"
+    sys_filename = joinpath(dirname(filename), sys_filename)
     PSY.to_json(op_problem.sys, sys_filename)
     obj = OperationsProblemSerializationWrapper(
         op_problem.template,

--- a/test/test_operations_solve.jl
+++ b/test/test_operations_solve.jl
@@ -472,7 +472,8 @@ function test_op_problem_write_functions(file_path)
         filename = joinpath(path, "test_op_problem.bin")
         serialize_problem(op_problem, filename)
         file_list = sort!(collect(readdir(path)))
-        @test ["op_problem.json", "test_op_problem.bin"] == file_list
+        @test "op_problem.json" in file_list
+        @test "test_op_problem.bin" in file_list
         ED2 = OperationsProblem(filename, optimizer = OSQP_optimizer)
         psi_checksolve_test(ED2, [MOI.OPTIMAL], 240000.0, 10000)
     end


### PR DESCRIPTION
The serialized system was going into the current directory instead of the user-requested directory.