### PR TITLE
resolving bug in PTDF with lines and transformers

### DIFF
--- a/src/core/constraints.jl
+++ b/src/core/constraints.jl
@@ -52,6 +52,7 @@ const MUST_RUN = "must_run"
 const MUST_RUN_LB = "must_run_lb"
 const NODAL_BALANCE_ACTIVE = "nodal_balance_active"
 const NODAL_BALANCE_REACTIVE = "nodal_balance_reactive"
+const NETWORK_FLOW = "network_flow"
 
 abstract type ConstraintType end
 

--- a/src/core/optimization_container.jl
+++ b/src/core/optimization_container.jl
@@ -421,11 +421,7 @@ function add_cons_container!(
         end
         assign_constraint!(optimization_container, cons_name, container)
     else
-<<<<<<< HEAD
         Throw(error("constraint container already exists: $cons_name"))
-=======
-        container = optimization_container.constraints[cons_name]
->>>>>>> d291bef1488cc4383402b03d2e60be0df2477574
     end
     return container
 end

--- a/src/core/optimization_container.jl
+++ b/src/core/optimization_container.jl
@@ -413,12 +413,16 @@ function add_cons_container!(
     axs...;
     sparse = false,
 )
-    if sparse
-        container = sparse_container_spec(optimization_container.JuMPmodel, axs...)
+    if !haskey(optimization_container.constraints, cons_name)
+        if sparse
+            container = sparse_container_spec(optimization_container.JuMPmodel, axs...)
+        else
+            container = JuMPConstraintArray(undef, axs...)
+        end
+        assign_constraint!(optimization_container, cons_name, container)
     else
-        container = JuMPConstraintArray(undef, axs...)
+        Throw(error("constraint container already exists: $cons_name"))
     end
-    assign_constraint!(optimization_container, cons_name, container)
     return container
 end
 

--- a/src/devices_models/device_constructors/branch_constructor.jl
+++ b/src/devices_models/device_constructors/branch_constructor.jl
@@ -210,8 +210,9 @@ function construct_device!(
         return
     end
 
-    add_variables!(optimization_container, FlowActivePowerFromToVariable, devices, U())
-    add_variables!(optimization_container, FlowActivePowerToFromVariable, devices, U())
+    #add_variables!(optimization_container, FlowActivePowerFromToVariable, devices, U())
+    #add_variables!(optimization_container, FlowActivePowerToFromVariable, devices, U())
+    add_variables!(optimization_container, FlowActivePowerVariable, devices, U())
 
     branch_rate_constraints!(
         optimization_container,

--- a/src/devices_models/device_constructors/branch_constructor.jl
+++ b/src/devices_models/device_constructors/branch_constructor.jl
@@ -210,8 +210,6 @@ function construct_device!(
         return
     end
 
-    #add_variables!(optimization_container, FlowActivePowerFromToVariable, devices, U())
-    #add_variables!(optimization_container, FlowActivePowerToFromVariable, devices, U())
     add_variables!(optimization_container, FlowActivePowerVariable, devices, U())
 
     branch_rate_constraints!(

--- a/src/devices_models/devices/AC_branches.jl
+++ b/src/devices_models/devices/AC_branches.jl
@@ -151,12 +151,11 @@ function branch_flow_values!(
     ::Type{StandardPTDFModel},
 ) where {B <: PSY.ACBranch}
     ptdf = get_PTDF(optimization_container)
-    buses = ptdf.axes[2]
-    branches = ptdf.axes[1]
+    branches = PSY.get_name.(devices)
     time_steps = model_time_steps(optimization_container)
-    constraint_val = JuMPConstraintArray(undef, time_steps)
+    constraint_name = make_constraint_name(NETWORK_FLOW, B)
     branch_flow =
-        add_cons_container!(optimization_container, :network_flow, branches, time_steps)
+        add_cons_container!(optimization_container, constraint_name, branches, time_steps)
     nodal_balance_expressions = optimization_container.expressions[:nodal_balance_active]
     flow_variables = get_variable(optimization_container, FLOW_ACTIVE_POWER, B)
     jump_model = get_jump_model(optimization_container)

--- a/src/devices_models/devices/hydro_generation.jl
+++ b/src/devices_models/devices/hydro_generation.jl
@@ -379,11 +379,7 @@ function commit_hydro_active_power_ub!(
     if use_parameters || use_forecasts
         spec = DeviceRangeConstraintSpec(;
             timeseries_range_constraint_spec = TimeSeriesConstraintSpec(
-                constraint_name = make_constraint_name(
-                    RangeConstraint,
-                    ActivePowerVariable,
-                    V,
-                ),
+                constraint_name = make_constraint_name(COMMITMENT, V),
                 variable_name = make_variable_name(ActivePowerVariable, V),
                 parameter_name = use_parameters ? ACTIVE_POWER : nothing,
                 forecast_label = "max_active_power",

--- a/src/network_models/powermodels_interface.jl
+++ b/src/network_models/powermodels_interface.jl
@@ -375,10 +375,7 @@ function PMvarmap(system_formulation::Type{S}) where {S <: PM.AbstractActivePowe
     pm_var_map = Dict{Type, Dict{Symbol, Union{String, NamedTuple}}}()
 
     pm_var_map[PSY.Bus] = Dict(:va => THETA)
-    pm_var_map[PSY.ACBranch] = Dict(
-        :p => FlowActivePowerFromToVariable,
-        #(from_to = FlowActivePowerFromToVariable, to_from = FlowActivePowerToFromVariable),
-    )
+    pm_var_map[PSY.ACBranch] = Dict(:p => FlowActivePowerFromToVariable)
     pm_var_map[PSY.DCBranch] = Dict(
         :p_dc => (
             from_to = FlowActivePowerFromToVariable,
@@ -415,8 +412,8 @@ function PMvarmap(system_formulation::Type{S}) where {S <: PM.AbstractPowerModel
     )
     pm_var_map[PSY.DCBranch] = Dict(
         :p_dc => (
-            from_to = FlowActivePowerFromToVariable,
-            to_from = FlowActivePowerToFromVariable,
+            from_to = FlowActivePowerVariable,#FlowActivePowerFromToVariable,
+            to_from = nothing,#FlowActivePowerToFromVariable,
         ),
         :q_dc => (
             from_to = FlowReactivePowerFromToVariable,
@@ -467,7 +464,7 @@ function PMexprmap(system_formulation::Type{PTDFPowerModel})
 
     pm_expr_map[PSY.ACBranch] = (
         pm_expr = Dict(:p => (from_to = FlowActivePowerVariable, to_from = nothing)),
-        psi_con = :network_flow,
+        psi_con = Symbol(NETWORK_FLOW),
     )
 
     return pm_expr_map
@@ -658,9 +655,10 @@ function add_pm_expr_refs!(
                         make_variable_name(var_type, d_type),
                     )
 
-                    psi_con_container = PSI.add_cons_container!(
+                    con_name = make_constraint_name(pm_expr_map[d_class].psi_con, d_type)
+                    psi_con_container = add_cons_container!(
                         optimization_container,
-                        pm_expr_map[d_class].psi_con,
+                        con_name,
                         mapped_ps_device_names,
                         time_steps,
                     )

--- a/src/network_models/powermodels_interface.jl
+++ b/src/network_models/powermodels_interface.jl
@@ -411,10 +411,7 @@ function PMvarmap(system_formulation::Type{S}) where {S <: PM.AbstractPowerModel
         ),
     )
     pm_var_map[PSY.DCBranch] = Dict(
-        :p_dc => (
-            from_to = FlowActivePowerVariable,#FlowActivePowerFromToVariable,
-            to_from = nothing,#FlowActivePowerToFromVariable,
-        ),
+        :p_dc => (from_to = FlowActivePowerVariable, to_from = nothing),
         :q_dc => (
             from_to = FlowReactivePowerFromToVariable,
             to_from = FlowReactivePowerToFromVariable,

--- a/test/test_device_branch_constructors.jl
+++ b/test/test_device_branch_constructors.jl
@@ -93,8 +93,11 @@ end
     transformer = PSY.get_component(Transformer2W, system, "Trans4")
     rate_limit2w = PSY.get_rate(tap_transformer)
 
-    for model in [DCPPowerModel, StandardPTDFModel]
+    for model in [DCPPowerModel, StandardPTDFModel],
+        hvdc_model in [HVDCDispatch, HVDCLossless]
+
         template = get_template_dispatch_with_network(model)
+        set_device_model!(template, HVDCLine, hvdc_model)
         op_problem_m = OperationsProblem(
             template,
             system;
@@ -229,7 +232,7 @@ end
           PSI.BuildStatus.BUILT
 
     check_variable_bounded(op_problem_m, :FqTF__HVDCLine)
-    check_variable_bounded(op_problem_m, :FpTF__HVDCLine)
+    check_variable_bounded(op_problem_m, :Fp__HVDCLine)
     @test check_variable_bounded(op_problem_m, :FpFT__TapTransformer)
     @test check_variable_unbounded(op_problem_m, :FqFT__TapTransformer)
     @test check_variable_bounded(op_problem_m, :FpTF__Transformer2W)
@@ -241,7 +244,7 @@ end
 
     @test check_flow_variable_values(
         op_problem_m,
-        :FpTF__HVDCLine,
+        :Fp__HVDCLine,
         :FqTF__HVDCLine,
         "DCLine3",
         limits_max,

--- a/test/test_network_constructors.jl
+++ b/test/test_network_constructors.jl
@@ -94,7 +94,7 @@ end
     systems = [c_sys5, c_sys14, c_sys14_dc]
     objfuncs = [GAEVF, GQEVF, GQEVF]
     constraint_names =
-        [:RateLimit_lb__Line, :RateLimit_ub__Line, :CopperPlateBalance, :network_flow]
+        [:RateLimit_lb__Line, :RateLimit_ub__Line, :CopperPlateBalance, :network_flow__Line]
     parameters = [true, false]
     PTDF_ref = IdDict{System, PTDF}(
         c_sys5 => PTDF(c_sys5),
@@ -158,7 +158,7 @@ end
     systems = [c_sys5, c_sys14, c_sys14_dc]
     objfuncs = [GAEVF, GQEVF, GQEVF]
     constraint_names =
-        [:RateLimit_lb__Line, :RateLimit_ub__Line, :CopperPlateBalance, :network_flow]
+        [:RateLimit_lb__Line, :RateLimit_ub__Line, :CopperPlateBalance, :network_flow__Line]
     parameters = [true, false]
     test_results = IdDict{System, Vector{Int}}(
         c_sys5 => [264, 0, 264, 264, 168],

--- a/test/test_operations_problem.jl
+++ b/test/test_operations_problem.jl
@@ -157,7 +157,8 @@ end
     parameters = [true, false]
     ptdf = PTDF(sys)
     # These are the duals of interest for the test
-    dual_constraint = [[:nodal_balance_active__Bus], [:CopperPlateBalance, :network_flow]]
+    dual_constraint =
+        [[:nodal_balance_active__Bus], [:CopperPlateBalance, :network_flow__Line]]
     LMPs = []
     for (ix, network) in enumerate(networks), p in parameters
         template = get_template_dispatch_with_network(network)

--- a/test/test_operations_problem.jl
+++ b/test/test_operations_problem.jl
@@ -177,15 +177,14 @@ end
 
         # These tests require results to be working
         if network == StandardPTDFModel
-            # TODO PENDING TESTS: what is ps_model?
-            #push!(LMPs, abs.(psi_ptdf_lmps(ps_model, ptdf)))
+            push!(LMPs, abs.(psi_ptdf_lmps(res, ptdf)))
         else
-            # TODO PENDING TESTS: this now includes a DateTime column. should this run on all other
-            # columns?
-            #duals = abs.(res.dual_values[:nodal_balance_active__Bus])
-            #push!(LMPs, duals[!, sort(propertynames(duals))])
+            duals = res.dual_values[:nodal_balance_active__Bus]
+            duals = abs.(duals[:, propertynames(duals) .!== :DateTime])
+            push!(LMPs, duals[!, sort(propertynames(duals))])
         end
     end
+    # TODO: the above calculation executes, but the following test does not pass
     #@test isapprox(convert(Array, LMPs[1]), convert(Array, LMPs[2]), atol = 100.0)
 end
 

--- a/test/test_utils/model_checks.jl
+++ b/test/test_utils/model_checks.jl
@@ -89,7 +89,7 @@ function psi_ptdf_lmps(res::ProblemResults, ptdf)
         hcat([duals[k][:, propertynames(duals[k]) .!== :DateTime] for k in nf_duals]...)
     μ = Matrix(flow_duals[:, ptdf.axes[1]])
 
-    buses = get_components(Bus, sys)
+    buses = get_components(Bus, get_system(res))
     lmps = OrderedDict()
     for bus in buses
         lmps[get_name(bus)] = μ * ptdf[:, get_number(bus)]

--- a/test/test_utils/model_checks.jl
+++ b/test/test_utils/model_checks.jl
@@ -83,7 +83,7 @@ end
 function psi_ptdf_lmps(op_problem::OperationsProblem, ptdf)
     res = solve!(op_problem)
     λ = convert(Array, res.dual_values[:CopperPlateBalance])
-    μ = convert(Array, res.dual_values[:network_flow])
+    μ = convert(Array, res.dual_values[:network_flow__Line]) #TODO: should this collect all branch network flows
     buses = get_components(Bus, op_problem.sys)
     lmps = OrderedDict()
     for bus in buses

--- a/test/test_utils/model_checks.jl
+++ b/test/test_utils/model_checks.jl
@@ -80,18 +80,22 @@ function psi_checksolve_test(
     @test isapprox(obj_value, expected_result, atol = tol)
 end
 
-function psi_ptdf_lmps(op_problem::OperationsProblem, ptdf)
-    res = solve!(op_problem)
-    λ = convert(Array, res.dual_values[:CopperPlateBalance])
-    μ = convert(Array, res.dual_values[:network_flow__Line]) #TODO: should this collect all branch network flows
-    buses = get_components(Bus, op_problem.sys)
+function psi_ptdf_lmps(res::OperationsProblemResults, ptdf)
+    duals = get_duals(res)
+    λ = convert(Array, duals[:CopperPlateBalance][:, :var])
+
+    nf_duals = collect(keys(duals))[occursin.(PSI.NETWORK_FLOW, string.(keys(duals)))]
+    flow_duals =
+        hcat([duals[k][:, propertynames(duals[k]) .!== :DateTime] for k in nf_duals]...)
+    μ = Matrix(flow_duals[:, ptdf.axes[1]])
+
+    buses = get_components(Bus, sys)
     lmps = OrderedDict()
     for bus in buses
         lmps[get_name(bus)] = μ * ptdf[:, get_number(bus)]
     end
-    lmps = DataFrame(lmps)
-    lmps = λ .- lmps
-    return lmps[!, sort(propertynames(lmps))]
+    lmp = λ .- DataFrames.DataFrame(lmps)
+    return lmp[!, sort(propertynames(lmp))]
 end
 
 function check_variable_unbounded(op_problem::OperationsProblem, var_name)

--- a/test/test_utils/model_checks.jl
+++ b/test/test_utils/model_checks.jl
@@ -80,7 +80,7 @@ function psi_checksolve_test(
     @test isapprox(obj_value, expected_result, atol = tol)
 end
 
-function psi_ptdf_lmps(res::OperationsProblemResults, ptdf)
+function psi_ptdf_lmps(res::ProblemResults, ptdf)
     duals = get_duals(res)
     λ = convert(Array, duals[:CopperPlateBalance][:, :var])
 


### PR DESCRIPTION
This PR addresses a bug where the :network_flow constraint container was being created for every branch device type, overwriting previous instances of the container.