### PR TITLE
Improve loading of simulation results

### DIFF
--- a/src/PowerSimulations.jl
+++ b/src/PowerSimulations.jl
@@ -241,6 +241,7 @@ export optimizer_with_attributes
 import MathOptInterface
 import ParameterJuMP
 import LinearAlgebra
+import JSON3
 import PowerSystems
 import InfrastructureSystems
 # so that users have access to IS.Results interfaces

--- a/src/PowerSimulations.jl
+++ b/src/PowerSimulations.jl
@@ -139,6 +139,8 @@ export get_existing_variables
 export get_problem_name
 export get_problem_results
 export get_system
+export get_system!
+export set_system!
 export list_problems
 export list_supported_formats
 export load_results!

--- a/src/core/definitions.jl
+++ b/src/core/definitions.jl
@@ -20,11 +20,6 @@ const JuMPVariableArray = JuMP.Containers.DenseAxisArray{JuMP.VariableRef}
 const JuMPParamArray = JuMP.Containers.DenseAxisArray{PJ.ParameterRef}
 const DenseAxisArrayContainer = Dict{Symbol, JuMP.Containers.DenseAxisArray}
 
-# Enums
-IS.@scoped_enum(BuildStatus, IN_PROGRESS = -1, BUILT = 0, FAILED = 1, EMPTY = 2,)
-IS.@scoped_enum(RunStatus, READY = -1, SUCCESSFUL = 0, RUNNING = 1, FAILED = 2,)
-IS.@scoped_enum(SOSStatusVariable, NO_VARIABLE = 1, PARAMETER = 2, VARIABLE = 3,)
-
 # Settings constants
 const UNSET_HORIZON = 0
 const UNSET_INI_TIME = Dates.DateTime(0)
@@ -66,3 +61,37 @@ const SIMULATION_LOG_FILENAME = "simulation.log"
 const REQUIRED_RECORDERS = (:simulation_status, :simulation)
 const KNOWN_SIMULATION_PATHS =
     ["data_store", "logs", "models_json", "recorder", "results", "simulation_files"]
+
+# Enums
+IS.@scoped_enum(BuildStatus, IN_PROGRESS = -1, BUILT = 0, FAILED = 1, EMPTY = 2,)
+IS.@scoped_enum(RunStatus, READY = -1, SUCCESSFUL = 0, RUNNING = 1, FAILED = 2,)
+IS.@scoped_enum(SOSStatusVariable, NO_VARIABLE = 1, PARAMETER = 2, VARIABLE = 3,)
+
+const ENUMS = (BuildStatus, RunStatus, SOSStatusVariable)
+
+const ENUM_MAPPINGS = Dict()
+
+for enum in ENUMS
+    ENUM_MAPPINGS[enum] = Dict()
+    for value in instances(enum)
+        ENUM_MAPPINGS[enum][lowercase(string(value))] = value
+    end
+end
+
+"""Get the enum value for the string. Case insensitive."""
+function get_enum_value(enum, value::String)
+    if !haskey(ENUM_MAPPINGS, enum)
+        throw(ArgumentError("enum=$enum is not valid"))
+    end
+
+    val = lowercase(value)
+    if !haskey(ENUM_MAPPINGS[enum], val)
+        throw(ArgumentError("enum=$enum does not have value=$val"))
+    end
+
+    return ENUM_MAPPINGS[enum][val]
+end
+
+Base.convert(::Type{BuildStatus}, val::String) = get_enum_value(BuildStatus, val)
+Base.convert(::Type{RunStatus}, val::String) = get_enum_value(RunStatus, val)
+Base.convert(::Type{SOSStatusVariable}, x::String) = get_enum_value(SOSStatusVariable, x)

--- a/src/core/simulation.jl
+++ b/src/core/simulation.jl
@@ -2,6 +2,8 @@
 const _PROGRESS_METER_ENABLED =
     !(isa(stderr, Base.TTY) == false || (get(ENV, "CI", nothing) == "true"))
 
+const RESULTS_DIR = "results"
+
 mutable struct SimulationInternal
     sim_files_dir::String
     store_dir::String
