### PR TITLE
Serialize simulation status

### DIFF
--- a/src/PowerSimulations.jl
+++ b/src/PowerSimulations.jl
@@ -241,6 +241,7 @@ export optimizer_with_attributes
 import MathOptInterface
 import ParameterJuMP
 import LinearAlgebra
+import JSON3
 import PowerSystems
 import InfrastructureSystems
 # so that users have access to IS.Results interfaces

--- a/src/core/definitions.jl
+++ b/src/core/definitions.jl
@@ -20,11 +20,6 @@ const JuMPVariableArray = JuMP.Containers.DenseAxisArray{JuMP.VariableRef}
 const JuMPParamArray = JuMP.Containers.DenseAxisArray{PJ.ParameterRef}
 const DenseAxisArrayContainer = Dict{Symbol, JuMP.Containers.DenseAxisArray}
 
-# Enums
-IS.@scoped_enum(BuildStatus, IN_PROGRESS = -1, BUILT = 0, FAILED = 1, EMPTY = 2,)
-IS.@scoped_enum(RunStatus, READY = -1, SUCCESSFUL = 0, RUNNING = 1, FAILED = 2,)
-IS.@scoped_enum(SOSStatusVariable, NO_VARIABLE = 1, PARAMETER = 2, VARIABLE = 3,)
-
 # Settings constants
 const UNSET_HORIZON = 0
 const UNSET_INI_TIME = Dates.DateTime(0)
@@ -66,3 +61,37 @@ const SIMULATION_LOG_FILENAME = "simulation.log"
 const REQUIRED_RECORDERS = (:simulation_status, :simulation)
 const KNOWN_SIMULATION_PATHS =
     ["data_store", "logs", "models_json", "recorder", "results", "simulation_files"]
+
+# Enums
+IS.@scoped_enum(BuildStatus, IN_PROGRESS = -1, BUILT = 0, FAILED = 1, EMPTY = 2,)
+IS.@scoped_enum(RunStatus, READY = -1, SUCCESSFUL = 0, RUNNING = 1, FAILED = 2,)
+IS.@scoped_enum(SOSStatusVariable, NO_VARIABLE = 1, PARAMETER = 2, VARIABLE = 3,)
+
+const ENUMS = (BuildStatus, RunStatus, SOSStatusVariable)
+
+const ENUM_MAPPINGS = Dict()
+
+for enum in ENUMS
+    ENUM_MAPPINGS[enum] = Dict()
+    for value in instances(enum)
+        ENUM_MAPPINGS[enum][lowercase(string(value))] = value
+    end
+end
+
+"""Get the enum value for the string. Case insensitive."""
+function get_enum_value(enum, value::String)
+    if !haskey(ENUM_MAPPINGS, enum)
+        throw(ArgumentError("enum=$enum is not valid"))
+    end
+
+    val = lowercase(value)
+    if !haskey(ENUM_MAPPINGS[enum], val)
+        throw(ArgumentError("enum=$enum does not have value=$val"))
+    end
+
+    return ENUM_MAPPINGS[enum][val]
+end
+
+Base.convert(::Type{BuildStatus}, val::String) = get_enum_value(BuildStatus, val)
+Base.convert(::Type{RunStatus}, val::String) = get_enum_value(RunStatus, val)
+Base.convert(::Type{SOSStatusVariable}, x::String) = get_enum_value(SOSStatusVariable, x)

--- a/src/core/simulation_results.jl
+++ b/src/core/simulation_results.jl
@@ -47,13 +47,14 @@ function ProblemResults(
 )
     name = Symbol(problem_name)
 
+    sys = nothing
     if load_system
-        sys = PSY.System(
-            joinpath(path, "problems", make_system_filename(problem_params.system_uuid)),
-            time_series_read_only = true,
-        )
-    else
-        sys = nothing
+        file = joinpath(path, "problems", make_system_filename(problem_params.system_uuid))
+        if isfile(file)
+            sys = PSY.System(file, time_series_read_only = true)
+        else
+            @info "Skipping load of the system because it wasn't serialized"
+        end
     end
 
     if results_output_path === nothing
@@ -637,6 +638,11 @@ function SimulationResults(path::AbstractString, execution = nothing; load_syste
         if !isdir(execution_path)
             error("Execution $execution not in the simulations results")
         end
+    end
+
+    status = deserialize_status(joinpath(execution_path, RESULTS_DIR))
+    if status != RunStatus.SUCCESSFUL
+        error("Results can only be read from a successful simulation: $status")
     end
 
     if !check_folder_integrity(execution_path)

--- a/test/test_simulation_results.jl
+++ b/test/test_simulation_results.jl
@@ -48,10 +48,6 @@ end
 
 function test_simulation_results(file_path::String, export_path)
     @testset "Test simulation results" begin
-        #file_path = "test_sim"
-        #isdir(file_path) && rm(file_path, recursive=true)
-        #mkpath(file_path)
-        #export_path="export_path"
         template_uc = get_template_hydro_st_uc()
         template_ed = get_template_hydro_st_ed()
         c_sys5_hy_uc = PSB.build_system(PSITestSystems, "c_sys5_hy_uc")
@@ -311,6 +307,12 @@ function test_simulation_results(file_path::String, export_path)
         @test isempty(results)
 
         verify_export_results(results, export_path)
+
+        # Test that you can't read a failed simulation.
+        PSI.set_simulation_status!(sim, RunStatus.FAILED)
+        PSI.serialize_status(sim)
+        @test PSI.deserialize_status(sim) == RunStatus.FAILED
+        @test_throws ErrorException SimulationResults(sim)
     end
 end
 


### PR DESCRIPTION
This allows blocking of reading results if the simulation failed.

Fixes #629 