### PR TITLE
fix incorrect implementations

### DIFF
--- a/src/core/service_models.jl
+++ b/src/core/service_models.jl
@@ -9,6 +9,7 @@ struct MyServiceFormulation <: PSI.AbstractServiceFormulation
 ```
 """
 abstract type AbstractServiceFormulation end
+abstract type AbstractReservesFormulation <: AbstractServiceFormulation end
 
 function _check_service_formulation(
     ::Type{D},

--- a/src/core/simulation.jl
+++ b/src/core/simulation.jl
@@ -380,12 +380,14 @@ function _assign_feedforward_chronologies(sim::Simulation)
     # JDNOTE: this is limiting since it only allows updating from one problem
     for (key, chron) in get_sequence(sim).feedforward_chronologies
         destination_problem = problems[key.second]
-        destination_problem_interval = get_interval(sequence, key.second)
+        destination_problem_interval_ = get_interval(sequence, key.second)
+        destination_problem_interval = IS.time_period_conversion(destination_problem_interval_)
         source_problem = problems[key.first]
         source_problem_number = get_simulation_number(source_problem)
         sim_info = get_simulation_info(destination_problem)
         sim_info.chronolgy_dict[source_problem_number] = chron
-        source_problem_resolution = PSY.get_time_series_resolution(source_problem.sys)
+        source_problem_resolution_ = PSY.get_time_series_resolution(source_problem.sys)
+        source_problem_resolution = IS.time_period_conversion(source_problem_resolution_)
         execution_wait_count = Int(source_problem_resolution / destination_problem_interval)
         set_execution_wait_count!(get_trigger(chron), execution_wait_count)
         initialize_trigger_count!(get_trigger(chron))

--- a/src/core/simulation.jl
+++ b/src/core/simulation.jl
@@ -855,7 +855,7 @@ function update_parameter!(
         component_name = PSY.get_name(d)
         for (ix, val) in enumerate(get_parameter_array(container)[component_name, :])
             value = ts_vector[ix]
-            JuMP.fix(val, value)
+            JuMP.set_vaue(val, value)
         end
     end
 
@@ -890,7 +890,7 @@ function update_parameter!(
             ignore_scaling_factors = true,
         )
         for (jx, value) in enumerate(ts_vector)
-            JuMP.fix(get_parameter_array(container)[ix, jx], value)
+            JuMP.set_vaue(get_parameter_array(container)[ix, jx], value)
         end
     end
 

--- a/src/core/simulation.jl
+++ b/src/core/simulation.jl
@@ -855,7 +855,7 @@ function update_parameter!(
         component_name = PSY.get_name(d)
         for (ix, val) in enumerate(get_parameter_array(container)[component_name, :])
             value = ts_vector[ix]
-            JuMP.set_vaue(val, value)
+            JuMP.set_value(val, value)
         end
     end
 
@@ -890,7 +890,7 @@ function update_parameter!(
             ignore_scaling_factors = true,
         )
         for (jx, value) in enumerate(ts_vector)
-            JuMP.set_vaue(get_parameter_array(container)[ix, jx], value)
+            JuMP.set_value(get_parameter_array(container)[ix, jx], value)
         end
     end
 

--- a/src/core/simulation.jl
+++ b/src/core/simulation.jl
@@ -381,7 +381,8 @@ function _assign_feedforward_chronologies(sim::Simulation)
     for (key, chron) in get_sequence(sim).feedforward_chronologies
         destination_problem = problems[key.second]
         destination_problem_interval_ = get_interval(sequence, key.second)
-        destination_problem_interval = IS.time_period_conversion(destination_problem_interval_)
+        destination_problem_interval =
+            IS.time_period_conversion(destination_problem_interval_)
         source_problem = problems[key.first]
         source_problem_number = get_simulation_number(source_problem)
         sim_info = get_simulation_info(destination_problem)

--- a/src/devices_models/device_constructors/branch_constructor.jl
+++ b/src/devices_models/device_constructors/branch_constructor.jl
@@ -67,7 +67,7 @@ function construct_device!(
         return
     end
 
-    add_variables!(optimization_container, S, devices)
+    add_variables!(optimization_container, S, devices, StaticBranch())
     branch_flow_values!(optimization_container, devices, model, S)
     branch_rate_constraints!(
         optimization_container,
@@ -90,7 +90,7 @@ function construct_device!(
         return
     end
 
-    add_variables!(optimization_container, S, devices)
+    add_variables!(optimization_container, S, devices, StaticBranchBounds())
     branch_flow_values!(optimization_container, devices, model, S)
     branch_rate_bounds!(optimization_container, devices, model, S)
     return
@@ -107,7 +107,7 @@ function construct_device!(
         return
     end
 
-    add_variables!(optimization_container, S, devices)
+    add_variables!(optimization_container, S, devices, StaticBranchUnbounded())
     branch_flow_values!(optimization_container, devices, model, S)
     return
 end
@@ -171,15 +171,19 @@ end
 function construct_device!(
     optimization_container::OptimizationContainer,
     sys::PSY.System,
-    model::DeviceModel{B, <:AbstractDCLineFormulation},
+    model::DeviceModel{B, U},
     ::Type{S},
-) where {B <: PSY.DCBranch, S <: Union{StandardPTDFModel, PTDFPowerModel}}
+) where {
+    B <: PSY.DCBranch,
+    U <: AbstractDCLineFormulation,
+    S <: Union{StandardPTDFModel, PTDFPowerModel},
+}
     devices = get_available_components(B, sys)
     if !validate_available_devices(B, devices)
         return
     end
 
-    add_variables!(optimization_container, StandardPTDFModel(), devices)
+    add_variables!(optimization_container, StandardPTDFModel, devices, U())
 
     branch_rate_constraints!(
         optimization_container,

--- a/src/devices_models/device_constructors/branch_constructor.jl
+++ b/src/devices_models/device_constructors/branch_constructor.jl
@@ -183,7 +183,7 @@ function construct_device!(
         return
     end
 
-    add_variables!(optimization_container, StandardPTDFModel, devices, U())
+    add_variables!(optimization_container, S, devices, U())
 
     branch_rate_constraints!(
         optimization_container,

--- a/src/devices_models/device_constructors/hydrogeneration_constructor.jl
+++ b/src/devices_models/device_constructors/hydrogeneration_constructor.jl
@@ -38,8 +38,8 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, ActivePowerVariable, devices)
-    add_variables!(optimization_container, ReactivePowerVariable, devices)
+    add_variables!(optimization_container, ActivePowerVariable, devices, D())
+    add_variables!(optimization_container, ReactivePowerVariable, devices, D())
 
     # Constraints
     add_constraints!(
@@ -89,7 +89,7 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, ActivePowerVariable, devices)
+    add_variables!(optimization_container, ActivePowerVariable, devices, D())
 
     # Constraints
     add_constraints!(
@@ -125,8 +125,18 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, ActivePowerVariable, devices)
-    add_variables!(optimization_container, ReactivePowerVariable, devices)
+    add_variables!(
+        optimization_container,
+        ActivePowerVariable,
+        devices,
+        HydroDispatchReservoirBudget(),
+    )
+    add_variables!(
+        optimization_container,
+        ReactivePowerVariable,
+        devices,
+        HydroDispatchReservoirBudget(),
+    )
 
     # Energy Budget Constraint
     energy_budget_constraints!(
@@ -162,7 +172,12 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, ActivePowerVariable, devices)
+    add_variables!(
+        optimization_container,
+        ActivePowerVariable,
+        devices,
+        HydroDispatchReservoirBudget(),
+    )
 
     # Energy Budget Constraint
     energy_budget_constraints!(
@@ -197,10 +212,30 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, ActivePowerVariable, devices)
-    add_variables!(optimization_container, ReactivePowerVariable, devices)
-    add_variables!(optimization_container, EnergyVariable, devices)
-    add_variables!(optimization_container, SpillageVariable, devices)
+    add_variables!(
+        optimization_container,
+        ActivePowerVariable,
+        devices,
+        HydroDispatchReservoirStorage(),
+    )
+    add_variables!(
+        optimization_container,
+        ReactivePowerVariable,
+        devices,
+        HydroDispatchReservoirStorage(),
+    )
+    add_variables!(
+        optimization_container,
+        EnergyVariable,
+        devices,
+        HydroDispatchReservoirStorage(),
+    )
+    add_variables!(
+        optimization_container,
+        SpillageVariable,
+        devices,
+        HydroDispatchReservoirStorage(),
+    )
 
     # Initial Conditions
     storage_energy_init(optimization_container, devices)
@@ -238,9 +273,24 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, ActivePowerVariable, devices)
-    add_variables!(optimization_container, EnergyVariable, devices)
-    add_variables!(optimization_container, SpillageVariable, devices)
+    add_variables!(
+        optimization_container,
+        ActivePowerVariable,
+        devices,
+        HydroDispatchReservoirStorage(),
+    )
+    add_variables!(
+        optimization_container,
+        EnergyVariable,
+        devices,
+        HydroDispatchReservoirStorage(),
+    )
+    add_variables!(
+        optimization_container,
+        SpillageVariable,
+        devices,
+        HydroDispatchReservoirStorage(),
+    )
 
     # Initial Conditions
     storage_energy_init(optimization_container, devices)
@@ -276,9 +326,9 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, ActivePowerVariable, devices)
-    add_variables!(optimization_container, ReactivePowerVariable, devices)
-    add_variables!(optimization_container, OnVariable, devices)
+    add_variables!(optimization_container, ActivePowerVariable, devices, D())
+    add_variables!(optimization_container, ReactivePowerVariable, devices, D())
+    add_variables!(optimization_container, OnVariable, devices, D())
 
     # Constraints
     add_constraints!(
@@ -335,8 +385,8 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, ActivePowerVariable, devices)
-    add_variables!(optimization_container, OnVariable, devices)
+    add_variables!(optimization_container, ActivePowerVariable, devices, D())
+    add_variables!(optimization_container, OnVariable, devices, D())
 
     # Constraints
     add_constraints!(
@@ -378,9 +428,9 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, ActivePowerVariable, devices)
-    add_variables!(optimization_container, ReactivePowerVariable, devices)
-    add_variables!(optimization_container, OnVariable, devices)
+    add_variables!(optimization_container, ActivePowerVariable, devices, D())
+    add_variables!(optimization_container, ReactivePowerVariable, devices, D())
+    add_variables!(optimization_container, OnVariable, devices, D())
 
     # Constraints
     add_constraints!(
@@ -439,8 +489,8 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, ActivePowerVariable, devices)
-    add_variables!(optimization_container, OnVariable, devices)
+    add_variables!(optimization_container, ActivePowerVariable, devices, D())
+    add_variables!(optimization_container, OnVariable, devices, D())
 
     # Constraints
     add_constraints!(
@@ -485,11 +535,11 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, ActivePowerVariable, devices)
-    add_variables!(optimization_container, ReactivePowerVariable, devices)
-    add_variables!(optimization_container, OnVariable, devices)
-    add_variables!(optimization_container, EnergyVariable, devices)
-    add_variables!(optimization_container, SpillageVariable, devices)
+    add_variables!(optimization_container, ActivePowerVariable, devices, D())
+    add_variables!(optimization_container, ReactivePowerVariable, devices, D())
+    add_variables!(optimization_container, OnVariable, devices, D())
+    add_variables!(optimization_container, EnergyVariable, devices, D())
+    add_variables!(optimization_container, SpillageVariable, devices, D())
 
     # Constraints
     add_constraints!(
@@ -547,10 +597,30 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, ActivePowerVariable, devices)
-    add_variables!(optimization_container, OnVariable, devices)
-    add_variables!(optimization_container, EnergyVariable, devices)
-    add_variables!(optimization_container, SpillageVariable, devices)
+    add_variables!(
+        optimization_container,
+        ActivePowerVariable,
+        devices,
+        HydroCommitmentReservoirStorage(),
+    )
+    add_variables!(
+        optimization_container,
+        OnVariable,
+        devices,
+        HydroCommitmentReservoirStorage(),
+    )
+    add_variables!(
+        optimization_container,
+        EnergyVariable,
+        devices,
+        HydroCommitmentReservoirStorage(),
+    )
+    add_variables!(
+        optimization_container,
+        SpillageVariable,
+        devices,
+        HydroCommitmentReservoirStorage(),
+    )
 
     # Constraints
     add_constraints!(
@@ -598,11 +668,36 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, ActivePowerInVariable, devices)
-    add_variables!(optimization_container, ActivePowerOutVariable, devices)
-    add_variables!(optimization_container, EnergyVariableUp, devices)
-    add_variables!(optimization_container, EnergyVariableDown, devices)
-    add_variables!(optimization_container, SpillageVariable, devices)
+    add_variables!(
+        optimization_container,
+        ActivePowerInVariable,
+        devices,
+        HydroDispatchPumpedStorage(),
+    )
+    add_variables!(
+        optimization_container,
+        ActivePowerOutVariable,
+        devices,
+        HydroDispatchPumpedStorage(),
+    )
+    add_variables!(
+        optimization_container,
+        EnergyVariableUp,
+        devices,
+        HydroDispatchPumpedStorage(),
+    )
+    add_variables!(
+        optimization_container,
+        EnergyVariableDown,
+        devices,
+        HydroDispatchPumpedStorage(),
+    )
+    add_variables!(
+        optimization_container,
+        SpillageVariable,
+        devices,
+        HydroDispatchPumpedStorage(),
+    )
 
     # Constraints
     add_constraints!(
@@ -661,12 +756,42 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, ActivePowerInVariable, devices)
-    add_variables!(optimization_container, ActivePowerOutVariable, devices)
-    add_variables!(optimization_container, EnergyVariableUp, devices)
-    add_variables!(optimization_container, EnergyVariableDown, devices)
-    add_variables!(optimization_container, SpillageVariable, devices)
-    add_variables!(optimization_container, ReserveVariable, devices)
+    add_variables!(
+        optimization_container,
+        ActivePowerInVariable,
+        devices,
+        HydroDispatchPumpedStoragewReservation(),
+    )
+    add_variables!(
+        optimization_container,
+        ActivePowerOutVariable,
+        devices,
+        HydroDispatchPumpedStoragewReservation(),
+    )
+    add_variables!(
+        optimization_container,
+        EnergyVariableUp,
+        devices,
+        HydroDispatchPumpedStoragewReservation(),
+    )
+    add_variables!(
+        optimization_container,
+        EnergyVariableDown,
+        devices,
+        HydroDispatchPumpedStoragewReservation(),
+    )
+    add_variables!(
+        optimization_container,
+        SpillageVariable,
+        devices,
+        HydroDispatchPumpedStoragewReservation(),
+    )
+    add_variables!(
+        optimization_container,
+        ReserveVariable,
+        devices,
+        HydroDispatchPumpedStoragewReservation(),
+    )
 
     # Constraints
     add_constraints!(

--- a/src/devices_models/device_constructors/hydrogeneration_constructor.jl
+++ b/src/devices_models/device_constructors/hydrogeneration_constructor.jl
@@ -535,11 +535,11 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, ActivePowerVariable, devices, D())
-    add_variables!(optimization_container, ReactivePowerVariable, devices, D())
-    add_variables!(optimization_container, OnVariable, devices, D())
-    add_variables!(optimization_container, EnergyVariable, devices, D())
-    add_variables!(optimization_container, SpillageVariable, devices, D())
+    add_variables!(optimization_container, ActivePowerVariable, devices, HydroCommitmentReservoirStorage())
+    add_variables!(optimization_container, ReactivePowerVariable, devices, HydroCommitmentReservoirStorage())
+    add_variables!(optimization_container, OnVariable, devices, HydroCommitmentReservoirStorage())
+    add_variables!(optimization_container, EnergyVariable, devices, HydroCommitmentReservoirStorage())
+    add_variables!(optimization_container, SpillageVariable, devices, HydroCommitmentReservoirStorage())
 
     # Constraints
     add_constraints!(

--- a/src/devices_models/device_constructors/hydrogeneration_constructor.jl
+++ b/src/devices_models/device_constructors/hydrogeneration_constructor.jl
@@ -535,11 +535,36 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, ActivePowerVariable, devices, HydroCommitmentReservoirStorage())
-    add_variables!(optimization_container, ReactivePowerVariable, devices, HydroCommitmentReservoirStorage())
-    add_variables!(optimization_container, OnVariable, devices, HydroCommitmentReservoirStorage())
-    add_variables!(optimization_container, EnergyVariable, devices, HydroCommitmentReservoirStorage())
-    add_variables!(optimization_container, SpillageVariable, devices, HydroCommitmentReservoirStorage())
+    add_variables!(
+        optimization_container,
+        ActivePowerVariable,
+        devices,
+        HydroCommitmentReservoirStorage(),
+    )
+    add_variables!(
+        optimization_container,
+        ReactivePowerVariable,
+        devices,
+        HydroCommitmentReservoirStorage(),
+    )
+    add_variables!(
+        optimization_container,
+        OnVariable,
+        devices,
+        HydroCommitmentReservoirStorage(),
+    )
+    add_variables!(
+        optimization_container,
+        EnergyVariable,
+        devices,
+        HydroCommitmentReservoirStorage(),
+    )
+    add_variables!(
+        optimization_container,
+        SpillageVariable,
+        devices,
+        HydroCommitmentReservoirStorage(),
+    )
 
     # Constraints
     add_constraints!(

--- a/src/devices_models/device_constructors/load_constructor.jl
+++ b/src/devices_models/device_constructors/load_constructor.jl
@@ -95,8 +95,18 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, ActivePowerVariable, devices, InterruptiblePowerLoad())
-    add_variables!(optimization_container, ReactivePowerVariable, devices, InterruptiblePowerLoad())
+    add_variables!(
+        optimization_container,
+        ActivePowerVariable,
+        devices,
+        InterruptiblePowerLoad(),
+    )
+    add_variables!(
+        optimization_container,
+        ReactivePowerVariable,
+        devices,
+        InterruptiblePowerLoad(),
+    )
     add_variables!(optimization_container, OnVariable, devices, InterruptiblePowerLoad())
 
     # Constraints
@@ -139,7 +149,12 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, ActivePowerVariable, devices, InterruptiblePowerLoad())
+    add_variables!(
+        optimization_container,
+        ActivePowerVariable,
+        devices,
+        InterruptiblePowerLoad(),
+    )
     add_variables!(optimization_container, OnVariable, devices, InterruptiblePowerLoad())
 
     # Constraints

--- a/src/devices_models/device_constructors/load_constructor.jl
+++ b/src/devices_models/device_constructors/load_constructor.jl
@@ -95,9 +95,9 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, ActivePowerVariable, devices, D())
-    add_variables!(optimization_container, ReactivePowerVariable, devices, D())
-    add_variables!(optimization_container, OnVariable, devices, D())
+    add_variables!(optimization_container, ActivePowerVariable, devices, InterruptiblePowerLoad())
+    add_variables!(optimization_container, ReactivePowerVariable, devices, InterruptiblePowerLoad())
+    add_variables!(optimization_container, OnVariable, devices, InterruptiblePowerLoad())
 
     # Constraints
     add_constraints!(
@@ -139,8 +139,8 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, ActivePowerVariable, devices, D())
-    add_variables!(optimization_container, OnVariable, devices, D())
+    add_variables!(optimization_container, ActivePowerVariable, devices, InterruptiblePowerLoad())
+    add_variables!(optimization_container, OnVariable, devices, InterruptiblePowerLoad())
 
     # Constraints
     add_constraints!(

--- a/src/devices_models/device_constructors/load_constructor.jl
+++ b/src/devices_models/device_constructors/load_constructor.jl
@@ -15,8 +15,8 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, ActivePowerVariable, devices)
-    add_variables!(optimization_container, ReactivePowerVariable, devices)
+    add_variables!(optimization_container, ActivePowerVariable, devices, D())
+    add_variables!(optimization_container, ReactivePowerVariable, devices, D())
 
     # Constraints
     add_constraints!(
@@ -62,7 +62,7 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, ActivePowerVariable, devices)
+    add_variables!(optimization_container, ActivePowerVariable, devices, D())
 
     # Constraints
     add_constraints!(
@@ -95,9 +95,9 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, ActivePowerVariable, devices)
-    add_variables!(optimization_container, ReactivePowerVariable, devices)
-    add_variables!(optimization_container, OnVariable, devices)
+    add_variables!(optimization_container, ActivePowerVariable, devices, D())
+    add_variables!(optimization_container, ReactivePowerVariable, devices, D())
+    add_variables!(optimization_container, OnVariable, devices, D())
 
     # Constraints
     add_constraints!(
@@ -139,8 +139,8 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, ActivePowerVariable, devices)
-    add_variables!(optimization_container, OnVariable, devices)
+    add_variables!(optimization_container, ActivePowerVariable, devices, D())
+    add_variables!(optimization_container, OnVariable, devices, D())
 
     # Constraints
     add_constraints!(

--- a/src/devices_models/device_constructors/regulationdevice_constructor.jl
+++ b/src/devices_models/device_constructors/regulationdevice_constructor.jl
@@ -18,10 +18,30 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, DeltaActivePowerUpVariable, devices)
-    add_variables!(optimization_container, DeltaActivePowerDownVariable, devices)
-    add_variables!(optimization_container, AdditionalDeltaActivePowerUpVariable, devices)
-    add_variables!(optimization_container, AdditionalDeltaActivePowerDownVariable, devices)
+    add_variables!(
+        optimization_container,
+        DeltaActivePowerUpVariable,
+        devices,
+        DeviceLimitedRegulation(),
+    )
+    add_variables!(
+        optimization_container,
+        DeltaActivePowerDownVariable,
+        devices,
+        DeviceLimitedRegulation(),
+    )
+    add_variables!(
+        optimization_container,
+        AdditionalDeltaActivePowerUpVariable,
+        devices,
+        DeviceLimitedRegulation(),
+    )
+    add_variables!(
+        optimization_container,
+        AdditionalDeltaActivePowerDownVariable,
+        devices,
+        DeviceLimitedRegulation(),
+    )
 
     # Constraints
     nodal_expression!(optimization_container, devices, S)
@@ -69,10 +89,30 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, DeltaActivePowerUpVariable, devices)
-    add_variables!(optimization_container, DeltaActivePowerDownVariable, devices)
-    add_variables!(optimization_container, AdditionalDeltaActivePowerUpVariable, devices)
-    add_variables!(optimization_container, AdditionalDeltaActivePowerDownVariable, devices)
+    add_variables!(
+        optimization_container,
+        DeltaActivePowerUpVariable,
+        devices,
+        ReserveLimitedRegulation(),
+    )
+    add_variables!(
+        optimization_container,
+        DeltaActivePowerDownVariable,
+        devices,
+        ReserveLimitedRegulation(),
+    )
+    add_variables!(
+        optimization_container,
+        AdditionalDeltaActivePowerUpVariable,
+        devices,
+        ReserveLimitedRegulation(),
+    )
+    add_variables!(
+        optimization_container,
+        AdditionalDeltaActivePowerDownVariable,
+        devices,
+        ReserveLimitedRegulation(),
+    )
 
     # Constraints
     nodal_expression!(optimization_container, devices, S)

--- a/src/devices_models/device_constructors/renewablegeneration_constructor.jl
+++ b/src/devices_models/device_constructors/renewablegeneration_constructor.jl
@@ -15,8 +15,8 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, ActivePowerVariable, devices)
-    add_variables!(optimization_container, ReactivePowerVariable, devices)
+    add_variables!(optimization_container, ActivePowerVariable, devices, D())
+    add_variables!(optimization_container, ReactivePowerVariable, devices, D())
 
     # Constraints
     add_constraints!(
@@ -62,7 +62,7 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, ActivePowerVariable, devices)
+    add_variables!(optimization_container, ActivePowerVariable, devices, D())
 
     # Constraints
     add_constraints!(

--- a/src/devices_models/device_constructors/storage_constructor.jl
+++ b/src/devices_models/device_constructors/storage_constructor.jl
@@ -11,13 +11,13 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, ActivePowerInVariable, devices)
-    add_variables!(optimization_container, ActivePowerOutVariable, devices)
-    add_variables!(optimization_container, ReactivePowerVariable, devices)
-    add_variables!(optimization_container, EnergyVariable, devices)
+    add_variables!(optimization_container, ActivePowerInVariable, devices, D())
+    add_variables!(optimization_container, ActivePowerOutVariable, devices, D())
+    add_variables!(optimization_container, ReactivePowerVariable, devices, D())
+    add_variables!(optimization_container, EnergyVariable, devices, D())
 
     # Initial Conditions
-    initial_conditions!(optimization_container, devices, D)
+    initial_conditions!(optimization_container, devices, D())
 
     # Constraints
     add_constraints!(
@@ -85,12 +85,12 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, ActivePowerInVariable, devices)
-    add_variables!(optimization_container, ActivePowerOutVariable, devices)
-    add_variables!(optimization_container, EnergyVariable, devices)
+    add_variables!(optimization_container, ActivePowerInVariable, devices, D())
+    add_variables!(optimization_container, ActivePowerOutVariable, devices, D())
+    add_variables!(optimization_container, EnergyVariable, devices, D())
 
     # Initial Conditions
-    initial_conditions!(optimization_container, devices, D)
+    initial_conditions!(optimization_container, devices, D())
 
     # Constraints
     add_constraints!(
@@ -145,14 +145,39 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, ActivePowerInVariable, devices)
-    add_variables!(optimization_container, ActivePowerOutVariable, devices)
-    add_variables!(optimization_container, ReactivePowerVariable, devices)
-    add_variables!(optimization_container, EnergyVariable, devices)
-    add_variables!(optimization_container, ReserveVariable, devices)
+    add_variables!(
+        optimization_container,
+        ActivePowerInVariable,
+        devices,
+        BookKeepingwReservation(),
+    )
+    add_variables!(
+        optimization_container,
+        ActivePowerOutVariable,
+        devices,
+        BookKeepingwReservation(),
+    )
+    add_variables!(
+        optimization_container,
+        ReactivePowerVariable,
+        devices,
+        BookKeepingwReservation(),
+    )
+    add_variables!(
+        optimization_container,
+        EnergyVariable,
+        devices,
+        BookKeepingwReservation(),
+    )
+    add_variables!(
+        optimization_container,
+        ReserveVariable,
+        devices,
+        BookKeepingwReservation(),
+    )
 
     # Initial Conditions
-    initial_conditions!(optimization_container, devices, model.formulation)
+    initial_conditions!(optimization_container, devices, BookKeepingwReservation())
 
     # Constraints
     add_constraints!(
@@ -216,13 +241,33 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, ActivePowerInVariable, devices)
-    add_variables!(optimization_container, ActivePowerOutVariable, devices)
-    add_variables!(optimization_container, EnergyVariable, devices)
-    add_variables!(optimization_container, ReserveVariable, devices)
+    add_variables!(
+        optimization_container,
+        ActivePowerInVariable,
+        devices,
+        BookKeepingwReservation(),
+    )
+    add_variables!(
+        optimization_container,
+        ActivePowerOutVariable,
+        devices,
+        BookKeepingwReservation(),
+    )
+    add_variables!(
+        optimization_container,
+        EnergyVariable,
+        devices,
+        BookKeepingwReservation(),
+    )
+    add_variables!(
+        optimization_container,
+        ReserveVariable,
+        devices,
+        BookKeepingwReservation(),
+    )
 
     # Initial Conditions
-    initial_conditions!(optimization_container, devices, model.formulation)
+    initial_conditions!(optimization_container, devices, BookKeepingwReservation())
 
     # Constraints
     add_constraints!(
@@ -277,13 +322,33 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, ActivePowerInVariable, devices)
-    add_variables!(optimization_container, ActivePowerOutVariable, devices)
-    add_variables!(optimization_container, ReactivePowerVariable, devices)
-    add_variables!(optimization_container, EnergyVariable, devices)
+    add_variables!(
+        optimization_container,
+        ActivePowerInVariable,
+        devices,
+        EndOfPeriodEnergyTarget(),
+    )
+    add_variables!(
+        optimization_container,
+        ActivePowerOutVariable,
+        devices,
+        EndOfPeriodEnergyTarget(),
+    )
+    add_variables!(
+        optimization_container,
+        ReactivePowerVariable,
+        devices,
+        EndOfPeriodEnergyTarget(),
+    )
+    add_variables!(
+        optimization_container,
+        EnergyVariable,
+        devices,
+        EndOfPeriodEnergyTarget(),
+    )
 
     # Initial Conditions
-    initial_conditions!(optimization_container, devices, model.formulation)
+    initial_conditions!(optimization_container, devices, EndOfPeriodEnergyTarget())
 
     # Constraints
     add_constraints!(
@@ -350,12 +415,27 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, ActivePowerInVariable, devices)
-    add_variables!(optimization_container, ActivePowerOutVariable, devices)
-    add_variables!(optimization_container, EnergyVariable, devices)
+    add_variables!(
+        optimization_container,
+        ActivePowerInVariable,
+        devices,
+        EndOfPeriodEnergyTarget(),
+    )
+    add_variables!(
+        optimization_container,
+        ActivePowerOutVariable,
+        devices,
+        EndOfPeriodEnergyTarget(),
+    )
+    add_variables!(
+        optimization_container,
+        EnergyVariable,
+        devices,
+        EndOfPeriodEnergyTarget(),
+    )
 
     # Initial Conditions
-    initial_conditions!(optimization_container, devices, model.formulation)
+    initial_conditions!(optimization_container, devices, EndOfPeriodEnergyTarget())
 
     # Constraints
     add_constraints!(

--- a/src/devices_models/device_constructors/thermalgeneration_constructor.jl
+++ b/src/devices_models/device_constructors/thermalgeneration_constructor.jl
@@ -243,9 +243,24 @@ function construct_device!(
         devices,
         ThermalBasicUnitCommitment(),
     )
-    add_variables!(optimization_container, OnVariable, devices, ThermalBasicUnitCommitment())
-    add_variables!(optimization_container, StartVariable, devices, ThermalBasicUnitCommitment())
-    add_variables!(optimization_container, StopVariable, devices, ThermalBasicUnitCommitment())
+    add_variables!(
+        optimization_container,
+        OnVariable,
+        devices,
+        ThermalBasicUnitCommitment(),
+    )
+    add_variables!(
+        optimization_container,
+        StartVariable,
+        devices,
+        ThermalBasicUnitCommitment(),
+    )
+    add_variables!(
+        optimization_container,
+        StopVariable,
+        devices,
+        ThermalBasicUnitCommitment(),
+    )
 
     # Initial Conditions
     initial_conditions!(optimization_container, devices, ThermalBasicUnitCommitment())
@@ -862,16 +877,12 @@ function construct_device!(
     return
 end
 
-
 function construct_device!(
     optimization_container::OptimizationContainer,
     sys::PSY.System,
     model::DeviceModel{T, ThermalCompactDispatch},
     ::Type{S},
-) where {
-    T <: PSY.ThermalGen,
-    S <: PM.AbstractPowerModel,
-}
+) where {T <: PSY.ThermalGen, S <: PM.AbstractPowerModel}
     devices = PSY.get_components(T, sys)
 
     if !validate_available_devices(T, devices)
@@ -879,8 +890,18 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, ActivePowerVariable, devices, ThermalCompactDispatch())
-    add_variables!(optimization_container, ReactivePowerVariable, devices, ThermalCompactDispatch())
+    add_variables!(
+        optimization_container,
+        ActivePowerVariable,
+        devices,
+        ThermalCompactDispatch(),
+    )
+    add_variables!(
+        optimization_container,
+        ReactivePowerVariable,
+        devices,
+        ThermalCompactDispatch(),
+    )
 
     # Initial Conditions
     initial_conditions!(optimization_container, devices, ThermalCompactDispatch())
@@ -917,10 +938,7 @@ function construct_device!(
     sys::PSY.System,
     model::DeviceModel{T, ThermalCompactDispatch},
     ::Type{S},
-) where {
-    T <: PSY.ThermalGen,
-    S <: PM.AbstractActivePowerModel,
-}
+) where {T <: PSY.ThermalGen, S <: PM.AbstractActivePowerModel}
     devices = PSY.get_components(T, sys)
 
     if !validate_available_devices(T, devices)
@@ -928,7 +946,12 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, ActivePowerVariable, devices, ThermalCompactDispatch())
+    add_variables!(
+        optimization_container,
+        ActivePowerVariable,
+        devices,
+        ThermalCompactDispatch(),
+    )
 
     # Initial Conditions
     initial_conditions!(optimization_container, devices, ThermalCompactDispatch())

--- a/src/devices_models/device_constructors/thermalgeneration_constructor.jl
+++ b/src/devices_models/device_constructors/thermalgeneration_constructor.jl
@@ -1,3 +1,20 @@
+function construct_device!(
+    optimization_container::OptimizationContainer,
+    sys::PSY.System,
+    ::DeviceModel{T, FixedOutput},
+    ::Type{S},
+) where {T <: PSY.ThermalGen, S <: PM.AbstractActivePowerModel}
+    devices = get_available_components(T, sys)
+
+    if !validate_available_devices(T, devices)
+        return
+    end
+
+    nodal_expression!(optimization_container, devices, S)
+
+    return
+end
+
 """
 This function creates the model for a full thermal dispatch formulation depending on combination of devices, device_formulation and system_formulation
 """
@@ -8,7 +25,7 @@ function construct_device!(
     ::Type{S},
 ) where {
     T <: PSY.ThermalGen,
-    D <: AbstractThermalUnitCommitment,
+    D <: AbstractStandardUnitCommitment,
     S <: PM.AbstractPowerModel,
 }
     devices = get_available_components(T, sys)
@@ -18,14 +35,14 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, ActivePowerVariable, devices)
-    add_variables!(optimization_container, ReactivePowerVariable, devices)
-    add_variables!(optimization_container, OnVariable, devices)
-    add_variables!(optimization_container, StartVariable, devices)
-    add_variables!(optimization_container, StopVariable, devices)
+    add_variables!(optimization_container, ActivePowerVariable, devices, D())
+    add_variables!(optimization_container, ReactivePowerVariable, devices, D())
+    add_variables!(optimization_container, OnVariable, devices, D())
+    add_variables!(optimization_container, StartVariable, devices, D())
+    add_variables!(optimization_container, StopVariable, devices, D())
 
     # Initial Conditions
-    initial_conditions!(optimization_container, devices, D)
+    initial_conditions!(optimization_container, devices, D())
 
     # Constraints
     add_constraints!(
@@ -73,7 +90,7 @@ function construct_device!(
     ::Type{S},
 ) where {
     T <: PSY.ThermalGen,
-    D <: AbstractThermalUnitCommitment,
+    D <: AbstractStandardUnitCommitment,
     S <: PM.AbstractActivePowerModel,
 }
     devices = get_available_components(T, sys)
@@ -83,13 +100,13 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, ActivePowerVariable, devices)
-    add_variables!(optimization_container, OnVariable, devices)
-    add_variables!(optimization_container, StartVariable, devices)
-    add_variables!(optimization_container, StopVariable, devices)
+    add_variables!(optimization_container, ActivePowerVariable, devices, D())
+    add_variables!(optimization_container, OnVariable, devices, D())
+    add_variables!(optimization_container, StartVariable, devices, D())
+    add_variables!(optimization_container, StopVariable, devices, D())
 
     # Initial Conditions
-    initial_conditions!(optimization_container, devices, D)
+    initial_conditions!(optimization_container, devices, D())
 
     # Constraints
     add_constraints!(
@@ -134,14 +151,39 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, ActivePowerVariable, devices)
-    add_variables!(optimization_container, ReactivePowerVariable, devices)
-    add_variables!(optimization_container, OnVariable, devices)
-    add_variables!(optimization_container, StartVariable, devices)
-    add_variables!(optimization_container, StopVariable, devices)
+    add_variables!(
+        optimization_container,
+        ActivePowerVariable,
+        devices,
+        ThermalBasicUnitCommitment(),
+    )
+    add_variables!(
+        optimization_container,
+        ReactivePowerVariable,
+        devices,
+        ThermalBasicUnitCommitment(),
+    )
+    add_variables!(
+        optimization_container,
+        OnVariable,
+        devices,
+        ThermalBasicUnitCommitment(),
+    )
+    add_variables!(
+        optimization_container,
+        StartVariable,
+        devices,
+        ThermalBasicUnitCommitment(),
+    )
+    add_variables!(
+        optimization_container,
+        StopVariable,
+        devices,
+        ThermalBasicUnitCommitment(),
+    )
 
     # Initial Conditions
-    initial_conditions!(optimization_container, devices, model.formulation)
+    initial_conditions!(optimization_container, devices, ThermalBasicUnitCommitment())
 
     # Constraints
     # TODO: active_power_constraints
@@ -195,13 +237,18 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, ActivePowerVariable, devices)
-    add_variables!(optimization_container, OnVariable, devices)
-    add_variables!(optimization_container, StartVariable, devices)
-    add_variables!(optimization_container, StopVariable, devices)
+    add_variables!(
+        optimization_container,
+        ActivePowerVariable,
+        devices,
+        ThermalBasicUnitCommitment(),
+    )
+    add_variables!(optimization_container, OnVariable, devices, ThermalBasicUnitCommitment())
+    add_variables!(optimization_container, StartVariable, devices, ThermalBasicUnitCommitment())
+    add_variables!(optimization_container, StopVariable, devices, ThermalBasicUnitCommitment())
 
     # Initial Conditions
-    initial_conditions!(optimization_container, devices, model.formulation)
+    initial_conditions!(optimization_container, devices, ThermalBasicUnitCommitment())
 
     # Constraints
     add_constraints!(
@@ -244,11 +291,21 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, ActivePowerVariable, devices)
-    add_variables!(optimization_container, ReactivePowerVariable, devices)
+    add_variables!(
+        optimization_container,
+        ActivePowerVariable,
+        devices,
+        ThermalRampLimited(),
+    )
+    add_variables!(
+        optimization_container,
+        ReactivePowerVariable,
+        devices,
+        ThermalRampLimited(),
+    )
 
     # Initial Conditions
-    initial_conditions!(optimization_container, devices, model.formulation)
+    initial_conditions!(optimization_container, devices, ThermalRampLimited())
 
     # Constraints
     add_constraints!(
@@ -294,10 +351,15 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, ActivePowerVariable, devices)
+    add_variables!(
+        optimization_container,
+        ActivePowerVariable,
+        devices,
+        ThermalRampLimited(),
+    )
 
     # Initial Conditions
-    initial_conditions!(optimization_container, devices, model.formulation)
+    initial_conditions!(optimization_container, devices, ThermalRampLimited())
 
     # Constraints
     add_constraints!(
@@ -335,8 +397,8 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, ActivePowerVariable, devices)
-    add_variables!(optimization_container, ReactivePowerVariable, devices)
+    add_variables!(optimization_container, ActivePowerVariable, devices, D())
+    add_variables!(optimization_container, ReactivePowerVariable, devices, D())
 
     # Initial Conditions
 
@@ -384,7 +446,7 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, ActivePowerVariable, devices)
+    add_variables!(optimization_container, ActivePowerVariable, devices, D())
 
     # Initial Conditions
 
@@ -409,23 +471,6 @@ end
 function construct_device!(
     optimization_container::OptimizationContainer,
     sys::PSY.System,
-    model::DeviceModel{T, FixedOutput},
-    ::Type{S},
-) where {T <: PSY.ThermalGen, S <: PM.AbstractActivePowerModel}
-    devices = get_available_components(T, sys)
-
-    if !validate_available_devices(T, devices)
-        return
-    end
-
-    nodal_expression!(optimization_container, devices, S)
-
-    return
-end
-
-function construct_device!(
-    optimization_container::OptimizationContainer,
-    sys::PSY.System,
     model::DeviceModel{PSY.ThermalMultiStart, ThermalMultiStartUnitCommitment},
     ::Type{S};
     kwargs...,
@@ -437,15 +482,51 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, ActivePowerVariable, devices)
-    add_variables!(optimization_container, ReactivePowerVariable, devices)
-    commitment_variables!(optimization_container, devices)
-    add_variables!(optimization_container, ColdStartVariable, devices)
-    add_variables!(optimization_container, WarmStartVariable, devices)
-    add_variables!(optimization_container, HotStartVariable, devices)
+    add_variables!(
+        optimization_container,
+        ActivePowerVariable,
+        devices,
+        ThermalMultiStartUnitCommitment(),
+    )
+    add_variables!(
+        optimization_container,
+        ReactivePowerVariable,
+        devices,
+        ThermalMultiStartUnitCommitment(),
+    )
+    add_variables!(
+        optimization_container,
+        OnVariable,
+        devices,
+        ThermalMultiStartUnitCommitment(),
+    )
+    add_variables!(
+        optimization_container,
+        StopVariable,
+        devices,
+        ThermalMultiStartUnitCommitment(),
+    )
+    add_variables!(
+        optimization_container,
+        ColdStartVariable,
+        devices,
+        ThermalMultiStartUnitCommitment(),
+    )
+    add_variables!(
+        optimization_container,
+        WarmStartVariable,
+        devices,
+        ThermalMultiStartUnitCommitment(),
+    )
+    add_variables!(
+        optimization_container,
+        HotStartVariable,
+        devices,
+        ThermalMultiStartUnitCommitment(),
+    )
 
     # Initial Conditions
-    initial_conditions!(optimization_container, devices, model.formulation)
+    initial_conditions!(optimization_container, devices, ThermalMultiStartUnitCommitment())
 
     # Constraints
     add_constraints!(
@@ -524,14 +605,45 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, ActivePowerVariable, devices)
-    commitment_variables!(optimization_container, devices)
-    add_variables!(optimization_container, ColdStartVariable, devices)
-    add_variables!(optimization_container, WarmStartVariable, devices)
-    add_variables!(optimization_container, HotStartVariable, devices)
+    add_variables!(
+        optimization_container,
+        ActivePowerVariable,
+        devices,
+        ThermalMultiStartUnitCommitment(),
+    )
+    add_variables!(
+        optimization_container,
+        OnVariable,
+        devices,
+        ThermalMultiStartUnitCommitment(),
+    )
+    add_variables!(
+        optimization_container,
+        StopVariable,
+        devices,
+        ThermalMultiStartUnitCommitment(),
+    )
+    add_variables!(
+        optimization_container,
+        ColdStartVariable,
+        devices,
+        ThermalMultiStartUnitCommitment(),
+    )
+    add_variables!(
+        optimization_container,
+        WarmStartVariable,
+        devices,
+        ThermalMultiStartUnitCommitment(),
+    )
+    add_variables!(
+        optimization_container,
+        HotStartVariable,
+        devices,
+        ThermalMultiStartUnitCommitment(),
+    )
 
     # Initial Conditions
-    initial_conditions!(optimization_container, devices, model.formulation)
+    initial_conditions!(optimization_container, devices, ThermalMultiStartUnitCommitment())
 
     # Constraints
     add_constraints!(
@@ -593,110 +705,6 @@ function construct_device!(
     sys::PSY.System,
     model::DeviceModel{T, ThermalCompactUnitCommitment},
     ::Type{S},
-) where {T <: PSY.ThermalMultiStart, S <: PM.AbstractPowerModel}
-    devices = PSY.get_components(T, sys)
-
-    if !validate_available_devices(T, devices)
-        return
-    end
-
-    # Variables
-    add_variables!(optimization_container, ActivePowerVariable, devices)
-    add_variables!(optimization_container, ReactivePowerVariable, devices)
-    commitment_variables!(optimization_container, devices)
-
-    # Initial Conditions
-    initial_conditions!(optimization_container, devices, model.formulation)
-
-    # Constraints
-    add_constraints!(
-        optimization_container,
-        RangeConstraint,
-        ActivePowerVariable,
-        devices,
-        model,
-        S,
-        get_feedforward(model),
-    )
-    add_constraints!(
-        optimization_container,
-        RangeConstraint,
-        ReactivePowerVariable,
-        devices,
-        model,
-        S,
-        get_feedforward(model),
-    )
-    commitment_constraints!(
-        optimization_container,
-        devices,
-        model,
-        S,
-        get_feedforward(model),
-    )
-    ramp_constraints!(optimization_container, devices, model, S, get_feedforward(model))
-    time_constraints!(optimization_container, devices, model, S, get_feedforward(model))
-
-    feedforward!(optimization_container, devices, model, get_feedforward(model))
-    # Cost Function
-    cost_function!(optimization_container, devices, model, S, get_feedforward(model))
-
-    return
-end
-
-function construct_device!(
-    optimization_container::OptimizationContainer,
-    sys::PSY.System,
-    model::DeviceModel{T, ThermalCompactUnitCommitment},
-    ::Type{S},
-) where {T <: PSY.ThermalMultiStart, S <: PM.AbstractActivePowerModel}
-    devices = PSY.get_components(T, sys)
-
-    if !validate_available_devices(T, devices)
-        return
-    end
-
-    # Variables
-    add_variables!(optimization_container, ActivePowerVariable, devices)
-    commitment_variables!(optimization_container, devices)
-
-    # Initial Conditions
-    initial_conditions!(optimization_container, devices, model.formulation)
-
-    # Constraints
-    add_constraints!(
-        optimization_container,
-        RangeConstraint,
-        ActivePowerVariable,
-        devices,
-        model,
-        S,
-        get_feedforward(model),
-    )
-    commitment_constraints!(
-        optimization_container,
-        devices,
-        model,
-        S,
-        get_feedforward(model),
-    )
-    ramp_constraints!(optimization_container, devices, model, S, get_feedforward(model))
-    time_constraints!(optimization_container, devices, model, S, get_feedforward(model))
-
-    feedforward!(optimization_container, devices, model, get_feedforward(model))
-    # Cost Function
-    cost_function!(optimization_container, devices, model, S, get_feedforward(model))
-
-    return
-end
-
-#=
-Currently ThermalStandard and Compact UC formulations are incompatible
-function construct_device!(
-    optimization_container::OptimizationContainer,
-    sys::PSY.System,
-    model::DeviceModel{T, ThermalCompactUnitCommitment},
-    ::Type{S},
 ) where {T <: PSY.ThermalGen, S <: PM.AbstractPowerModel}
     devices = PSY.get_components(T, sys)
 
@@ -705,12 +713,39 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, ActivePowerVariable, devices)
-    add_variables!(optimization_container, ReactivePowerVariable, devices)
-    commitment_variables!(optimization_container, devices)
+    add_variables!(
+        optimization_container,
+        ActivePowerVariable,
+        devices,
+        ThermalCompactUnitCommitment(),
+    )
+    add_variables!(
+        optimization_container,
+        ReactivePowerVariable,
+        devices,
+        ThermalCompactUnitCommitment(),
+    )
+    add_variables!(
+        optimization_container,
+        OnVariable,
+        devices,
+        ThermalCompactUnitCommitment(),
+    )
+    add_variables!(
+        optimization_container,
+        StartVariable,
+        devices,
+        ThermalCompactUnitCommitment(),
+    )
+    add_variables!(
+        optimization_container,
+        StopVariable,
+        devices,
+        ThermalCompactUnitCommitment(),
+    )
 
     # Initial Conditions
-    initial_conditions!(optimization_container, devices, model.formulation)
+    initial_conditions!(optimization_container, devices, ThermalCompactUnitCommitment())
 
     # Constraints
     add_constraints!(
@@ -740,6 +775,7 @@ function construct_device!(
     )
     ramp_constraints!(optimization_container, devices, model, S, get_feedforward(model))
     time_constraints!(optimization_container, devices, model, S, get_feedforward(model))
+
     feedforward!(optimization_container, devices, model, get_feedforward(model))
     # Cost Function
     cost_function!(optimization_container, devices, model, S, get_feedforward(model))
@@ -760,11 +796,33 @@ function construct_device!(
     end
 
     # Variables
-    add_variables!(optimization_container, ActivePowerVariable, devices)
-    commitment_variables!(optimization_container, devices)
+    add_variables!(
+        optimization_container,
+        ActivePowerVariable,
+        devices,
+        ThermalCompactUnitCommitment(),
+    )
+    add_variables!(
+        optimization_container,
+        OnVariable,
+        devices,
+        ThermalCompactUnitCommitment(),
+    )
+    add_variables!(
+        optimization_container,
+        StartVariable,
+        devices,
+        ThermalCompactUnitCommitment(),
+    )
+    add_variables!(
+        optimization_container,
+        StopVariable,
+        devices,
+        ThermalCompactUnitCommitment(),
+    )
 
     # Initial Conditions
-    initial_conditions!(optimization_container, devices, model.formulation)
+    initial_conditions!(optimization_container, devices, ThermalCompactUnitCommitment())
 
     # Constraints
     add_constraints!(
@@ -785,97 +843,6 @@ function construct_device!(
     )
     ramp_constraints!(optimization_container, devices, model, S, get_feedforward(model))
     time_constraints!(optimization_container, devices, model, S, get_feedforward(model))
-    feedforward!(optimization_container, devices, model, get_feedforward(model))
-    # Cost Function
-    cost_function!(optimization_container, devices, model, S, get_feedforward(model))
-
-    return
-end
-=#
-
-function construct_device!(
-    optimization_container::OptimizationContainer,
-    sys::PSY.System,
-    model::DeviceModel{T, D},
-    ::Type{S},
-) where {
-    T <: PSY.ThermalMultiStart,
-    D <: ThermalCompactDispatch,
-    S <: PM.AbstractPowerModel,
-}
-    devices = PSY.get_components(T, sys)
-
-    if !validate_available_devices(T, devices)
-        return
-    end
-
-    # Variables
-    add_variables!(optimization_container, ActivePowerVariable, devices)
-    add_variables!(optimization_container, ReactivePowerVariable, devices)
-
-    # Initial Conditions
-    initial_conditions!(optimization_container, devices, model.formulation)
-
-    # Constraints
-    add_constraints!(
-        optimization_container,
-        RangeConstraint,
-        ActivePowerVariable,
-        devices,
-        model,
-        S,
-        get_feedforward(model),
-    )
-    add_constraints!(
-        optimization_container,
-        RangeConstraint,
-        ReactivePowerVariable,
-        devices,
-        model,
-        S,
-        get_feedforward(model),
-    )
-    ramp_constraints!(optimization_container, devices, model, S, get_feedforward(model))
-    feedforward!(optimization_container, devices, model, get_feedforward(model))
-    # Cost Function
-    cost_function!(optimization_container, devices, model, S, get_feedforward(model))
-
-    return
-end
-
-function construct_device!(
-    optimization_container::OptimizationContainer,
-    sys::PSY.System,
-    model::DeviceModel{T, D},
-    ::Type{S},
-) where {
-    T <: PSY.ThermalMultiStart,
-    D <: ThermalCompactDispatch,
-    S <: PM.AbstractActivePowerModel,
-}
-    devices = PSY.get_components(T, sys)
-
-    if !validate_available_devices(T, devices)
-        return
-    end
-
-    # Variables
-    add_variables!(optimization_container, ActivePowerVariable, devices)
-
-    # Initial Conditions
-    initial_conditions!(optimization_container, devices, model.formulation)
-
-    # Constraints
-    add_constraints!(
-        optimization_container,
-        RangeConstraint,
-        ActivePowerVariable,
-        devices,
-        model,
-        S,
-        get_feedforward(model),
-    )
-    ramp_constraints!(optimization_container, devices, model, S, get_feedforward(model))
     feedforward!(optimization_container, devices, model, get_feedforward(model))
     # Cost Function
     cost_function!(optimization_container, devices, model, S, get_feedforward(model))

--- a/src/devices_models/devices/AC_branches.jl
+++ b/src/devices_models/devices/AC_branches.jl
@@ -27,11 +27,6 @@ struct StaticBranchUnbounded <: AbstractBranchFormulation end
 #################################### Branch Variables ##################################################
 # Because of the way we integrate with PowerModels, most of the time PowerSimulations will create variables
 # for the branch flows either in AC or DC.
-flow_variables!(
-    ::OptimizationContainer,
-    ::Type{<:PM.AbstractPowerModel},
-    ::IS.FlattenIteratorWrapper{<:PSY.ACBranch},
-) = nothing
 
 add_variables!(
     optimization_container::OptimizationContainer,

--- a/src/devices_models/devices/AC_branches.jl
+++ b/src/devices_models/devices/AC_branches.jl
@@ -37,9 +37,10 @@ add_variables!(
     optimization_container::OptimizationContainer,
     ::Type{<:AbstractPTDFModel},
     devices::IS.FlattenIteratorWrapper{<:PSY.ACBranch},
-) = add_variable!(optimization_container, FlowActivePowerVariable(), devices)
+    formulation::AbstractBranchFormulation
+) = add_variable!(optimization_container, FlowActivePowerVariable(), devices, formulation)
 
-get_variable_binary(::FlowActivePowerVariable, ::Type{<:PSY.ACBranch}) = false
+get_variable_binary(::FlowActivePowerVariable, ::Type{<:PSY.ACBranch}, ::AbstractBranchFormulation) = false
 
 #################################### Flow Variable Bounds ##################################################
 function _get_constraint_data(

--- a/src/devices_models/devices/AC_branches.jl
+++ b/src/devices_models/devices/AC_branches.jl
@@ -32,10 +32,14 @@ add_variables!(
     optimization_container::OptimizationContainer,
     ::Type{<:AbstractPTDFModel},
     devices::IS.FlattenIteratorWrapper{<:PSY.ACBranch},
-    formulation::AbstractBranchFormulation
+    formulation::AbstractBranchFormulation,
 ) = add_variable!(optimization_container, FlowActivePowerVariable(), devices, formulation)
 
-get_variable_binary(::FlowActivePowerVariable, ::Type{<:PSY.ACBranch}, ::AbstractBranchFormulation) = false
+get_variable_binary(
+    ::FlowActivePowerVariable,
+    ::Type{<:PSY.ACBranch},
+    ::AbstractBranchFormulation,
+) = false
 
 #################################### Flow Variable Bounds ##################################################
 function _get_constraint_data(

--- a/src/devices_models/devices/DC_branches.jl
+++ b/src/devices_models/devices/DC_branches.jl
@@ -13,8 +13,9 @@ flow_variables!(
 
 function add_variables!(
     optimization_container::OptimizationContainer,
-    ::StandardPTDFModel,
+    ::Type{StandardPTDFModel},
     devices::IS.FlattenIteratorWrapper{B},
+    formulations::AbstractDCLineFormulation
 ) where {B <: PSY.DCBranch}
     time_steps = model_time_steps(optimization_container)
     var_name = make_variable_name(FLOW_ACTIVE_POWER, B)

--- a/src/devices_models/devices/DC_branches.jl
+++ b/src/devices_models/devices/DC_branches.jl
@@ -5,15 +5,16 @@ struct HVDCDispatch <: AbstractDCLineFormulation end
 struct VoltageSourceDC <: AbstractDCLineFormulation end
 
 #################################### Branch Variables ##################################################
-flow_variables!(
-    optimization_container::OptimizationContainer,
+add_variables!(
+    ::OptimizationContainer,
     ::Type{<:PM.AbstractPowerModel},
     devices::IS.FlattenIteratorWrapper{<:PSY.DCBranch},
+    ::AbstractDCLineFormulation
 ) = nothing
 
 function add_variables!(
     optimization_container::OptimizationContainer,
-    ::Type{StandardPTDFModel},
+    ::Type{<: Union{StandardPTDFModel, PTDFPowerModel}},
     devices::IS.FlattenIteratorWrapper{B},
     formulations::AbstractDCLineFormulation
 ) where {B <: PSY.DCBranch}

--- a/src/devices_models/devices/DC_branches.jl
+++ b/src/devices_models/devices/DC_branches.jl
@@ -9,14 +9,14 @@ add_variables!(
     ::OptimizationContainer,
     ::Type{<:PM.AbstractPowerModel},
     devices::IS.FlattenIteratorWrapper{<:PSY.DCBranch},
-    ::AbstractDCLineFormulation
+    ::AbstractDCLineFormulation,
 ) = nothing
 
 function add_variables!(
     optimization_container::OptimizationContainer,
-    ::Type{<: Union{StandardPTDFModel, PTDFPowerModel}},
+    ::Type{<:Union{StandardPTDFModel, PTDFPowerModel}},
     devices::IS.FlattenIteratorWrapper{B},
-    formulations::AbstractDCLineFormulation
+    formulations::AbstractDCLineFormulation,
 ) where {B <: PSY.DCBranch}
     time_steps = model_time_steps(optimization_container)
     var_name = make_variable_name(FLOW_ACTIVE_POWER, B)

--- a/src/devices_models/devices/common/add_variable.jl
+++ b/src/devices_models/devices/common/add_variable.jl
@@ -63,10 +63,10 @@ function add_variable!(
 ) where {U <: Union{Vector{D}, IS.FlattenIteratorWrapper{D}}} where {D <: PSY.Component}
     @assert !isempty(devices)
     time_steps = model_time_steps(optimization_container)
-
+    settings = get_settings(optimization_container)
     var_name = make_variable_name(typeof(variable_type), D)
     binary = get_variable_binary(variable_type, D, formulation)
-    expression_name = get_variable_expression_name(variable_type, D, formulation)
+    expression_name = get_variable_expression_name(variable_type, D)
     sign = get_variable_sign(variable_type, D, formulation)
 
     variable = add_var_container!(
@@ -90,8 +90,10 @@ function add_variable!(
         lb = get_variable_lower_bound(variable_type, d, formulation)
         !(lb === nothing) && !binary && JuMP.set_lower_bound(variable[name, t], lb)
 
-        init = get_variable_initial_value(variable_type, d, formulation)
-        !(init === nothing) && JuMP.set_start_value(variable[name, t], init)
+        if get_warm_start(settings)
+            init = get_variable_initial_value(variable_type, d, formulation)
+            !(init === nothing) && JuMP.set_start_value(variable[name, t], init)
+        end
 
         if !((expression_name === nothing))
             bus_number = PSY.get_number(PSY.get_bus(d))

--- a/src/devices_models/devices/common/add_variable.jl
+++ b/src/devices_models/devices/common/add_variable.jl
@@ -5,7 +5,7 @@ function add_variables!(
     optimization_container::OptimizationContainer,
     ::Type{T},
     devices::Union{Vector{U}, IS.FlattenIteratorWrapper{U}},
-    formulation::AbstractDeviceFormulation,
+    formulation::Union{AbstractDeviceFormulation, AbstractServiceFormulation}
 ) where {T <: VariableType, U <: PSY.Component}
     add_variable!(optimization_container, T(), devices, formulation)
 end
@@ -18,8 +18,9 @@ function add_variables!(
     ::Type{T},
     service::U,
     devices::Vector{V},
+    formulation::AbstractReservesFormulation
 ) where {T <: VariableType, U <: PSY.Reserve, V <: PSY.Device}
-    add_variable!(optimization_container, T(), devices, service)
+    add_variable!(optimization_container, T(), devices, service, formulation)
 end
 
 @doc raw"""
@@ -115,15 +116,16 @@ function add_variable!(
     optimization_container::OptimizationContainer,
     variable_type::VariableType,
     devices::U,
-    service::PSY.Reserve,
-) where {U <: Union{Vector{D}, IS.FlattenIteratorWrapper{D}}} where {D <: PSY.Component}
+    service::T,
+    formulation::AbstractReservesFormulation
+) where {T<: PSY.Service, U <: Union{Vector{D}, IS.FlattenIteratorWrapper{D}}} where {D <: PSY.Component}
     @assert !isempty(devices)
     time_steps = model_time_steps(optimization_container)
 
-    var_name = make_variable_name(PSY.get_name(service), typeof(service))
-    binary = get_variable_binary(variable_type, typeof(service))
-    expression_name = get_variable_expression_name(variable_type, typeof(service))
-    sign = get_variable_sign(variable_type, typeof(service))
+    var_name = make_variable_name(PSY.get_name(service), T)
+    binary = get_variable_binary(variable_type, T, formulation)
+    expression_name = get_variable_expression_name(variable_type, T)
+    sign = get_variable_sign(variable_type, T, formulation)
 
     variable = add_var_container!(
         optimization_container,
@@ -166,7 +168,7 @@ function add_variable!(
                 bus_number,
                 t,
                 variable[name, t],
-                get_variable_sign(variable_type, eltype(devices)),
+                get_variable_sign(variable_type, eltype(devices), formulation),
             )
         end
     end

--- a/src/devices_models/devices/common/add_variable.jl
+++ b/src/devices_models/devices/common/add_variable.jl
@@ -5,7 +5,7 @@ function add_variables!(
     optimization_container::OptimizationContainer,
     ::Type{T},
     devices::Union{Vector{U}, IS.FlattenIteratorWrapper{U}},
-    formulation::Union{AbstractDeviceFormulation, AbstractServiceFormulation}
+    formulation::Union{AbstractDeviceFormulation, AbstractServiceFormulation},
 ) where {T <: VariableType, U <: PSY.Component}
     add_variable!(optimization_container, T(), devices, formulation)
 end
@@ -18,7 +18,7 @@ function add_variables!(
     ::Type{T},
     service::U,
     devices::Vector{V},
-    formulation::AbstractReservesFormulation
+    formulation::AbstractReservesFormulation,
 ) where {T <: VariableType, U <: PSY.Reserve, V <: PSY.Device}
     add_variable!(optimization_container, T(), devices, service, formulation)
 end
@@ -117,8 +117,11 @@ function add_variable!(
     variable_type::VariableType,
     devices::U,
     service::T,
-    formulation::AbstractReservesFormulation
-) where {T<: PSY.Service, U <: Union{Vector{D}, IS.FlattenIteratorWrapper{D}}} where {D <: PSY.Component}
+    formulation::AbstractReservesFormulation,
+) where {
+    T <: PSY.Service,
+    U <: Union{Vector{D}, IS.FlattenIteratorWrapper{D}},
+} where {D <: PSY.Component}
     @assert !isempty(devices)
     time_steps = model_time_steps(optimization_container)
 

--- a/src/devices_models/devices/common/cost_functions.jl
+++ b/src/devices_models/devices/common/cost_functions.jl
@@ -488,7 +488,16 @@ function add_to_cost!(
     end
 
     # Original implementation had SOS by default, here it detects if that's needed
-    variable_cost_data = spec.variable_cost(cost_data)
+    if spec.uses_compact_power
+        variable_cost_data = spec.variable_cost(cost_data)
+    else
+       min_gen_cost = spec.fixed_cost(cost_data)
+       min_gen = PSY.get_active_power_limits(component).min
+       variable_cost_data_ = PSY.get_variable(spec.variable_cost(cost_data))
+       variable_cost_data_ = [(v[1] + min_gen_cost, v[2] + min_gen) for v in variable_cost_data_]
+       variable_cost_data = PSY.VariableCost(variable_cost_data_)
+    end
+
     for t in time_steps
         variable_cost!(optimization_container, spec, component_name, variable_cost_data, t)
     end

--- a/src/devices_models/devices/common/cost_functions.jl
+++ b/src/devices_models/devices/common/cost_functions.jl
@@ -11,6 +11,7 @@ struct AddCostSpec
     fixed_cost::Union{Nothing, Function}
     has_multistart_variables::Bool
     addtional_linear_terms::Dict{String, Symbol}
+    uses_compact_power::Bool
 end
 
 function AddCostSpec(;
@@ -26,6 +27,7 @@ function AddCostSpec(;
     fixed_cost = nothing,
     has_multistart_variables = false,
     addtional_linear_terms = Dict{String, Symbol}(),
+    uses_compact_power = false
 )
     return AddCostSpec(
         variable_type,
@@ -40,6 +42,7 @@ function AddCostSpec(;
         fixed_cost,
         has_multistart_variables,
         addtional_linear_terms,
+        uses_compact_power
     )
 end
 

--- a/src/devices_models/devices/common/cost_functions.jl
+++ b/src/devices_models/devices/common/cost_functions.jl
@@ -493,7 +493,7 @@ function add_to_cost!(
     else
         min_gen_cost = spec.fixed_cost(cost_data)
         min_gen = PSY.get_active_power_limits(component).min
-        variable_cost_data_ = PSY.get_variable(spec.variable_cost(cost_data))
+        variable_cost_data_ = PSY.get_cost(spec.variable_cost(cost_data))
         variable_cost_data_ =
             [(v[1] + min_gen_cost, v[2] + min_gen) for v in variable_cost_data_]
         variable_cost_data = PSY.VariableCost(variable_cost_data_)

--- a/src/devices_models/devices/common/cost_functions.jl
+++ b/src/devices_models/devices/common/cost_functions.jl
@@ -27,7 +27,7 @@ function AddCostSpec(;
     fixed_cost = nothing,
     has_multistart_variables = false,
     addtional_linear_terms = Dict{String, Symbol}(),
-    uses_compact_power = false
+    uses_compact_power = false,
 )
     return AddCostSpec(
         variable_type,
@@ -42,7 +42,7 @@ function AddCostSpec(;
         fixed_cost,
         has_multistart_variables,
         addtional_linear_terms,
-        uses_compact_power
+        uses_compact_power,
     )
 end
 
@@ -491,11 +491,12 @@ function add_to_cost!(
     if spec.uses_compact_power
         variable_cost_data = spec.variable_cost(cost_data)
     else
-       min_gen_cost = spec.fixed_cost(cost_data)
-       min_gen = PSY.get_active_power_limits(component).min
-       variable_cost_data_ = PSY.get_variable(spec.variable_cost(cost_data))
-       variable_cost_data_ = [(v[1] + min_gen_cost, v[2] + min_gen) for v in variable_cost_data_]
-       variable_cost_data = PSY.VariableCost(variable_cost_data_)
+        min_gen_cost = spec.fixed_cost(cost_data)
+        min_gen = PSY.get_active_power_limits(component).min
+        variable_cost_data_ = PSY.get_variable(spec.variable_cost(cost_data))
+        variable_cost_data_ =
+            [(v[1] + min_gen_cost, v[2] + min_gen) for v in variable_cost_data_]
+        variable_cost_data = PSY.VariableCost(variable_cost_data_)
     end
 
     for t in time_steps

--- a/src/devices_models/devices/electric_loads.jl
+++ b/src/devices_models/devices/electric_loads.jl
@@ -14,7 +14,7 @@ get_variable_sign(_, ::Type{<:PSY.ElectricLoad}, ::AbstractLoadFormulation) = -1
 
 get_variable_binary(::ActivePowerVariable, ::Type{<:PSY.ElectricLoad}, ::AbstractLoadFormulation) = false
 
-get_variable_expression_name(::ActivePowerVariable, ::Type{<:PSY.ElectricLoad}, ::Type{<:PM.AbstractPowerModel}) = :nodal_balance_active
+get_variable_expression_name(::ActivePowerVariable, ::Type{<:PSY.ElectricLoad}) = :nodal_balance_active
 
 get_variable_lower_bound(::ActivePowerVariable, d::PSY.ElectricLoad, ::AbstractLoadFormulation) = 0.0
 get_variable_upper_bound(::ActivePowerVariable, d::PSY.ElectricLoad, ::AbstractLoadFormulation) = PSY.get_active_power(d)
@@ -23,7 +23,7 @@ get_variable_upper_bound(::ActivePowerVariable, d::PSY.ElectricLoad, ::AbstractL
 
 get_variable_binary(::ReactivePowerVariable, ::Type{<:PSY.ElectricLoad}, ::AbstractLoadFormulation) = false
 
-get_variable_expression_name(::ReactivePowerVariable, ::Type{<:PSY.ElectricLoad}, ::Type{<:PM.AbstractPowerModel}) = :nodal_balance_reactive
+get_variable_expression_name(::ReactivePowerVariable, ::Type{<:PSY.ElectricLoad}) = :nodal_balance_reactive
 
 get_variable_lower_bound(::ReactivePowerVariable, d::PSY.ElectricLoad, ::AbstractLoadFormulation) = 0.0
 get_variable_upper_bound(::ReactivePowerVariable, d::PSY.ElectricLoad, ::AbstractLoadFormulation) = PSY.get_reactive_power(d)

--- a/src/devices_models/devices/electric_loads.jl
+++ b/src/devices_models/devices/electric_loads.jl
@@ -8,29 +8,29 @@ struct DispatchablePowerLoad <: AbstractControllablePowerLoadFormulation end
 
 ########################### ElectricLoad ####################################
 
-get_variable_sign(_, ::Type{<:PSY.ElectricLoad}) = -1.0
+get_variable_sign(_, ::Type{<:PSY.ElectricLoad}, ::AbstractLoadFormulation) = -1.0
 
 ########################### ActivePowerVariable, ElectricLoad ####################################
 
-get_variable_binary(::ActivePowerVariable, ::Type{<:PSY.ElectricLoad}) = false
+get_variable_binary(::ActivePowerVariable, ::Type{<:PSY.ElectricLoad}, ::AbstractLoadFormulation) = false
 
-get_variable_expression_name(::ActivePowerVariable, ::Type{<:PSY.ElectricLoad}) = :nodal_balance_active
+get_variable_expression_name(::ActivePowerVariable, ::Type{<:PSY.ElectricLoad}, ::Type{<:PM.AbstractPowerModel}) = :nodal_balance_active
 
-get_variable_lower_bound(::ActivePowerVariable, d::PSY.ElectricLoad, _) = 0.0
-get_variable_upper_bound(::ActivePowerVariable, d::PSY.ElectricLoad, _) = PSY.get_active_power(d)
-
-########################### ReactivePowerVariable, ElectricLoad ####################################
-
-get_variable_binary(::ReactivePowerVariable, ::Type{<:PSY.ElectricLoad}) = false
-
-get_variable_expression_name(::ReactivePowerVariable, ::Type{<:PSY.ElectricLoad}) = :nodal_balance_reactive
-
-get_variable_lower_bound(::ReactivePowerVariable, d::PSY.ElectricLoad, _) = 0.0
-get_variable_upper_bound(::ReactivePowerVariable, d::PSY.ElectricLoad, _) = PSY.get_reactive_power(d)
+get_variable_lower_bound(::ActivePowerVariable, d::PSY.ElectricLoad, ::AbstractLoadFormulation) = 0.0
+get_variable_upper_bound(::ActivePowerVariable, d::PSY.ElectricLoad, ::AbstractLoadFormulation) = PSY.get_active_power(d)
 
 ########################### ReactivePowerVariable, ElectricLoad ####################################
 
-get_variable_binary(::OnVariable, ::Type{<:PSY.ElectricLoad}) = true
+get_variable_binary(::ReactivePowerVariable, ::Type{<:PSY.ElectricLoad}, ::AbstractLoadFormulation) = false
+
+get_variable_expression_name(::ReactivePowerVariable, ::Type{<:PSY.ElectricLoad}, ::Type{<:PM.AbstractPowerModel}) = :nodal_balance_reactive
+
+get_variable_lower_bound(::ReactivePowerVariable, d::PSY.ElectricLoad, ::AbstractLoadFormulation) = 0.0
+get_variable_upper_bound(::ReactivePowerVariable, d::PSY.ElectricLoad, ::AbstractLoadFormulation) = PSY.get_reactive_power(d)
+
+########################### ReactivePowerVariable, ElectricLoad ####################################
+
+get_variable_binary(::OnVariable, ::Type{<:PSY.ElectricLoad}, ::AbstractLoadFormulation) = true
 
 #! format: on
 

--- a/src/devices_models/devices/hydro_generation.jl
+++ b/src/devices_models/devices/hydro_generation.jl
@@ -14,39 +14,29 @@ struct HydroCommitmentReservoirBudget <: AbstractHydroUnitCommitment end
 struct HydroCommitmentReservoirStorage <: AbstractHydroUnitCommitment end
 
 ########################### ActivePowerVariable, HydroGen #################################
+get_variable_binary(::ActivePowerVariable, ::Type{<:PSY.HydroGen}, ::AbstractHydroFormulation) = false
+get_variable_expression_name(::ActivePowerVariable, ::Type{<:PSY.HydroGen}, ::Type{<:PM.AbstractPowerModel}) = :nodal_balance_active
 
-get_variable_binary(::ActivePowerVariable, ::Type{<:PSY.HydroGen}) = false
-get_variable_expression_name(::ActivePowerVariable, ::Type{<:PSY.HydroGen}) = :nodal_balance_active
+get_variable_initial_value(::ActivePowerVariable, d::PSY.HydroGen, ::AbstractHydroFormulation) = PSY.get_active_power(d)
 
-get_variable_initial_value(pv::ActivePowerVariable, d::PSY.HydroGen, settings) = get_variable_initial_value(pv, d, WarmStartVariable())
-get_variable_initial_value(::ActivePowerVariable, d::PSY.HydroGen, ::WarmStartVariable) = PSY.get_active_power(d)
-
-get_variable_lower_bound(::ActivePowerVariable, d::PSY.HydroGen, _) = PSY.get_active_power_limits(d).min
-get_variable_upper_bound(::ActivePowerVariable, d::PSY.HydroGen, _) = PSY.get_active_power_limits(d).max
+get_variable_lower_bound(::ActivePowerVariable, d::PSY.HydroGen, ::AbstractHydroFormulation) = PSY.get_active_power_limits(d).min
+get_variable_upper_bound(::ActivePowerVariable, d::PSY.HydroGen, ::AbstractHydroFormulation) = PSY.get_active_power_limits(d).max
 
 ############## ActivePowerVariable, HydroDispatchRunOfRiver ####################
-
 get_variable_lower_bound(::ActivePowerVariable, d::PSY.HydroGen, ::HydroDispatchRunOfRiver) = 0.0
 
 ############## ReactivePowerVariable, HydroGen ####################
-
-get_variable_binary(::ReactivePowerVariable, ::Type{<:PSY.HydroGen}) = false
-
-get_variable_expression_name(::ReactivePowerVariable, ::Type{<:PSY.HydroGen}) = :nodal_balance_reactive
-
-get_variable_initial_value(pv::ReactivePowerVariable, d::PSY.HydroGen, settings) =
-get_variable_initial_value(pv, d, WarmStartVariable())
-get_variable_initial_value(::ReactivePowerVariable, d::PSY.HydroGen, ::WarmStartVariable) = PSY.get_active_power(d)
-
-get_variable_lower_bound(::ReactivePowerVariable, d::PSY.HydroGen, _) = PSY.get_active_power_limits(d).min
-get_variable_upper_bound(::ReactivePowerVariable, d::PSY.HydroGen, _) = PSY.get_active_power_limits(d).max
+get_variable_binary(::ReactivePowerVariable, ::Type{<:PSY.HydroGen}, ::AbstractHydroFormulation) = false
+get_variable_expression_name(::ReactivePowerVariable, ::Type{<:PSY.HydroGen}, ::Type{<:PM.AbstractPowerModel}) = :nodal_balance_reactive
+get_variable_initial_value(::ReactivePowerVariable, d::PSY.HydroGen, ::AbstractHydroFormulation) = PSY.get_active_power(d)
+get_variable_lower_bound(::ReactivePowerVariable, d::PSY.HydroGen, ::AbstractHydroFormulation) = PSY.get_active_power_limits(d).min
+get_variable_upper_bound(::ReactivePowerVariable, d::PSY.HydroGen, ::AbstractHydroFormulation) = PSY.get_active_power_limits(d).max
 
 ############## EnergyVariable, HydroGen ####################
-
-get_variable_binary(::EnergyVariable, ::Type{<:PSY.HydroGen}) = false
-get_variable_initial_value(pv::EnergyVariable, d::PSY.HydroGen, settings) = PSY.get_initial_storage(d)
-get_variable_lower_bound(::EnergyVariable, d::PSY.HydroGen, _) = 0.0
-get_variable_upper_bound(::EnergyVariable, d::PSY.HydroGen, _) = PSY.get_storage_capacity(d)
+get_variable_binary(::EnergyVariable, ::Type{<:PSY.HydroGen}, ::AbstractHydroFormulation) = false
+get_variable_initial_value(pv::EnergyVariable, d::PSY.HydroGen, ::AbstractHydroFormulation) = PSY.get_initial_storage(d)
+get_variable_lower_bound(::EnergyVariable, d::PSY.HydroGen, ::AbstractHydroFormulation) = 0.0
+get_variable_upper_bound(::EnergyVariable, d::PSY.HydroGen, ::AbstractHydroFormulation) = PSY.get_storage_capacity(d)
 
 ########################### EnergyVariableUp, HydroGen #################################
 
@@ -59,47 +49,45 @@ get_variable_upper_bound(::EnergyVariableUp, d::PSY.HydroGen, _) = PSY.get_stora
 
 ########################### EnergyVariableDown, HydroGen #################################
 
-get_variable_binary(::EnergyVariableDown, ::Type{<:PSY.HydroGen}) = false
+get_variable_binary(::EnergyVariableDown, ::Type{<:PSY.HydroGen}, ::AbstractHydroFormulation) = false
 
-get_variable_initial_value(pv::EnergyVariableDown, d::PSY.HydroGen, settings) = PSY.get_initial_storage(d).down
+get_variable_initial_value(::EnergyVariableDown, d::PSY.HydroGen, ::AbstractHydroFormulation) = PSY.get_initial_storage(d).down
 
-get_variable_lower_bound(::EnergyVariableDown, d::PSY.HydroGen, _) = 0.0
-get_variable_upper_bound(::EnergyVariableDown, d::PSY.HydroGen, _) = PSY.get_storage_capacity(d).down
+get_variable_lower_bound(::EnergyVariableDown, d::PSY.HydroGen, ::AbstractHydroFormulation) = 0.0
+get_variable_upper_bound(::EnergyVariableDown, d::PSY.HydroGen, ::AbstractHydroFormulation) = PSY.get_storage_capacity(d).down
 
 ########################### ActivePowerInVariable, HydroGen #################################
 
-get_variable_binary(::ActivePowerInVariable, ::Type{<:PSY.HydroGen}) = false
-get_variable_expression_name(::ActivePowerInVariable, ::Type{<:PSY.HydroGen}) = :nodal_balance_active
+get_variable_binary(::ActivePowerInVariable, ::Type{<:PSY.HydroGen}, ::AbstractHydroFormulation) = false
+get_variable_expression_name(::ActivePowerInVariable, ::Type{<:PSY.HydroGen}, ::Type{<:PM.AbstractPowerModel}) = :nodal_balance_active
 
-get_variable_lower_bound(::ActivePowerInVariable, d::PSY.HydroGen, _) = 0.0
-get_variable_upper_bound(::ActivePowerInVariable, d::PSY.HydroGen, _) = nothing
-get_variable_sign(::ActivePowerInVariable, d::Type{<:PSY.HydroGen}) = -1.0
+get_variable_lower_bound(::ActivePowerInVariable, d::PSY.HydroGen, ::AbstractHydroFormulation) = 0.0
+get_variable_upper_bound(::ActivePowerInVariable, d::PSY.HydroGen, ::AbstractHydroFormulation) = nothing
+get_variable_sign(::ActivePowerInVariable, d::Type{<:PSY.HydroGen}, ::AbstractHydroFormulation) = -1.0
 
 ########################### ActivePowerOutVariable, HydroGen #################################
 
-get_variable_binary(::ActivePowerOutVariable, ::Type{<:PSY.HydroGen}) = false
-get_variable_expression_name(::ActivePowerOutVariable, ::Type{<:PSY.HydroGen}) = :nodal_balance_active
+get_variable_binary(::ActivePowerOutVariable, ::Type{<:PSY.HydroGen}, ::AbstractHydroFormulation) = false
+get_variable_expression_name(::ActivePowerOutVariable, ::Type{<:PSY.HydroGen}, ::Type{<:PM.AbstractPowerModel}) = :nodal_balance_active
 
-get_variable_lower_bound(::ActivePowerOutVariable, d::PSY.HydroGen, _) = 0.0
-get_variable_upper_bound(::ActivePowerOutVariable, d::PSY.HydroGen, _) = nothing
-get_variable_sign(::ActivePowerOutVariable, d::Type{<:PSY.HydroGen}) = 1.0
+get_variable_lower_bound(::ActivePowerOutVariable, d::PSY.HydroGen, ::AbstractHydroFormulation) = 0.0
+get_variable_upper_bound(::ActivePowerOutVariable, d::PSY.HydroGen, ::AbstractHydroFormulation) = nothing
+get_variable_sign(::ActivePowerOutVariable, d::Type{<:PSY.HydroGen}, ::AbstractHydroFormulation) = 1.0
 
 ############## OnVariable, HydroGen ####################
 
-get_variable_binary(::OnVariable, ::Type{<:PSY.HydroGen}) = true
-
-get_variable_initial_value(pv::OnVariable, d::PSY.HydroGen, settings) = get_variable_initial_value(pv, d, WarmStartVariable())
-get_variable_initial_value(::OnVariable, d::PSY.HydroGen, ::WarmStartVariable) = PSY.get_active_power(d) > 0 ? 1.0 : 0.0
+get_variable_binary(::OnVariable, ::Type{<:PSY.HydroGen}, ::AbstractHydroFormulation) = true
+get_variable_initial_value(::OnVariable, d::PSY.HydroGen, ::AbstractHydroFormulation) = PSY.get_active_power(d) > 0 ? 1.0 : 0.0
 
 ############## SpillageVariable, HydroGen ####################
 
-get_variable_binary(::SpillageVariable, ::Type{<:PSY.HydroGen}) = false
-get_variable_lower_bound(::SpillageVariable, d::PSY.HydroGen, _) = 0.0
+get_variable_binary(::SpillageVariable, ::Type{<:PSY.HydroGen}, ::AbstractHydroFormulation) = false
+get_variable_lower_bound(::SpillageVariable, d::PSY.HydroGen, ::AbstractHydroFormulation) = 0.0
 
 ############## ReserveVariable, HydroGen ####################
 
-get_variable_binary(::ReserveVariable, ::Type{<:PSY.HydroGen}) = true
-get_variable_binary(::ReserveVariable, ::Type{<:PSY.HydroPumpedStorage}) = true
+get_variable_binary(::ReserveVariable, ::Type{<:PSY.HydroGen}, ::AbstractHydroFormulation) = true
+get_variable_binary(::ReserveVariable, ::Type{<:PSY.HydroPumpedStorage}, ::AbstractHydroFormulation) = true
 
 #! format: on
 
@@ -580,7 +568,7 @@ end
 function initial_conditions!(
     optimization_container::OptimizationContainer,
     devices::IS.FlattenIteratorWrapper{H},
-    device_formulation::Type{<:AbstractHydroUnitCommitment},
+    device_formulation::AbstractHydroUnitCommitment,
 ) where {H <: PSY.HydroGen}
     status_init(optimization_container, devices)
     output_init(optimization_container, devices)
@@ -592,8 +580,8 @@ end
 function initial_conditions!(
     optimization_container::OptimizationContainer,
     devices::IS.FlattenIteratorWrapper{H},
-    device_formulation::Type{D},
-) where {H <: PSY.HydroGen, D <: AbstractHydroDispatchFormulation}
+    device_formulation::AbstractHydroDispatchFormulation,
+) where {H <: PSY.HydroGen}
     output_init(optimization_container, devices)
 
     return

--- a/src/devices_models/devices/hydro_generation.jl
+++ b/src/devices_models/devices/hydro_generation.jl
@@ -15,7 +15,7 @@ struct HydroCommitmentReservoirStorage <: AbstractHydroUnitCommitment end
 
 ########################### ActivePowerVariable, HydroGen #################################
 get_variable_binary(::ActivePowerVariable, ::Type{<:PSY.HydroGen}, ::AbstractHydroFormulation) = false
-get_variable_expression_name(::ActivePowerVariable, ::Type{<:PSY.HydroGen}, ::Type{<:PM.AbstractPowerModel}) = :nodal_balance_active
+get_variable_expression_name(::ActivePowerVariable, ::Type{<:PSY.HydroGen}) = :nodal_balance_active
 
 get_variable_initial_value(::ActivePowerVariable, d::PSY.HydroGen, ::AbstractHydroFormulation) = PSY.get_active_power(d)
 
@@ -27,7 +27,7 @@ get_variable_lower_bound(::ActivePowerVariable, d::PSY.HydroGen, ::HydroDispatch
 
 ############## ReactivePowerVariable, HydroGen ####################
 get_variable_binary(::ReactivePowerVariable, ::Type{<:PSY.HydroGen}, ::AbstractHydroFormulation) = false
-get_variable_expression_name(::ReactivePowerVariable, ::Type{<:PSY.HydroGen}, ::Type{<:PM.AbstractPowerModel}) = :nodal_balance_reactive
+get_variable_expression_name(::ReactivePowerVariable, ::Type{<:PSY.HydroGen}) = :nodal_balance_reactive
 get_variable_initial_value(::ReactivePowerVariable, d::PSY.HydroGen, ::AbstractHydroFormulation) = PSY.get_active_power(d)
 get_variable_lower_bound(::ReactivePowerVariable, d::PSY.HydroGen, ::AbstractHydroFormulation) = PSY.get_active_power_limits(d).min
 get_variable_upper_bound(::ReactivePowerVariable, d::PSY.HydroGen, ::AbstractHydroFormulation) = PSY.get_active_power_limits(d).max
@@ -40,12 +40,12 @@ get_variable_upper_bound(::EnergyVariable, d::PSY.HydroGen, ::AbstractHydroFormu
 
 ########################### EnergyVariableUp, HydroGen #################################
 
-get_variable_binary(::EnergyVariableUp, ::Type{<:PSY.HydroGen}) = false
+get_variable_binary(::EnergyVariableUp, ::Type{<:PSY.HydroGen}, ::AbstractHydroFormulation) = false
 
-get_variable_initial_value(pv::EnergyVariableUp, d::PSY.HydroGen, settings) = PSY.get_initial_storage(d).up
+get_variable_initial_value(pv::EnergyVariableUp, d::PSY.HydroGen, ::AbstractHydroFormulation) = PSY.get_initial_storage(d).up
 
-get_variable_lower_bound(::EnergyVariableUp, d::PSY.HydroGen, _) = 0.0
-get_variable_upper_bound(::EnergyVariableUp, d::PSY.HydroGen, _) = PSY.get_storage_capacity(d).up
+get_variable_lower_bound(::EnergyVariableUp, d::PSY.HydroGen, ::AbstractHydroFormulation) = 0.0
+get_variable_upper_bound(::EnergyVariableUp, d::PSY.HydroGen, ::AbstractHydroFormulation) = PSY.get_storage_capacity(d).up
 
 ########################### EnergyVariableDown, HydroGen #################################
 
@@ -59,7 +59,7 @@ get_variable_upper_bound(::EnergyVariableDown, d::PSY.HydroGen, ::AbstractHydroF
 ########################### ActivePowerInVariable, HydroGen #################################
 
 get_variable_binary(::ActivePowerInVariable, ::Type{<:PSY.HydroGen}, ::AbstractHydroFormulation) = false
-get_variable_expression_name(::ActivePowerInVariable, ::Type{<:PSY.HydroGen}, ::Type{<:PM.AbstractPowerModel}) = :nodal_balance_active
+get_variable_expression_name(::ActivePowerInVariable, ::Type{<:PSY.HydroGen}) = :nodal_balance_active
 
 get_variable_lower_bound(::ActivePowerInVariable, d::PSY.HydroGen, ::AbstractHydroFormulation) = 0.0
 get_variable_upper_bound(::ActivePowerInVariable, d::PSY.HydroGen, ::AbstractHydroFormulation) = nothing
@@ -68,7 +68,7 @@ get_variable_sign(::ActivePowerInVariable, d::Type{<:PSY.HydroGen}, ::AbstractHy
 ########################### ActivePowerOutVariable, HydroGen #################################
 
 get_variable_binary(::ActivePowerOutVariable, ::Type{<:PSY.HydroGen}, ::AbstractHydroFormulation) = false
-get_variable_expression_name(::ActivePowerOutVariable, ::Type{<:PSY.HydroGen}, ::Type{<:PM.AbstractPowerModel}) = :nodal_balance_active
+get_variable_expression_name(::ActivePowerOutVariable, ::Type{<:PSY.HydroGen}) = :nodal_balance_active
 
 get_variable_lower_bound(::ActivePowerOutVariable, d::PSY.HydroGen, ::AbstractHydroFormulation) = 0.0
 get_variable_upper_bound(::ActivePowerOutVariable, d::PSY.HydroGen, ::AbstractHydroFormulation) = nothing

--- a/src/devices_models/devices/interfaces.jl
+++ b/src/devices_models/devices/interfaces.jl
@@ -1,11 +1,11 @@
 ########################### Interfaces ########################################################
 
 get_variable_name(variabletype, d) = error("Not Implemented")
-get_variable_binary(pv, d::PSY.Component) = get_variable_binary(pv, typeof(d))
-get_variable_binary(pv, t::Type{<:PSY.Component}) =
+get_variable_binary(pv, d::PSY.Component, _) = get_variable_binary(pv, typeof(d))
+get_variable_binary(pv, t::Type{<:PSY.Component}, _) =
     error("`get_variable_binary` must be implemented for $pv and $t")
-get_variable_expression_name(_, ::Type{<:PSY.Component}) = nothing
-get_variable_sign(_, ::Type{<:PSY.Component}) = 1.0
-get_variable_initial_value(_, d::PSY.Component, _) = nothing
-get_variable_lower_bound(_, d::PSY.Component, _) = nothing
-get_variable_upper_bound(_, d::PSY.Component, _) = nothing
+get_variable_expression_name(_, ::Type{<:PSY.Component}, _) = nothing
+get_variable_sign(_, ::Type{<:PSY.Component}, _) = 1.0
+get_variable_initial_value(_, d::PSY.Component, __) = nothing
+get_variable_lower_bound(_, d::PSY.Component, __) = nothing
+get_variable_upper_bound(_, d::PSY.Component, __) = nothing

--- a/src/devices_models/devices/interfaces.jl
+++ b/src/devices_models/devices/interfaces.jl
@@ -4,7 +4,7 @@ get_variable_name(variabletype, d) = error("Not Implemented")
 get_variable_binary(pv, d::PSY.Component, _) = get_variable_binary(pv, typeof(d))
 get_variable_binary(pv, t::Type{<:PSY.Component}, _) =
     error("`get_variable_binary` must be implemented for $pv and $t")
-get_variable_expression_name(_, ::Type{<:PSY.Component}, _) = nothing
+get_variable_expression_name(_, ::Type{<:PSY.Component}) = nothing
 get_variable_sign(_, ::Type{<:PSY.Component}, _) = 1.0
 get_variable_initial_value(_, d::PSY.Component, __) = nothing
 get_variable_lower_bound(_, d::PSY.Component, __) = nothing

--- a/src/devices_models/devices/regulation_device.jl
+++ b/src/devices_models/devices/regulation_device.jl
@@ -6,23 +6,23 @@ struct DeviceLimitedRegulation <: AbstractRegulationFormulation end
 
 ############################ DeltaActivePowerUpVariable, RegulationDevice ###########################
 
-get_variable_binary(::DeltaActivePowerUpVariable, ::Type{<:PSY.RegulationDevice}) = false
-get_variable_lower_bound(::DeltaActivePowerUpVariable, ::PSY.RegulationDevice, _) = 0.0
+get_variable_binary(::DeltaActivePowerUpVariable, ::Type{<:PSY.RegulationDevice}, ::AbstractRegulationFormulation) = false
+get_variable_lower_bound(::DeltaActivePowerUpVariable, ::PSY.RegulationDevice, ::AbstractRegulationFormulation) = 0.0
 
 ############################ DeltaActivePowerDownVariable, RegulationDevice ###########################
 
-get_variable_binary(::DeltaActivePowerDownVariable, ::Type{<:PSY.RegulationDevice}) = false
-get_variable_lower_bound(::DeltaActivePowerDownVariable, ::PSY.RegulationDevice, _) = 0.0
+get_variable_binary(::DeltaActivePowerDownVariable, ::Type{<:PSY.RegulationDevice}, ::AbstractRegulationFormulation) = false
+get_variable_lower_bound(::DeltaActivePowerDownVariable, ::PSY.RegulationDevice, ::AbstractRegulationFormulation) = 0.0
 
 ############################ AdditionalDeltaActivePowerUpVariable, RegulationDevice ###########################
 
-get_variable_binary(::AdditionalDeltaActivePowerUpVariable, ::Type{<:PSY.RegulationDevice}) = false
-get_variable_lower_bound(::AdditionalDeltaActivePowerUpVariable, ::PSY.RegulationDevice, _) = 0.0
+get_variable_binary(::AdditionalDeltaActivePowerUpVariable, ::Type{<:PSY.RegulationDevice}, ::AbstractRegulationFormulation) = false
+get_variable_lower_bound(::AdditionalDeltaActivePowerUpVariable, ::PSY.RegulationDevice, ::AbstractRegulationFormulation) = 0.0
 
 ############################ AdditionalDeltaActivePowerDownVariable, RegulationDevice ###########################
 
-get_variable_binary(::AdditionalDeltaActivePowerDownVariable, ::Type{<:PSY.RegulationDevice}) = false
-get_variable_lower_bound(::AdditionalDeltaActivePowerDownVariable, ::PSY.RegulationDevice, _) = 0.0
+get_variable_binary(::AdditionalDeltaActivePowerDownVariable, ::Type{<:PSY.RegulationDevice}, ::AbstractRegulationFormulation) = false
+get_variable_lower_bound(::AdditionalDeltaActivePowerDownVariable, ::PSY.RegulationDevice, ::AbstractRegulationFormulation) = 0.0
 
 #! format: on
 

--- a/src/devices_models/devices/renewable_generation.jl
+++ b/src/devices_models/devices/renewable_generation.jl
@@ -7,18 +7,18 @@ struct RenewableConstantPowerFactor <: AbstractRenewableDispatchFormulation end
 
 ########################### ActivePowerVariable, RenewableGen #################################
 
-get_variable_binary(::ActivePowerVariable, ::Type{<:PSY.RenewableGen}) = false
+get_variable_binary(::ActivePowerVariable, ::Type{<:PSY.RenewableGen}, ::AbstractRenewableFormulation) = false
 
-get_variable_expression_name(::ActivePowerVariable, ::Type{<:PSY.RenewableGen}) = :nodal_balance_active
+get_variable_expression_name(::ActivePowerVariable, ::Type{<:PSY.RenewableGen}, ::Type{<:PM.AbstractPowerModel}) = :nodal_balance_active
 
-get_variable_lower_bound(::ActivePowerVariable, d::PSY.RenewableGen, _) = 0.0
-get_variable_upper_bound(::ActivePowerVariable, d::PSY.RenewableGen, _) = PSY.get_max_active_power(d)
+get_variable_lower_bound(::ActivePowerVariable, d::PSY.RenewableGen, ::AbstractRenewableFormulation) = 0.0
+get_variable_upper_bound(::ActivePowerVariable, d::PSY.RenewableGen, ::AbstractRenewableFormulation) = PSY.get_max_active_power(d)
 
 ########################### ReactivePowerVariable, RenewableGen #################################
 
-get_variable_binary(::ReactivePowerVariable, ::Type{<:PSY.RenewableGen}) = false
+get_variable_binary(::ReactivePowerVariable, ::Type{<:PSY.RenewableGen}, ::AbstractRenewableFormulation) = false
 
-get_variable_expression_name(::ReactivePowerVariable, ::Type{<:PSY.RenewableGen}) = :nodal_balance_reactive
+get_variable_expression_name(::ReactivePowerVariable, ::Type{<:PSY.RenewableGen}, ::Type{<:PM.AbstractPowerModel}) = :nodal_balance_reactive
 
 #! format: on
 

--- a/src/devices_models/devices/renewable_generation.jl
+++ b/src/devices_models/devices/renewable_generation.jl
@@ -9,7 +9,7 @@ struct RenewableConstantPowerFactor <: AbstractRenewableDispatchFormulation end
 
 get_variable_binary(::ActivePowerVariable, ::Type{<:PSY.RenewableGen}, ::AbstractRenewableFormulation) = false
 
-get_variable_expression_name(::ActivePowerVariable, ::Type{<:PSY.RenewableGen}, ::Type{<:PM.AbstractPowerModel}) = :nodal_balance_active
+get_variable_expression_name(::ActivePowerVariable, ::Type{<:PSY.RenewableGen}) = :nodal_balance_active
 
 get_variable_lower_bound(::ActivePowerVariable, d::PSY.RenewableGen, ::AbstractRenewableFormulation) = 0.0
 get_variable_upper_bound(::ActivePowerVariable, d::PSY.RenewableGen, ::AbstractRenewableFormulation) = PSY.get_max_active_power(d)
@@ -18,7 +18,7 @@ get_variable_upper_bound(::ActivePowerVariable, d::PSY.RenewableGen, ::AbstractR
 
 get_variable_binary(::ReactivePowerVariable, ::Type{<:PSY.RenewableGen}, ::AbstractRenewableFormulation) = false
 
-get_variable_expression_name(::ReactivePowerVariable, ::Type{<:PSY.RenewableGen}, ::Type{<:PM.AbstractPowerModel}) = :nodal_balance_reactive
+get_variable_expression_name(::ReactivePowerVariable, ::Type{<:PSY.RenewableGen}) = :nodal_balance_reactive
 
 #! format: on
 

--- a/src/devices_models/devices/storage.jl
+++ b/src/devices_models/devices/storage.jl
@@ -8,36 +8,35 @@ struct EndOfPeriodEnergyTarget <: AbstractEnergyManagement end
 
 ########################### ActivePowerInVariable, Storage #################################
 
-get_variable_binary(::ActivePowerInVariable, ::Type{<:PSY.Storage}) = false
-get_variable_expression_name(::ActivePowerInVariable, ::Type{<:PSY.Storage}) = :nodal_balance_active
+get_variable_binary(::ActivePowerInVariable, ::Type{<:PSY.Storage}, ::AbstractStorageFormulation) = false
+get_variable_expression_name(::ActivePowerInVariable, ::Type{<:PSY.Storage}, ::Type{<:PM.AbstractPowerModel}) = :nodal_balance_active
 
-get_variable_lower_bound(::ActivePowerInVariable, d::PSY.Storage, _) = 0.0
-get_variable_upper_bound(::ActivePowerInVariable, d::PSY.Storage, _) = nothing
-get_variable_sign(::ActivePowerInVariable, d::Type{<:PSY.Storage}) = -1.0
+get_variable_lower_bound(::ActivePowerInVariable, d::PSY.Storage, ::AbstractStorageFormulation) = 0.0
+get_variable_upper_bound(::ActivePowerInVariable, d::PSY.Storage, ::AbstractStorageFormulation) = nothing
+get_variable_sign(::ActivePowerInVariable, d::Type{<:PSY.Storage}, ::AbstractStorageFormulation) = -1.0
 
 ########################### ActivePowerOutVariable, Storage #################################
 
-get_variable_binary(::ActivePowerOutVariable, ::Type{<:PSY.Storage}) = false
-get_variable_expression_name(::ActivePowerOutVariable, ::Type{<:PSY.Storage}) = :nodal_balance_active
+get_variable_binary(::ActivePowerOutVariable, ::Type{<:PSY.Storage}, ::AbstractStorageFormulation) = false
+get_variable_expression_name(::ActivePowerOutVariable, ::Type{<:PSY.Storage}, ::Type{<:PM.AbstractPowerModel}) = :nodal_balance_active
 
-get_variable_lower_bound(::ActivePowerOutVariable, d::PSY.Storage, _) = 0.0
-get_variable_upper_bound(::ActivePowerOutVariable, d::PSY.Storage, _) = nothing
-get_variable_sign(::ActivePowerOutVariable, d::Type{<:PSY.Storage}) = 1.0
+get_variable_lower_bound(::ActivePowerOutVariable, d::PSY.Storage, ::AbstractStorageFormulation) = 0.0
+get_variable_upper_bound(::ActivePowerOutVariable, d::PSY.Storage, ::AbstractStorageFormulation) = nothing
+get_variable_sign(::ActivePowerOutVariable, d::Type{<:PSY.Storage}, ::AbstractStorageFormulation) = 1.0
 
 ############## ReactivePowerVariable, Storage ####################
 
-get_variable_binary(::ReactivePowerVariable, ::Type{<:PSY.Storage}) = false
-
-get_variable_expression_name(::ReactivePowerVariable, ::Type{<:PSY.Storage}) = :nodal_balance_reactive
+get_variable_binary(::ReactivePowerVariable, ::Type{<:PSY.Storage}, ::AbstractStorageFormulation) = false
+get_variable_expression_name(::ReactivePowerVariable, ::Type{<:PSY.Storage}, ::Type{<:PM.AbstractPowerModel}) = :nodal_balance_reactive
 
 ############## EnergyVariable, Storage ####################
 
-get_variable_binary(::EnergyVariable, ::Type{<:PSY.Storage}) = false
-get_variable_lower_bound(::EnergyVariable, d::PSY.Storage, _) = 0.0
+get_variable_binary(::EnergyVariable, ::Type{<:PSY.Storage}, ::AbstractStorageFormulation) = false
+get_variable_lower_bound(::EnergyVariable, d::PSY.Storage, ::AbstractStorageFormulation) = 0.0
 
 ############## ReserveVariable, Storage ####################
 
-get_variable_binary(::ReserveVariable, ::Type{<:PSY.Storage}) = true
+get_variable_binary(::ReserveVariable, ::Type{<:PSY.Storage}, ::AbstractStorageFormulation) = true
 
 #! format: on
 
@@ -179,8 +178,8 @@ end
 function initial_conditions!(
     optimization_container::OptimizationContainer,
     devices::IS.FlattenIteratorWrapper{St},
-    ::Type{D},
-) where {St <: PSY.Storage, D <: AbstractStorageFormulation}
+    ::AbstractStorageFormulation,
+) where {St <: PSY.Storage}
     storage_energy_init(optimization_container, devices)
     return
 end

--- a/src/devices_models/devices/storage.jl
+++ b/src/devices_models/devices/storage.jl
@@ -9,7 +9,7 @@ struct EndOfPeriodEnergyTarget <: AbstractEnergyManagement end
 ########################### ActivePowerInVariable, Storage #################################
 
 get_variable_binary(::ActivePowerInVariable, ::Type{<:PSY.Storage}, ::AbstractStorageFormulation) = false
-get_variable_expression_name(::ActivePowerInVariable, ::Type{<:PSY.Storage}, ::Type{<:PM.AbstractPowerModel}) = :nodal_balance_active
+get_variable_expression_name(::ActivePowerInVariable, ::Type{<:PSY.Storage}) = :nodal_balance_active
 
 get_variable_lower_bound(::ActivePowerInVariable, d::PSY.Storage, ::AbstractStorageFormulation) = 0.0
 get_variable_upper_bound(::ActivePowerInVariable, d::PSY.Storage, ::AbstractStorageFormulation) = nothing
@@ -18,7 +18,7 @@ get_variable_sign(::ActivePowerInVariable, d::Type{<:PSY.Storage}, ::AbstractSto
 ########################### ActivePowerOutVariable, Storage #################################
 
 get_variable_binary(::ActivePowerOutVariable, ::Type{<:PSY.Storage}, ::AbstractStorageFormulation) = false
-get_variable_expression_name(::ActivePowerOutVariable, ::Type{<:PSY.Storage}, ::Type{<:PM.AbstractPowerModel}) = :nodal_balance_active
+get_variable_expression_name(::ActivePowerOutVariable, ::Type{<:PSY.Storage}) = :nodal_balance_active
 
 get_variable_lower_bound(::ActivePowerOutVariable, d::PSY.Storage, ::AbstractStorageFormulation) = 0.0
 get_variable_upper_bound(::ActivePowerOutVariable, d::PSY.Storage, ::AbstractStorageFormulation) = nothing
@@ -27,7 +27,7 @@ get_variable_sign(::ActivePowerOutVariable, d::Type{<:PSY.Storage}, ::AbstractSt
 ############## ReactivePowerVariable, Storage ####################
 
 get_variable_binary(::ReactivePowerVariable, ::Type{<:PSY.Storage}, ::AbstractStorageFormulation) = false
-get_variable_expression_name(::ReactivePowerVariable, ::Type{<:PSY.Storage}, ::Type{<:PM.AbstractPowerModel}) = :nodal_balance_reactive
+get_variable_expression_name(::ReactivePowerVariable, ::Type{<:PSY.Storage}) = :nodal_balance_reactive
 
 ############## EnergyVariable, Storage ####################
 

--- a/src/devices_models/devices/thermal_generation.jl
+++ b/src/devices_models/devices/thermal_generation.jl
@@ -1110,8 +1110,14 @@ function AddCostSpec(
     return AddCostSpec(;
         variable_type = ActivePowerVariable,
         component_type = T,
-        has_status_variable = has_on_variable(optimization_container, PSY.ThermalMultiStart),
-        has_status_parameter = has_on_parameter(optimization_container, PSY.ThermalMultiStart),
+        has_status_variable = has_on_variable(
+            optimization_container,
+            PSY.ThermalMultiStart,
+        ),
+        has_status_parameter = has_on_parameter(
+            optimization_container,
+            PSY.ThermalMultiStart,
+        ),
         variable_cost = PSY.get_variable,
         start_up_cost = x -> getfield(PSY.get_start_up(x), :cold),
         shut_down_cost = PSY.get_shut_down,
@@ -1119,7 +1125,6 @@ function AddCostSpec(
         sos_status = SOSStatusVariable.VARIABLE,
     )
 end
-
 
 function AddCostSpec(
     ::Type{T},
@@ -1159,7 +1164,7 @@ function AddCostSpec(
         start_up_cost = PSY.get_start_up,
         fixed_cost = fixed_cost_func,
         sos_status = SOSStatusVariable.VARIABLE,
-        uses_compact_power = true
+        uses_compact_power = true,
     )
 end
 
@@ -1182,7 +1187,7 @@ function AddCostSpec(
         variable_cost = _get_compact_varcost,
         fixed_cost = fixed_cost_func,
         sos_status = sos_status,
-        uses_compact_power = true
+        uses_compact_power = true,
     )
 end
 
@@ -1203,7 +1208,7 @@ function AddCostSpec(
         fixed_cost = fixed_cost_func,
         sos_status = SOSStatusVariable.VARIABLE,
         has_multistart_variables = true,
-        uses_compact_power = true
+        uses_compact_power = true,
     )
 end
 

--- a/src/devices_models/devices/thermal_generation.jl
+++ b/src/devices_models/devices/thermal_generation.jl
@@ -1109,7 +1109,7 @@ function AddCostSpec(
 ) where {U <: AbstractStandardUnitCommitment}
     return AddCostSpec(;
         variable_type = ActivePowerVariable,
-        component_type = T,
+        component_type = PSY.ThermalMultiStart,
         has_status_variable = has_on_variable(
             optimization_container,
             PSY.ThermalMultiStart,

--- a/src/devices_models/devices/thermal_generation.jl
+++ b/src/devices_models/devices/thermal_generation.jl
@@ -19,69 +19,43 @@ struct ThermalCompactUnitCommitment <: AbstractCompactUnitCommitment end
 struct ThermalCompactDispatch <: AbstractThermalDispatchFormulation end
 
 ############## ActivePowerVariable, ThermalGen ####################
+get_variable_binary(::ActivePowerVariable, ::Type{<:PSY.ThermalGen}, ::AbstractThermalFormulation) = false
 
-get_variable_binary(::ActivePowerVariable, ::Type{<:PSY.ThermalGen}) = false
+get_variable_expression_name(::ActivePowerVariable, ::Type{<:PSY.ThermalGen}, ::Type{<:PM.AbstractPowerModel}) = :nodal_balance_active
+get_variable_initial_value(::ActivePowerVariable, d::PSY.ThermalGen, ::AbstractThermalFormulation) = PSY.get_active_power(d)
+get_variable_initial_value(::ActivePowerVariable, d::PSY.ThermalGen, ::AbstractCompactUnitCommitment) = max(0.0, PSY.get_active_power(d) - PSY.get_active_power_limits(d).min)
 
-get_variable_expression_name(::ActivePowerVariable, ::Type{<:PSY.ThermalGen}) = :nodal_balance_active
-
-get_variable_initial_value(pv::ActivePowerVariable, d::PSY.ThermalGen, settings) =
-    get_variable_initial_value(pv, d, get_warm_start(settings) ? WarmStartVariable() : ColdStartVariable())
-get_variable_initial_value(::ActivePowerVariable, d::PSY.ThermalGen, ::WarmStartVariable) = PSY.get_active_power(d)
-get_variable_initial_value(::ActivePowerVariable, d::PSY.ThermalGen, ::ColdStartVariable) = nothing
-
-get_variable_lower_bound(::ActivePowerVariable, d::PSY.ThermalGen, _) = PSY.get_active_power_limits(d).min
-get_variable_upper_bound(::ActivePowerVariable, d::PSY.ThermalGen, _) = PSY.get_active_power_limits(d).max
-
-############## ActivePowerVariable, ThermalMultiStart ####################
-
-get_variable_binary(::ActivePowerVariable, ::Type{<:PSY.ThermalMultiStart}) = false
-
-get_variable_expression_name(::ActivePowerVariable, ::Type{<:PSY.ThermalMultiStart}) = :nodal_balance_active
-get_variable_initial_value(pv::ActivePowerVariable, d::PSY.ThermalMultiStart, settings) =
-    get_variable_initial_value(pv, d, get_warm_start(settings) ? WarmStartVariable() : ColdStartVariable())
-get_variable_initial_value(::ActivePowerVariable, d::PSY.ThermalMultiStart, ::WarmStartVariable) = PSY.get_active_power(d)
-get_variable_initial_value(::ActivePowerVariable, d::PSY.ThermalMultiStart, ::ColdStartVariable) = nothing
-
-get_variable_lower_bound(::ActivePowerVariable, d::PSY.ThermalMultiStart, _) = 0
-get_variable_upper_bound(::ActivePowerVariable, d::PSY.ThermalMultiStart, _) = PSY.get_active_power_limits(d).max
+get_variable_lower_bound(::ActivePowerVariable, d::PSY.ThermalGen, ::AbstractThermalFormulation) = PSY.get_active_power_limits(d).min
+get_variable_lower_bound(::ActivePowerVariable, d::PSY.ThermalGen, ::AbstractCompactUnitCommitment) = 0.0
+get_variable_upper_bound(::ActivePowerVariable, d::PSY.ThermalGen, ::AbstractThermalFormulation) = PSY.get_active_power_limits(d).max
+get_variable_upper_bound(::ActivePowerVariable, d::PSY.ThermalGen, ::AbstractThermalFormulation) = PSY.get_active_power_limits(d).max - PSY.get_active_power_limits(d).min
 
 ############## ReactivePowerVariable, ThermalGen ####################
+get_variable_binary(::ReactivePowerVariable, ::Type{<:PSY.ThermalGen}, ::AbstractThermalFormulation) = false
+get_variable_expression_name(::ReactivePowerVariable, ::Type{<:PSY.ThermalGen}, ::Type{<:PM.AbstractPowerModel}) = :nodal_balance_reactive
 
-get_variable_binary(::ReactivePowerVariable, ::Type{<:PSY.ThermalGen}) = false
+get_variable_initial_value(::ReactivePowerVariable, d::PSY.ThermalGen, ::AbstractThermalFormulation) = PSY.get_reactive_power(d)
 
-get_variable_expression_name(::ReactivePowerVariable, ::Type{<:PSY.ThermalGen}) = :nodal_balance_reactive
-
-get_variable_initial_value(pv::ReactivePowerVariable, d::PSY.ThermalGen, settings) =
-get_variable_initial_value(pv, d, get_warm_start(settings) ? WarmStartVariable() : ColdStartVariable())
-get_variable_initial_value(::ReactivePowerVariable, d::PSY.ThermalGen, ::WarmStartVariable) = PSY.get_active_power(d)
-get_variable_initial_value(::ReactivePowerVariable, d::PSY.ThermalGen, ::ColdStartVariable) = nothing
-
-get_variable_lower_bound(::ReactivePowerVariable, d::PSY.ThermalGen, _) = PSY.get_active_power_limits(d).min
-get_variable_upper_bound(::ReactivePowerVariable, d::PSY.ThermalGen, _) = PSY.get_active_power_limits(d).max
+get_variable_lower_bound(::ReactivePowerVariable, d::PSY.ThermalGen, ::AbstractThermalFormulation) = PSY.get_active_power_limits(d).min
+get_variable_upper_bound(::ReactivePowerVariable, d::PSY.ThermalGen, ::AbstractThermalFormulation) = PSY.get_active_power_limits(d).max
 
 ############## OnVariable, ThermalGen ####################
-
-get_variable_binary(::OnVariable, ::Type{<:PSY.ThermalGen}) = true
-
-get_variable_initial_value(pv::OnVariable, d::PSY.ThermalGen, settings) =
-    get_variable_initial_value(pv, d, get_warm_start(settings) ? WarmStartVariable() : ColdStartVariable())
-get_variable_initial_value(::OnVariable, d::PSY.ThermalGen, ::WarmStartVariable) = PSY.get_active_power(d) > 0 ? 1.0 : 0.0
-get_variable_initial_value(::OnVariable, d::PSY.ThermalGen, ::ColdStartVariable) = nothing
+get_variable_binary(::OnVariable, ::Type{<:PSY.ThermalGen}, ::AbstractThermalFormulation) = true
+get_variable_initial_value(::OnVariable, d::PSY.ThermalGen, ::AbstractThermalFormulation) = PSY.get_status(d) ? 1.0 : 0.0
 
 ############## StopVariable, ThermalGen ####################
-
-get_variable_binary(::StopVariable, ::Type{<:PSY.ThermalGen}) = true
+get_variable_binary(::StopVariable, ::Type{<:PSY.ThermalGen}, ::AbstractThermalFormulation) = true
+get_variable_lower_bound(::StopVariable, d::PSY.ThermalGen, ::AbstractThermalFormulation) = 0.0
+get_variable_upper_bound(::StopVariable, d::PSY.ThermalGen, ::AbstractThermalFormulation) = 1.0
 
 ############## StartVariable, ThermalGen ####################
-
-get_variable_binary(::StartVariable, d::Type{<:PSY.ThermalGen}) = true
-get_variable_lower_bound(::StartVariable, d::PSY.ThermalGen, _) = 0.0
-get_variable_upper_bound(::StartVariable, d::PSY.ThermalGen, _) = 1.0
+get_variable_binary(::StartVariable, d::Type{<:PSY.ThermalGen}, ::AbstractThermalFormulation) = true
+get_variable_lower_bound(::StartVariable, d::PSY.ThermalGen, ::AbstractThermalFormulation) = 0.0
+get_variable_upper_bound(::StartVariable, d::PSY.ThermalGen, ::AbstractThermalFormulation) = 1.0
 
 ############## ColdStartVariable, WarmStartVariable, HotStartVariable ############
+get_variable_binary(::Union{ColdStartVariable, WarmStartVariable, HotStartVariable}, ::Type{PSY.ThermalMultiStart}, ::AbstractThermalFormulation) = true
 
-get_variable_binary(v::T, d::PSY.ThermalMultiStart) where T <: Union{ColdStartVariable, WarmStartVariable, HotStartVariable} = get_variable_binary(v, typeof(d))
-get_variable_binary(::T, ::Type{PSY.ThermalMultiStart}) where T <: Union{ColdStartVariable, WarmStartVariable, HotStartVariable} = true
 
 #! format: on
 
@@ -424,8 +398,8 @@ end
 function initial_conditions!(
     optimization_container::OptimizationContainer,
     devices::IS.FlattenIteratorWrapper{T},
-    ::Type{D},
-) where {T <: PSY.ThermalGen, D <: AbstractThermalUnitCommitment}
+    ::AbstractThermalUnitCommitment,
+) where {T <: PSY.ThermalGen}
     status_init(optimization_container, devices)
     output_init(optimization_container, devices)
     duration_init(optimization_container, devices)
@@ -435,7 +409,7 @@ end
 function initial_conditions!(
     optimization_container::OptimizationContainer,
     devices::IS.FlattenIteratorWrapper{T},
-    ::Type{ThermalBasicUnitCommitment},
+    ::ThermalBasicUnitCommitment,
 ) where {T <: PSY.ThermalGen}
     status_init(optimization_container, devices)
     output_init(optimization_container, devices)
@@ -445,8 +419,8 @@ end
 function initial_conditions!(
     optimization_container::OptimizationContainer,
     devices::IS.FlattenIteratorWrapper{T},
-    ::Type{D},
-) where {T <: PSY.ThermalGen, D <: AbstractThermalDispatchFormulation}
+    ::AbstractThermalDispatchFormulation,
+) where {T <: PSY.ThermalGen}
     output_init(optimization_container, devices)
     return
 end

--- a/src/devices_models/devices/thermal_generation.jl
+++ b/src/devices_models/devices/thermal_generation.jl
@@ -21,18 +21,18 @@ struct ThermalCompactDispatch <: AbstractThermalDispatchFormulation end
 ############## ActivePowerVariable, ThermalGen ####################
 get_variable_binary(::ActivePowerVariable, ::Type{<:PSY.ThermalGen}, ::AbstractThermalFormulation) = false
 
-get_variable_expression_name(::ActivePowerVariable, ::Type{<:PSY.ThermalGen}, ::Type{<:PM.AbstractPowerModel}) = :nodal_balance_active
+get_variable_expression_name(::ActivePowerVariable, ::Type{<:PSY.ThermalGen}) = :nodal_balance_active
 get_variable_initial_value(::ActivePowerVariable, d::PSY.ThermalGen, ::AbstractThermalFormulation) = PSY.get_active_power(d)
 get_variable_initial_value(::ActivePowerVariable, d::PSY.ThermalGen, ::AbstractCompactUnitCommitment) = max(0.0, PSY.get_active_power(d) - PSY.get_active_power_limits(d).min)
 
 get_variable_lower_bound(::ActivePowerVariable, d::PSY.ThermalGen, ::AbstractThermalFormulation) = PSY.get_active_power_limits(d).min
 get_variable_lower_bound(::ActivePowerVariable, d::PSY.ThermalGen, ::AbstractCompactUnitCommitment) = 0.0
 get_variable_upper_bound(::ActivePowerVariable, d::PSY.ThermalGen, ::AbstractThermalFormulation) = PSY.get_active_power_limits(d).max
-get_variable_upper_bound(::ActivePowerVariable, d::PSY.ThermalGen, ::AbstractThermalFormulation) = PSY.get_active_power_limits(d).max - PSY.get_active_power_limits(d).min
+get_variable_upper_bound(::ActivePowerVariable, d::PSY.ThermalGen, ::AbstractCompactUnitCommitment) = PSY.get_active_power_limits(d).max - PSY.get_active_power_limits(d).min
 
 ############## ReactivePowerVariable, ThermalGen ####################
 get_variable_binary(::ReactivePowerVariable, ::Type{<:PSY.ThermalGen}, ::AbstractThermalFormulation) = false
-get_variable_expression_name(::ReactivePowerVariable, ::Type{<:PSY.ThermalGen}, ::Type{<:PM.AbstractPowerModel}) = :nodal_balance_reactive
+get_variable_expression_name(::ReactivePowerVariable, ::Type{<:PSY.ThermalGen}) = :nodal_balance_reactive
 
 get_variable_initial_value(::ReactivePowerVariable, d::PSY.ThermalGen, ::AbstractThermalFormulation) = PSY.get_reactive_power(d)
 

--- a/src/devices_models/devices/thermal_generation.jl
+++ b/src/devices_models/devices/thermal_generation.jl
@@ -1103,6 +1103,25 @@ function AddCostSpec(
 end
 
 function AddCostSpec(
+    ::Type{PSY.ThermalMultiStart},
+    ::Type{U},
+    optimization_container::OptimizationContainer,
+) where {U <: AbstractStandardUnitCommitment}
+    return AddCostSpec(;
+        variable_type = ActivePowerVariable,
+        component_type = T,
+        has_status_variable = has_on_variable(optimization_container, PSY.ThermalMultiStart),
+        has_status_parameter = has_on_parameter(optimization_container, PSY.ThermalMultiStart),
+        variable_cost = PSY.get_variable,
+        start_up_cost = x -> getfield(PSY.get_start_up(x), :cold),
+        shut_down_cost = PSY.get_shut_down,
+        fixed_cost = PSY.get_fixed,
+        sos_status = SOSStatusVariable.VARIABLE,
+    )
+end
+
+
+function AddCostSpec(
     ::Type{T},
     ::Type{U},
     optimization_container::OptimizationContainer,
@@ -1140,6 +1159,7 @@ function AddCostSpec(
         start_up_cost = PSY.get_start_up,
         fixed_cost = fixed_cost_func,
         sos_status = SOSStatusVariable.VARIABLE,
+        uses_compact_power = true
     )
 end
 
@@ -1162,6 +1182,7 @@ function AddCostSpec(
         variable_cost = _get_compact_varcost,
         fixed_cost = fixed_cost_func,
         sos_status = sos_status,
+        uses_compact_power = true
     )
 end
 
@@ -1182,6 +1203,7 @@ function AddCostSpec(
         fixed_cost = fixed_cost_func,
         sos_status = SOSStatusVariable.VARIABLE,
         has_multistart_variables = true,
+        uses_compact_power = true
     )
 end
 
@@ -1274,6 +1296,16 @@ function cost_function!(
         end
     end
     return
+end
+
+function cost_function!(
+    ::OptimizationContainer,
+    ::IS.FlattenIteratorWrapper{PSY.ThermalMultiStart},
+    ::DeviceModel{PSY.ThermalMultiStart, ThermalDispatchNoMin},
+    ::Type{<:PM.AbstractPowerModel},
+    ::Union{Nothing, AbstractAffectFeedForward},
+)
+    error("DispatchNoMin is not compatible with ThermalMultiStart")
 end
 
 # TODO: Define for now just for Area Balance and reason about others later. This will

--- a/src/network_models/powermodels_interface.jl
+++ b/src/network_models/powermodels_interface.jl
@@ -647,7 +647,12 @@ function add_pm_expr_refs!(
                     var_type = getfield(ps_v, dir)
                     var_type === nothing && continue
 
-                    add_variable!(optimization_container, var_type(), mapped_ps_devices)
+                    add_variable!(
+                        optimization_container,
+                        var_type(),
+                        mapped_ps_devices,
+                        StaticBranchUnbounded(),
+                    )
                     psi_var_container = get_variable(
                         optimization_container,
                         make_variable_name(var_type, d_type),

--- a/src/services_models/agc.jl
+++ b/src/services_models/agc.jl
@@ -17,21 +17,21 @@ end
 
 ########################## ActivePowerVariable, Area ###########################
 
-get_variable_binary(::ActivePowerVariable, ::Type{<:PSY.Area}) = false
+get_variable_binary(::ActivePowerVariable, ::Type{<:PSY.Area}, ::AbstractAGCFormulation) = false
 
 ########################## SmoothACE, AggregationTopology ###########################
 
-get_variable_binary(::SmoothACE, ::Type{<:PSY.AggregationTopology}) = false
+get_variable_binary(::SmoothACE, ::Type{<:PSY.AggregationTopology}, ::AbstractAGCFormulation) = false
 
 ########################## DeltaActivePowerUpVariable, Area ###########################
 
-get_variable_binary(::DeltaActivePowerUpVariable, ::Type{<:PSY.Area}) = false
-get_variable_lower_bound(::DeltaActivePowerUpVariable, ::PSY.Area, _) = 0.0
+get_variable_binary(::DeltaActivePowerUpVariable, ::Type{<:PSY.Area}, ::AbstractAGCFormulation) = false
+get_variable_lower_bound(::DeltaActivePowerUpVariable, ::PSY.Area, ::AbstractAGCFormulation) = 0.0
 
 ########################## DeltaActivePowerDownVariable, Area ###########################
 
-get_variable_binary(::DeltaActivePowerDownVariable, ::Type{<:PSY.Area}) = false
-get_variable_lower_bound(::DeltaActivePowerDownVariable, ::PSY.Area, _) = 0.0
+get_variable_binary(::DeltaActivePowerDownVariable, ::Type{<:PSY.Area}, ::AbstractAGCFormulation) = false
+get_variable_lower_bound(::DeltaActivePowerDownVariable, ::PSY.Area, ::AbstractAGCFormulation) = 0.0
 
 ########################## AdditionalDeltaPowerUpVariable, Area ###########################
 
@@ -71,13 +71,13 @@ get_variable_lower_bound(::DeltaActivePowerDownVariable, ::PSY.Area, _) = 0.0
 ########################## AreaMismatchVariable, Area ###########################
 
 make_variable_name(::Type{AreaMismatchVariable}, _) = make_variable_name(AreaMismatchVariable)
-get_variable_binary(::AreaMismatchVariable, ::Type{<:PSY.Area}) = false
+get_variable_binary(::AreaMismatchVariable, ::Type{<:PSY.Area}, ::AbstractAGCFormulation) = false
 
 ########################## LiftVariable, Area ###########################
 
 make_variable_name(::Type{LiftVariable}, _) = make_variable_name(LiftVariable)
-get_variable_binary(::LiftVariable, ::Type{<:PSY.Area}) = false
-get_variable_lower_bound(::LiftVariable, ::PSY.Area, _) = 0.0
+get_variable_binary(::LiftVariable, ::Type{<:PSY.Area}, ::AbstractAGCFormulation) = false
+get_variable_lower_bound(::LiftVariable, ::PSY.Area, ::AbstractAGCFormulation) = 0.0
 
 ########################## , ###########################
 

--- a/src/services_models/reserves.jl
+++ b/src/services_models/reserves.jl
@@ -6,15 +6,15 @@ struct StepwiseCostReserve <: AbstractReservesFormulation end
 
 ############################### ActiveServiceVariable, Reserve #########################################
 
-get_variable_binary(::ActiveServiceVariable, ::Type{<:PSY.Reserve}) = false
+get_variable_binary(::ActiveServiceVariable, ::Type{<:PSY.Reserve}, ::AbstractReservesFormulation) = false
 get_variable_upper_bound(::ActiveServiceVariable, ::PSY.Reserve, ::PSY.Component, _) = nothing
 get_variable_lower_bound(::ActiveServiceVariable, ::PSY.Reserve, ::PSY.Component, _) = 0.0
 
 ############################### ServiceRequirementVariable, ReserveDemandCurve ################################
 
-get_variable_binary(::ServiceRequirementVariable, ::Type{<:PSY.ReserveDemandCurve}) = false
-get_variable_upper_bound(::ServiceRequirementVariable, ::PSY.ReserveDemandCurve, ::PSY.Component, _) = nothing
-get_variable_lower_bound(::ServiceRequirementVariable, ::PSY.ReserveDemandCurve, ::PSY.Component, _) = 0.0
+get_variable_binary(::ServiceRequirementVariable, ::Type{<:PSY.ReserveDemandCurve}, ::AbstractReservesFormulation) = false
+get_variable_upper_bound(::ServiceRequirementVariable, ::PSY.ReserveDemandCurve, ::PSY.Component, ::AbstractReservesFormulation) = nothing
+get_variable_lower_bound(::ServiceRequirementVariable, ::PSY.ReserveDemandCurve, ::PSY.Component, ::AbstractReservesFormulation) = 0.0
 
 #! format: on
 ################################## Reserve Requirement Constraint ##########################

--- a/src/services_models/reserves.jl
+++ b/src/services_models/reserves.jl
@@ -1,5 +1,4 @@
 #! format: off
-abstract type AbstractReservesFormulation <: AbstractServiceFormulation end
 struct RangeReserve <: AbstractReservesFormulation end
 struct StepwiseCostReserve <: AbstractReservesFormulation end
 ############################### Reserve Variables #########################################

--- a/src/services_models/services_constructor.jl
+++ b/src/services_models/services_constructor.jl
@@ -97,7 +97,7 @@ function construct_service!(
             ActiveServiceVariable,
             service,
             contributing_devices,
-            RangeReserve()
+            RangeReserve(),
         )
         # Constraints
         service_requirement_constraint!(optimization_container, service, model)
@@ -121,7 +121,12 @@ function construct_service!(
     time_steps = model_time_steps(optimization_container)
     names = [PSY.get_name(s) for s in services]
     # Does not use the standard implementation of add_variable!()
-    add_variable!(optimization_container, ServiceRequirementVariable(), services, StepwiseCostReserve())
+    add_variable!(
+        optimization_container,
+        ServiceRequirementVariable(),
+        services,
+        StepwiseCostReserve(),
+    )
     add_cons_container!(
         optimization_container,
         make_constraint_name(REQUIREMENT, SR),
@@ -145,7 +150,7 @@ function construct_service!(
             ActiveServiceVariable,
             service,
             contributing_devices,
-            StepwiseCostReserve()
+            StepwiseCostReserve(),
         )
         # Constraints
         service_requirement_constraint!(optimization_container, service, model)

--- a/src/services_models/services_constructor.jl
+++ b/src/services_models/services_constructor.jl
@@ -97,6 +97,7 @@ function construct_service!(
             ActiveServiceVariable,
             service,
             contributing_devices,
+            RangeReserve()
         )
         # Constraints
         service_requirement_constraint!(optimization_container, service, model)
@@ -119,7 +120,8 @@ function construct_service!(
     services_mapping = PSY.get_contributing_device_mapping(sys)
     time_steps = model_time_steps(optimization_container)
     names = [PSY.get_name(s) for s in services]
-    add_variables!(optimization_container, ServiceRequirementVariable, services)
+    # Does not use the standard implementation of add_variable!()
+    add_variable!(optimization_container, ServiceRequirementVariable(), services, StepwiseCostReserve())
     add_cons_container!(
         optimization_container,
         make_constraint_name(REQUIREMENT, SR),
@@ -143,6 +145,7 @@ function construct_service!(
             ActiveServiceVariable,
             service,
             contributing_devices,
+            StepwiseCostReserve()
         )
         # Constraints
         service_requirement_constraint!(optimization_container, service, model)
@@ -174,12 +177,12 @@ function construct_service!(
         end
     end
     add_variables!(optimization_container, SteadyStateFrequencyDeviation)
-    add_variables!(optimization_container, AreaMismatchVariable, areas)
-    add_variables!(optimization_container, SmoothACE, areas)
-    add_variables!(optimization_container, LiftVariable, areas)
-    add_variables!(optimization_container, ActivePowerVariable, areas)
-    add_variables!(optimization_container, DeltaActivePowerUpVariable, areas)
-    add_variables!(optimization_container, DeltaActivePowerDownVariable, areas)
+    add_variables!(optimization_container, AreaMismatchVariable, areas, T())
+    add_variables!(optimization_container, SmoothACE, areas, T())
+    add_variables!(optimization_container, LiftVariable, areas, T())
+    add_variables!(optimization_container, ActivePowerVariable, areas, T())
+    add_variables!(optimization_container, DeltaActivePowerUpVariable, areas, T())
+    add_variables!(optimization_container, DeltaActivePowerDownVariable, areas, T())
     # add_variables!(optimization_container, AdditionalDeltaActivePowerUpVariable, areas)
     # add_variables!(optimization_container, AdditionalDeltaActivePowerDownVariable, areas)
     balancing_auxiliary_variables!(optimization_container, sys)

--- a/test/test_device_thermal_generation_constructors.jl
+++ b/test/test_device_thermal_generation_constructors.jl
@@ -736,7 +736,7 @@ end
             use_parameters = p,
         )
         mock_construct_device!(op_problem, model)
-        moi_tests(op_problem, p, 120, 0, 120, 120, 0, false)
+        moi_tests(op_problem, p, 120, 0, 168, 120, 0, false)
         psi_checkobjfun_test(op_problem, GAEVF)
     end
 end
@@ -768,7 +768,7 @@ end
             use_parameters = p,
         )
         mock_construct_device!(op_problem, model)
-        moi_tests(op_problem, p, 240, 0, 240, 240, 0, false)
+        moi_tests(op_problem, p, 240, 0, 288, 240, 0, false)
         psi_checkobjfun_test(op_problem, GAEVF)
     end
 end


### PR DESCRIPTION
@kdheepak This PR fixes an incorrect implementation of the use of warm start across the package. Due to the use of defaults, it was working but the implementation was incoherent. Some constructors would take settings others would take formulations. 

This situation leads to multiple confusions on the behavior of the package and made it hard to debug. I added types to all the functions to avoid future incorrect behaviors. 

One note about implementation, I implemented the formulations as instances just because it seemed to be your preference, makes the code review easier, and follows better the way things are currently implemented. @daniel-thom any thoughts on the use of instances vs types in the fix for the problem? 

Given the urgency to address these issues, I will keep the PR open for 24 hours. 

@sourabhdalvi please check that the Thermal Formulations have consistent results after the change. 