@@ -53,7 +55,7 @@ function SimulationInternal(
     logs_dir = joinpath(simulation_dir, "logs")
     models_dir = joinpath(simulation_dir, "problems")
     recorder_dir = joinpath(simulation_dir, "recorder")
-    results_dir = joinpath(simulation_dir, "results")
+    results_dir = joinpath(simulation_dir, RESULTS_DIR)
 
     for path in (
         simulation_dir,
@@ -1019,6 +1021,7 @@ function execute!(sim::Simulation; kwargs...)
         close(logger)
     end
     compute_file_hash(get_store_dir(sim), HDF_FILENAME)
+    serialize_status(sim)
     return get_simulation_status(sim)
 end
 
@@ -1326,7 +1329,7 @@ function serialize_simulation(sim::Simulation; path = nothing, force = false)
         get_name(sim),
     )
     Serialization.serialize(filename, obj)
-    @info "Serialized simulation" get_name(sim) directory
+    @info "Serialized simulation name = $(get_name(sim))" directory
     return directory
 end
 
@@ -1381,4 +1384,31 @@ function deserialize_model(
     finally
         cd(orig)
     end
+end
+
+function serialize_status(sim::Simulation)
+    data = Dict("run_status" => string(get_simulation_status(sim)))
+    filename = joinpath(get_results_dir(sim), "status.json")
+    open(filename, "w") do io
+        JSON3.write(io, data)
+    end
+
+    return
+end
+
+function deserialize_status(sim::Simulation)
+    return deserialize_status(get_results_dir(sim))
+end
+
+function deserialize_status(results_path::AbstractString)
+    filename = joinpath(results_path, "status.json")
+    if !isfile(filename)
+        error("run status file $filename does not exist")
+    end
+
+    data = open(filename, "r") do io
+        JSON3.read(io, Dict)
+    end
+
+    return get_enum_value(RunStatus, data["run_status"])
 end

--- a/test/test_simulation_results.jl
+++ b/test/test_simulation_results.jl
@@ -121,6 +121,14 @@ function test_simulation_results(file_path::String, export_path)
         results_uc = get_problem_results(results, "UC")
         results_ed = get_problem_results(results, "ED")
 
+        @test get_system(results_uc) === nothing
+        @test_throws IS.InvalidValue set_system!(results_uc, c_sys5_hy_ed)
+        set_system!(results_uc, c_sys5_hy_uc)
+        @test IS.get_uuid(get_system!(results_uc)) === IS.get_uuid(c_sys5_hy_uc)
+
+        @test get_system(results_ed) === nothing
+        @test IS.get_uuid(get_system!(results_ed)) === IS.get_uuid(c_sys5_hy_ed)
+
         results_from_file = SimulationResults(joinpath(file_path, "cache"))
         @test list_problems(results) == ["ED", "UC"]
         results_uc_from_file = get_problem_results(results_from_file, "UC")

--- a/test/test_simulation_results.jl
+++ b/test/test_simulation_results.jl
@@ -48,10 +48,6 @@ end
 
 function test_simulation_results(file_path::String, export_path)
     @testset "Test simulation results" begin
-        #file_path = "test_sim"
-        #isdir(file_path) && rm(file_path, recursive=true)
-        #mkpath(file_path)
-        #export_path="export_path"
         template_uc = get_template_hydro_st_uc()
         template_ed = get_template_hydro_st_ed()
         c_sys5_hy_uc = PSB.build_system(PSITestSystems, "c_sys5_hy_uc")
@@ -311,6 +307,17 @@ function test_simulation_results(file_path::String, export_path)
         @test isempty(results)
 
         verify_export_results(results, export_path)
+
+        # Test that you can't read a failed simulation.
+        PSI.set_simulation_status!(sim, RunStatus.FAILED)
+        PSI.serialize_status(sim)
+        @test PSI.deserialize_status(sim) == RunStatus.FAILED
+        @test_throws ErrorException SimulationResults(sim)
+        @test_logs(
+            match_mode = :any,
+            (:warn, r"Results may not be valid"),
+            SimulationResults(sim, ignore_status = true),
+        )
     end
 end
 


### PR DESCRIPTION
1. Serialize the status of a simulation so that if a user tries to load results for a failed simulation, it will fail by default.
2. Do not load systems by default in SimulationResults. Deserialize on the first access by the user or let the user set them manually.