### PR TITLE
fill empty param array with NaN

### DIFF
--- a/src/core/psi_container.jl
+++ b/src/core/psi_container.jl
@@ -438,7 +438,7 @@ function add_param_container!(
     container = ParameterContainer(
         param_reference,
         JuMP.Containers.DenseAxisArray{PJ.ParameterRef}(undef, axs...),
-        JuMP.Containers.DenseAxisArray{Float64}(undef, axs...),
+        fill!(JuMP.Containers.DenseAxisArray{Float64}(undef, axs...), NaN),
     )
     assign_parameter!(psi_container, container)
     return container


### PR DESCRIPTION
This will prevent that in the future values close to 0 from using undef get confused from actual 0 values. 