### PR TITLE
Prefetch sequential reads of time series data

### DIFF
--- a/src/core/operations_problem.jl
+++ b/src/core/operations_problem.jl
@@ -287,7 +287,7 @@ set_run_status!(problem::OperationsProblem, status) = problem.internal.run_statu
 get_time_series_cache(problem::OperationsProblem) = problem.internal.time_series_cache
 empty_time_series_cache!(x::OperationsProblem) = empty!(get_time_series_cache(x))
 
-function get_time_series_array!(
+function get_time_series_values!(
     time_series_type::Type{<:IS.TimeSeriesData},
     problem::OperationsProblem,
     component,
@@ -325,7 +325,7 @@ function get_time_series_array!(
 
     ts = IS.get_next_time_series_array!(ts_cache)
     @assert_op IS.get_initial_timestamp(ts) == initial_time
-    return ts
+    return TimeSeries.values(ts)
 end
 
 function make_time_series_cache(

--- a/src/core/operations_problem.jl
+++ b/src/core/operations_problem.jl
@@ -327,8 +327,7 @@ function get_time_series_values!(
         cache[key] = ts_cache
     end
 
-    ts = IS.get_next_time_series_array!(ts_cache)
-    @assert_op IS.get_initial_timestamp(ts) == initial_time
+    ts = IS.get_time_series_array!(ts_cache, initial_time)
     return TimeSeries.values(ts)
 end
 

--- a/src/core/param_result_cache.jl
+++ b/src/core/param_result_cache.jl
@@ -30,7 +30,7 @@ get_cache_hit_percentage(x::ParamResultCache) = get_cache_hit_percentage(x.stats
 get_size(x::ParamResultCache) = length(x) * x.size_per_entry
 has_clean(x::ParamResultCache) = !isempty(x.data) && !is_dirty(x, first(keys(x.data)))
 has_dirty(x::ParamResultCache) = !isempty(x.dirty_timestamps)
-is_dirty(x::ParamResultCache, t) = t >= first(keys(x.dirty_timestamps))
+is_dirty(x::ParamResultCache, t) = t >= first(x.dirty_timestamps)
 should_keep_in_cache(x::ParamResultCache) = x.flush_rule.keep_in_cache
 
 function Base.empty!(cache::ParamResultCache)

--- a/src/core/settings.jl
+++ b/src/core/settings.jl
@@ -2,6 +2,7 @@ struct Settings
     horizon::Base.RefValue{Int}
     use_forecast_data::Bool
     use_parameters::Base.RefValue{Bool}
+    time_series_cache_size::Int
     warm_start::Base.RefValue{Bool}
     balance_slack_variables::Bool
     services_slack_variables::Bool
@@ -21,6 +22,7 @@ function Settings(
     initial_time::Dates.DateTime = UNSET_INI_TIME,
     use_parameters::Bool = false,
     use_forecast_data::Bool = true,
+    time_series_cache_size::Int = IS.TIME_SERIES_CACHE_SIZE_BYTES,
     warm_start::Bool = true,
     balance_slack_variables::Bool = false,
     services_slack_variables::Bool = false,
@@ -38,6 +40,7 @@ function Settings(
         Ref(horizon),
         use_forecast_data,
         Ref(use_parameters),
+        time_series_cache_size,
         Ref(warm_start),
         balance_slack_variables,
         services_slack_variables,
@@ -51,6 +54,19 @@ function Settings(
         allow_fails,
         ext,
     )
+end
+
+function log_values(settings::Settings)
+    text = Vector{String}()
+    for (name, type) in zip(fieldnames(Settings), fieldtypes(Settings))
+        val = getfield(settings, name)
+        if type <: Base.RefValue
+            val = val[]
+        end
+        push!(text, "$name = $val")
+    end
+
+    @info "Settings: $(join(text, ", "))"
 end
 
 function copy_for_serialization(settings::Settings)
@@ -103,6 +119,7 @@ get_system_to_file(settings::Settings) = settings.system_to_file
 get_export_pwl_vars(settings::Settings) = settings.export_pwl_vars
 get_allow_fails(settings::Settings) = settings.allow_fails
 get_optimizer_log_print(settings::Settings) = settings.optimizer_log_print
+use_time_series_cache(settings::Settings) = settings.time_series_cache_size > 0
 
 function set_horizon!(settings::Settings, horizon::Int)
     settings.horizon[] = horizon

--- a/src/core/settings.jl
+++ b/src/core/settings.jl
@@ -36,6 +36,12 @@ function Settings(
     allow_fails = false,
     ext = Dict{String, Any}(),
 )
+    if time_series_cache_size > 0 &&
+       sys.data.time_series_storage isa IS.InMemoryTimeSeriesStorage
+        @info "Overriding time_series_cache_size because time series is stored in memory"
+        time_series_cache_size = 0
+    end
+
     return Settings(
         Ref(horizon),
         use_forecast_data,

--- a/src/core/simulation.jl
+++ b/src/core/simulation.jl
@@ -835,12 +835,11 @@ function update_parameter!(
     problem::OperationsProblem,
     sim::Simulation,
 ) where {T <: PSY.Component}
-    TimerOutputs.@timeit RUN_SIMULATION_TIMER "update_parameter!" begin
+    TimerOutputs.@timeit RUN_SIMULATION_TIMER "ts_update_parameter!" begin
         components = get_available_components(T, problem.sys)
         initial_forecast_time = get_simulation_time(sim, get_simulation_number(problem))
         horizon = length(model_time_steps(problem.internal.optimization_container))
         for d in components
-            # RECORDER TODO: Parameter Update from forecast
             ts_vector = get_time_series_values!(
                 PSY.Deterministic,
                 problem,
@@ -867,8 +866,7 @@ function update_parameter!(
     problem::OperationsProblem,
     sim::Simulation,
 ) where {T <: PSY.Service}
-    # RECORDER TODO: Parameter Update from forecast
-    TimerOutputs.@timeit RUN_SIMULATION_TIMER "update_parameter!" begin
+    TimerOutputs.@timeit RUN_SIMULATION_TIMER "ts_update_parameter!" begin
         components = get_available_components(T, problem.sys)
         initial_forecast_time = get_simulation_time(sim, get_simulation_number(problem))
         horizon = length(model_time_steps(problem.internal.optimization_container))

--- a/src/core/simulation.jl
+++ b/src/core/simulation.jl
@@ -841,16 +841,14 @@ function update_parameter!(
     for d in components
         # RECORDER TODO: Parameter Update from forecast
         TimerOutputs.@timeit RUN_SIMULATION_TIMER "GetTimeSeries" begin
-            ts_vector = TimeSeries.values(
-                get_time_series_array!(
-                    PSY.Deterministic,
-                    problem,
-                    d,
-                    get_data_label(param_reference),
-                    initial_forecast_time,
-                    horizon,
-                    ignore_scaling_factors = true,
-                ),
+            ts_vector = get_time_series_values!(
+                PSY.Deterministic,
+                problem,
+                d,
+                get_data_label(param_reference),
+                initial_forecast_time,
+                horizon,
+                ignore_scaling_factors = true,
             )
         end
         component_name = PSY.get_name(d)
@@ -877,16 +875,14 @@ function update_parameter!(
     for ix in axes(param_array)[1]
         service = PSY.get_component(T, problem.sys, ix)
         TimerOutputs.@timeit RUN_SIMULATION_TIMER "GetTimeSeries" begin
-            ts_vector = TimeSeries.values(
-                get_time_series_array!(
-                    PSY.Deterministic,
-                    problem,
-                    service,
-                    get_data_label(param_reference),
-                    initial_forecast_time,
-                    horizon,
-                    ignore_scaling_factors = true,
-                ),
+            get_time_series_values!(
+                PSY.Deterministic,
+                problem,
+                service,
+                get_data_label(param_reference),
+                initial_forecast_time,
+                horizon,
+                ignore_scaling_factors = true,
             )
         end
         for (jx, value) in enumerate(ts_vector)

--- a/src/core/simulation.jl
+++ b/src/core/simulation.jl
@@ -840,7 +840,7 @@ function update_parameter!(
     horizon = length(model_time_steps(problem.internal.optimization_container))
     for d in components
         # RECORDER TODO: Parameter Update from forecast
-        TimerOutputs.@timeit RUN_SIMULATION_TIMER "ReadCachedTimeSeries" begin
+        TimerOutputs.@timeit RUN_SIMULATION_TIMER "GetTimeSeries" begin
             ts_vector = TimeSeries.values(
                 get_time_series_array!(
                     PSY.Deterministic,
@@ -848,6 +848,7 @@ function update_parameter!(
                     d,
                     get_data_label(param_reference),
                     initial_forecast_time,
+                    horizon,
                     ignore_scaling_factors = true,
                 ),
             )
@@ -875,7 +876,7 @@ function update_parameter!(
     param_array = get_parameter_array(container)
     for ix in axes(param_array)[1]
         service = PSY.get_component(T, problem.sys, ix)
-        TimerOutputs.@timeit RUN_SIMULATION_TIMER "ReadCachedTimeSeries" begin
+        TimerOutputs.@timeit RUN_SIMULATION_TIMER "GetTimeSeries" begin
             ts_vector = TimeSeries.values(
                 get_time_series_array!(
                     PSY.Deterministic,
@@ -883,6 +884,7 @@ function update_parameter!(
                     service,
                     get_data_label(param_reference),
                     initial_forecast_time,
+                    horizon,
                     ignore_scaling_factors = true,
                 ),
             )

--- a/src/core/simulation.jl
+++ b/src/core/simulation.jl
@@ -835,12 +835,12 @@ function update_parameter!(
     problem::OperationsProblem,
     sim::Simulation,
 ) where {T <: PSY.Component}
-    components = get_available_components(T, problem.sys)
-    initial_forecast_time = get_simulation_time(sim, get_simulation_number(problem))
-    horizon = length(model_time_steps(problem.internal.optimization_container))
-    for d in components
-        # RECORDER TODO: Parameter Update from forecast
-        TimerOutputs.@timeit RUN_SIMULATION_TIMER "GetTimeSeries" begin
+    TimerOutputs.@timeit RUN_SIMULATION_TIMER "update_parameter!" begin
+        components = get_available_components(T, problem.sys)
+        initial_forecast_time = get_simulation_time(sim, get_simulation_number(problem))
+        horizon = length(model_time_steps(problem.internal.optimization_container))
+        for d in components
+            # RECORDER TODO: Parameter Update from forecast
             ts_vector = get_time_series_values!(
                 PSY.Deterministic,
                 problem,
@@ -850,11 +850,11 @@ function update_parameter!(
                 horizon,
                 ignore_scaling_factors = true,
             )
-        end
-        component_name = PSY.get_name(d)
-        for (ix, val) in enumerate(get_parameter_array(container)[component_name, :])
-            value = ts_vector[ix]
-            JuMP.set_value(val, value)
+            component_name = PSY.get_name(d)
+            for (ix, val) in enumerate(get_parameter_array(container)[component_name, :])
+                value = ts_vector[ix]
+                JuMP.set_value(val, value)
+            end
         end
     end
 
@@ -868,14 +868,14 @@ function update_parameter!(
     sim::Simulation,
 ) where {T <: PSY.Service}
     # RECORDER TODO: Parameter Update from forecast
-    components = get_available_components(T, problem.sys)
-    initial_forecast_time = get_simulation_time(sim, get_simulation_number(problem))
-    horizon = length(model_time_steps(problem.internal.optimization_container))
-    param_array = get_parameter_array(container)
-    for ix in axes(param_array)[1]
-        service = PSY.get_component(T, problem.sys, ix)
-        TimerOutputs.@timeit RUN_SIMULATION_TIMER "GetTimeSeries" begin
-            get_time_series_values!(
+    TimerOutputs.@timeit RUN_SIMULATION_TIMER "update_parameter!" begin
+        components = get_available_components(T, problem.sys)
+        initial_forecast_time = get_simulation_time(sim, get_simulation_number(problem))
+        horizon = length(model_time_steps(problem.internal.optimization_container))
+        param_array = get_parameter_array(container)
+        for ix in axes(param_array)[1]
+            service = PSY.get_component(T, problem.sys, ix)
+            ts_vector = get_time_series_values!(
                 PSY.Deterministic,
                 problem,
                 service,
@@ -884,9 +884,9 @@ function update_parameter!(
                 horizon,
                 ignore_scaling_factors = true,
             )
-        end
-        for (jx, value) in enumerate(ts_vector)
-            JuMP.set_value(get_parameter_array(container)[ix, jx], value)
+            for (jx, value) in enumerate(ts_vector)
+                JuMP.set_value(get_parameter_array(container)[ix, jx], value)
+            end
         end
     end
 

--- a/test/test_simulation_results.jl
+++ b/test/test_simulation_results.jl
@@ -52,13 +52,20 @@ function test_simulation_results(file_path::String, export_path)
         template_ed = get_template_hydro_st_ed()
         c_sys5_hy_uc = PSB.build_system(PSITestSystems, "c_sys5_hy_uc")
         c_sys5_hy_ed = PSB.build_system(PSITestSystems, "c_sys5_hy_ed")
+        time_series_cache_size = 0  # This is only for test coverage.
         problems = SimulationProblems(
-            UC = OperationsProblem(template_uc, c_sys5_hy_uc; optimizer = GLPK_optimizer),
+            UC = OperationsProblem(
+                template_uc,
+                c_sys5_hy_uc;
+                optimizer = GLPK_optimizer,
+                time_series_cache_size = time_series_cache_size,
+            ),
             ED = OperationsProblem(
                 template_ed,
                 c_sys5_hy_ed;
                 optimizer = GLPK_optimizer,
                 constraint_duals = [:CopperPlateBalance],
+                time_series_cache_size = time_series_cache_size,
             ),
         )
 


### PR DESCRIPTION
This PR improves performance when time series data is read during a simulation.

The current implementation repeatedly reads in very small increments. Suppose a simulation has many components with Deterministic forecasts with a horizon of 24. It will read 24 floats for every component at every execution. 24 x 8 = 192 bytes. This is very inefficient for the OS and storage system. When reading sequentially, which is what we do here, it is much better to read in large chunks.

This PR uses a feature in InfrastructureSystems to prefetch 1 MiB of chronological time series data for each time array into cache at a time and then service the small reads from that cache.

Here is before & after data from a simulation with a System that has 1350 Deterministic forecasts across components. This shows that the implementation will scale very well with simulations with increasing numbers of steps.

These simulations were run on a system with a modern, fast SSD. The gains will be significantly higher if the simulation is run on a computer with spinning disks.

```
➜  test grep ReadForecast standard/4/logs/simulation.log | head
│          Section       ncalls   time   %tot     avg     alloc   %tot      avg
│          ReadForecast  1.35k    618ms  0.10%   456μs   14.9MiB  0.02%  11.3KiB
│          ReadForecast  1.35k    593ms  0.10%   437μs   14.9MiB  0.02%  11.3KiB
│          ReadForecast  1.35k    561ms  0.09%   414μs   14.9MiB  0.02%  11.3KiB
│          ReadForecast  1.35k    562ms  0.09%   415μs   14.9MiB  0.02%  11.3KiB
│          ReadForecast  1.35k    607ms  0.10%   448μs   14.9MiB  0.02%  11.3KiB
│          ReadForecast  1.35k    557ms  0.09%   411μs   14.9MiB  0.02%  11.3KiB
│          ReadForecast  1.35k    580ms  0.09%   428μs   14.9MiB  0.02%  11.3KiB
│          ReadForecast  1.35k    562ms  0.09%   415μs   14.9MiB  0.02%  11.3KiB
│          ReadForecast  1.35k    594ms  0.10%   439μs   14.9MiB  0.02%  11.3KiB
│          ReadForecast  1.35k    570ms  0.09%   420μs   14.9MiB  0.02%  11.3KiB
➜  test grep ReadForecast standard/8/logs/simulation.log | head
│          Section       ncalls   time   %tot     avg     alloc   %tot      avg
│          ReadForecast  1.35k    11.4s  2.26%  8.41ms   7.02GiB  9.50%  5.31MiB
│          ReadForecast  1.35k   8.29ms  0.00%  6.12μs   2.54MiB  0.00%  1.92KiB
│          ReadForecast  1.35k   8.54ms  0.00%  6.30μs   2.54MiB  0.00%  1.92KiB
│          ReadForecast  1.35k   8.76ms  0.00%  6.47μs   2.54MiB  0.00%  1.92KiB
│          ReadForecast  1.35k   8.09ms  0.00%  5.97μs   2.54MiB  0.00%  1.92KiB
│          ReadForecast  1.35k   8.48ms  0.00%  6.26μs   2.54MiB  0.00%  1.92KiB
│          ReadForecast  1.35k   8.41ms  0.00%  6.21μs   2.54MiB  0.00%  1.92KiB
│          ReadForecast  1.35k   8.66ms  0.00%  6.39μs   2.54MiB  0.00%  1.92KiB
│          ReadForecast  1.35k   8.43ms  0.00%  6.22μs   2.54MiB  0.00%  1.92KiB
│          ReadForecast  1.35k   8.48ms  0.00%  6.26μs   2.54MiB  0.00%  1.92KiB
```

Before merging we need to run a comparable test on a system that transforms SingleTimeSeries to DeterministicSingleTimeSeries.