### PR TITLE
Add constraint keys

### DIFF
--- a/src/PowerSimulations.jl
+++ b/src/PowerSimulations.jl
@@ -220,41 +220,73 @@ export TimeDurationOff
 export PowerOutput
 
 # Constraints
-export ACTIVE
-export ACTIVE_RANGE
-export ACTIVE_RANGE_LB
-export ACTIVE_RANGE_UB
-export COMMITMENT
-export DURATION
-export DURATION_DOWN
-export DURATION_UP
-export ENERGY_CAPACITY
-export ENERGY_LIMIT
-export FEEDFORWARD
-export FEEDFORWARD_UB
-export FEEDFORWARD_BIN
-export FEEDFORWARD_INTEGRAL_LIMIT
-export FLOW_LIMIT
-export FLOW_LIMIT_FROM_TO
-export FLOW_LIMIT_TO_FROM
-export FLOW_REACTIVE_POWER_FROM_TO
-export FLOW_REACTIVE_POWER_TO_FROM
-export FLOW_ACTIVE_POWER_FROM_TO
-export FLOW_ACTIVE_POWER_TO_FROM
-export FLOW_ACTIVE_POWER
-export FLOW_REACTIVE_POWER
-export INPUT_POWER_RANGE
-export OUTPUT_POWER_RANGE
-export RAMP
-export RAMP_DOWN
-export RAMP_UP
-export RATE_LIMIT
-export RATE_LIMIT_FT
-export RATE_LIMIT_TF
-export REACTIVE
-export REACTIVE_RANGE
-export REQUIREMENT
-export INFLOW_RANGE
+export AbsoluteValueConstraint
+export ActiveConstraint
+export ActivePowerVariableLimitsConstraint
+export ActiveRangeConstraint
+export ActiveRangeICConstraint
+export AreaDispatchBalanceConstraint
+export AreaParticipationAssignmentConstraint
+export BalanceAuxConstraint
+export CommitmentConstraint
+export CopperPlateBalanceConstraint
+export DeltaActivePowerDownVariableLimitsConstraint
+export DeltaActivePowerUpVariableLimitsConstraint
+export DurationConstraint
+export EnergyBalanceConstraint
+export EnergyBudgetConstraint
+export EnergyCapacityConstraint
+export EnergyCapacityDownConstraint
+export EnergyCapacityUpConstraint
+export EnergyLimitConstraint
+export EnergyShortageVariableLimitsConstraint
+export EnergyTargetConstraint
+export EqualityConstraint
+export FeedforwardBinConstraint
+export FeedforwardConstraint
+export FeedforwardIntegralLimitConstraint
+export FeedforwardUBConstraint
+export FlowActivePowerConstraint
+export FlowActivePowerFromToConstraint
+export FlowActivePowerToFromConstraint
+export FlowLimitConstraint
+export FlowLimitFromToConstraint
+export FlowLimitToFromConstraint
+export FlowRateConstraint
+export FlowRateConstraintFT
+export FlowRateConstraintTF
+export FlowReactivePowerConstraint
+export FlowReactivePowerFromToConstraint
+export FlowReactivePowerToFromConstraint
+export FrequencyResponseConstraint
+export InflowRangeConstraint
+export InputActivePowerVariableLimitsConstraint
+export InputPowerRangeConstraint
+export MustRunConstraint
+export NetworkFlowConstraint
+export NodalBalanceActiveConstraint
+export NodalBalanceReactiveConstraint
+export OutputActivePowerVariableLimitsConstraint
+export OutputPowerRangeConstraint
+export ParticipationAssignmentConstraint
+export RampConstraint
+export RampLimitConstraint
+export RangeLimitConstraint
+export RateLimitConstraint
+export RateLimitFTConstraint
+export RateLimitTFConstraint
+export ReactiveConstraint
+export ReactivePowerVariableLimitsConstraint
+export ReactiveRangeConstraint
+export RegulationLimitsDownConstraint
+export RegulationLimitsUpConstraint
+export RequirementConstraint
+export ReserveEnergyConstraint
+export ReservePowerConstraint
+export SACEPidAreaConstraint
+export StartTypeConstraint
+export StartupInitialConditionConstraint
+export StartupTimeLimitTemperatureConstraint
 
 #################################################################################
 # Imports
@@ -344,6 +376,7 @@ const TS = TimeSeries
 # Includes
 
 include("utils.jl")
+include("logging.jl")
 
 include("core/definitions.jl")
 

--- a/src/core/abstract_types.jl
+++ b/src/core/abstract_types.jl
@@ -18,6 +18,13 @@ function encode_symbol(
     return Symbol("$(IS.strip_module_name(string(U)))_$(T_)" * meta_)
 end
 
+function check_meta_chars(meta)
+    # Underscores in this field will prevent us from being able to decode keys.
+    if occursin("_", meta)
+        throw(IS.InvalidValue("'_' is not allowed in meta"))
+    end
+end
+
 abstract type AbstractAffectFeedForward end
 
 abstract type AbstractCache end

--- a/src/core/abstract_types.jl
+++ b/src/core/abstract_types.jl
@@ -12,7 +12,7 @@ function encode_symbol(
     ::Type{T},
     ::Type{U},
     meta::String = CONTAINER_KEY_EMPTY_META,
-) where {T <: PSY.Component, U}
+) where {T <: Union{PSY.Component, PSY.System}, U}
     meta_ = isempty(meta) ? meta : "_" * meta
     T_ = replace(replace(IS.strip_module_name(T), "{" => "_"), "}" => "")
     return Symbol("$(IS.strip_module_name(string(U)))_$(T_)" * meta_)

--- a/src/core/constraints.jl
+++ b/src/core/constraints.jl
@@ -81,6 +81,7 @@ function ConstraintKey(
     ::Type{U},
     meta = CONTAINER_KEY_EMPTY_META,
 ) where {T <: ConstraintType, U <: Union{PSY.Component, PSY.System}}  # TODO DT: IS.InfrastructureType instead?
+    check_meta_chars(meta)
     return ConstraintKey{T, U}(meta)
 end
 

--- a/src/core/constraints.jl
+++ b/src/core/constraints.jl
@@ -1,94 +1,97 @@
 # The constants below are strings instead of enums because there is a requirement that users
 # should be able to define their own without changing PowerSimulations.
 
-# Constraints
-const ACTIVE = "active"
-const ACTIVE_RANGE = "activerange"
-const ACTIVE_RANGE_LB = "activerange_lb"
-const ACTIVE_RANGE_UB = "activerange_ub"
-const COMMITMENT = "commitment"
-const DURATION = "duration"
-const DURATION_DOWN = "duration_dn"
-const DURATION_UP = "duration_up"
-const ENERGY_CAPACITY = "energy_capacity"
-const ENERGY_CAPACITY_UP = "energy_capacity_up"
-const ENERGY_CAPACITY_DOWN = "energy_capacity_down"
-const ENERGY_LIMIT = "energy_limit"
-const ENERGY_TARGET = "energy_target"
-const FEEDFORWARD = "FF"
-const FEEDFORWARD_UB = "FF_ub"
-const FEEDFORWARD_BIN = "FF_bin"
-const FEEDFORWARD_INTEGRAL_LIMIT = "FF_integral"
-const FLOW_LIMIT = "FlowLimit"
-const FLOW_LIMIT_FROM_TO = "FlowLimitFT"
-const FLOW_LIMIT_TO_FROM = "FlowLimitTF"
-const FLOW_REACTIVE_POWER_FROM_TO = "FqFT"
-const FLOW_REACTIVE_POWER_TO_FROM = "FqTF"
-const FLOW_ACTIVE_POWER_FROM_TO = "FpFT"
-const FLOW_ACTIVE_POWER_TO_FROM = "FpTF"
-const FLOW_ACTIVE_POWER = "Fp"
-const FLOW_REACTIVE_POWER = "Fq"
-const INPUT_POWER_RANGE = "inputpower_range"
-const OUTPUT_POWER_RANGE = "outputpower_range"
-const RAMP = "ramp"
-const RAMP_DOWN = "ramp_dn"
-const RAMP_UP = "ramp_up"
-const RATE_LIMIT = "RateLimit"
-const RATE_LIMIT_FT = "RateLimitFT"
-const RATE_LIMIT_TF = "RateLimitTF"
-const REACTIVE = "reactive"
-const REACTIVE_RANGE = "reactiverange"
-const REQUIREMENT = "requirement"
-const RESERVE_POWER = "reserve_power"
-const RESERVE_ENERGY = "reserve_energy"
-const INFLOW_RANGE = "inflowrange"
-const ACTIVE_RANGE_IC = "active_range_ic"
-const START_TYPE = "start_type"
-const STARTUP_TIMELIMIT = "startup_timelimit"
-const STARTUP_TIMELIMIT_WARM = "startup_timelimit_warm"
-const STARTUP_TIMELIMIT_HOT = "startup_timelimit_warm"
-const STARTUP_INITIAL_CONDITION = "startup_initial_condition"
-const STARTUP_INITIAL_CONDITION_UB = "startup_initial_condition_ub"
-const STARTUP_INITIAL_CONDITION_LB = "startup_initial_condition_lb"
-const MUST_RUN = "must_run"
-const MUST_RUN_LB = "must_run_lb"
-const NODAL_BALANCE_ACTIVE = "nodal_balance_active"
-const NODAL_BALANCE_REACTIVE = "nodal_balance_reactive"
-const NETWORK_FLOW = "network_flow"
-
 abstract type ConstraintType end
 
-struct RangeConstraint <: ConstraintType end
+struct AbsoluteValueConstraint <: ConstraintType end
+struct ActiveConstraint <: ConstraintType end
+struct ActivePowerVariableLimitsConstraint <: ConstraintType end
+struct ActiveRangeConstraint <: ConstraintType end
+struct ActiveRangeICConstraint <: ConstraintType end
+struct AreaDispatchBalanceConstraint <: ConstraintType end
+struct AreaParticipationAssignmentConstraint <: ConstraintType end
+struct BalanceAuxConstraint <: ConstraintType end
+struct CommitmentConstraint <: ConstraintType end
+struct CopperPlateBalanceConstraint <: ConstraintType end
+struct DeltaActivePowerDownVariableLimitsConstraint <: ConstraintType end
+struct DeltaActivePowerUpVariableLimitsConstraint <: ConstraintType end
+struct DurationConstraint <: ConstraintType end
 struct EnergyBalanceConstraint <: ConstraintType end
-struct FlowRateConstraint <: ConstraintType end
-struct FlowRateConstraintTF <: ConstraintType end
-struct FlowRateConstraintFT <: ConstraintType end
+struct EnergyBudgetConstraint <: ConstraintType end
+struct EnergyCapacityConstraint <: ConstraintType end
+struct EnergyCapacityDownConstraint <: ConstraintType end
+struct EnergyCapacityUpConstraint <: ConstraintType end
+struct EnergyLimitConstraint <: ConstraintType end
+struct EnergyTargetConstraint <: ConstraintType end
+struct EnergyShortageVariableLimitsConstraint <: ConstraintType end
 struct EqualityConstraint <: ConstraintType end
+struct FeedforwardBinConstraint <: ConstraintType end
+struct FeedforwardConstraint <: ConstraintType end
+struct FeedforwardIntegralLimitConstraint <: ConstraintType end
+struct FeedforwardUBConstraint <: ConstraintType end
+struct FlowActivePowerConstraint <: ConstraintType end
+struct FlowActivePowerFromToConstraint <: ConstraintType end
+struct FlowActivePowerToFromConstraint <: ConstraintType end
+struct FlowLimitConstraint <: ConstraintType end
+struct FlowLimitFromToConstraint <: ConstraintType end
+struct FlowLimitToFromConstraint <: ConstraintType end
+struct FlowRateConstraint <: ConstraintType end
+struct FlowRateConstraintFT <: ConstraintType end
+struct FlowRateConstraintTF <: ConstraintType end
+struct FlowReactivePowerConstraint <: ConstraintType end
+struct FlowReactivePowerFromToConstraint <: ConstraintType end
+struct FlowReactivePowerToFromConstraint <: ConstraintType end
+struct FrequencyResponseConstraint <: ConstraintType end
+struct InflowRangeConstraint <: ConstraintType end
+struct InputActivePowerVariableLimitsConstraint <: ConstraintType end
+struct InputPowerRangeConstraint <: ConstraintType end
+struct MustRunConstraint <: ConstraintType end
+struct NetworkFlowConstraint <: ConstraintType end
+struct NodalBalanceActiveConstraint <: ConstraintType end
+struct NodalBalanceReactiveConstraint <: ConstraintType end
+struct OutputActivePowerVariableLimitsConstraint <: ConstraintType end
+struct OutputPowerRangeConstraint <: ConstraintType end
+struct ParticipationAssignmentConstraint <: ConstraintType end
+struct RampConstraint <: ConstraintType end
+struct RampLimitConstraint <: ConstraintType end
+struct RangeLimitConstraint <: ConstraintType end
+struct RateLimitConstraint <: ConstraintType end
+struct RateLimitFTConstraint <: ConstraintType end
+struct RateLimitTFConstraint <: ConstraintType end
+struct ReactiveConstraint <: ConstraintType end
+struct ReactivePowerVariableLimitsConstraint <: ConstraintType end
+struct ReactiveRangeConstraint <: ConstraintType end
+struct RegulationLimitsDownConstraint <: ConstraintType end
+struct RegulationLimitsUpConstraint <: ConstraintType end
+struct RequirementConstraint <: ConstraintType end
+struct ReserveEnergyConstraint <: ConstraintType end
+struct ReservePowerConstraint <: ConstraintType end
+struct SACEPidAreaConstraint <: ConstraintType end
+struct StartTypeConstraint <: ConstraintType end
+struct StartupInitialConditionConstraint <: ConstraintType end
+struct StartupTimeLimitTemperatureConstraint <: ConstraintType end
 
-# TODO: These functions need to dissapear
-function make_constraint_name(
+struct ConstraintKey{T <: ConstraintType, U <: Union{PSY.Component, PSY.System}} <:
+       OptimizationContainerKey
+    meta::String
+end
+
+function ConstraintKey(
     ::Type{T},
     ::Type{U},
-    ::Type{V},
-) where {T <: ConstraintType, U <: VariableType, V <: PSY.Device}
-    return encode_symbol(T, encode_symbol(V, U))
+    meta = CONTAINER_KEY_EMPTY_META,
+) where {T <: ConstraintType, U <: Union{PSY.Component, PSY.System}}  # TODO DT: IS.InfrastructureType instead?
+    return ConstraintKey{T, U}(meta)
 end
 
-function make_constraint_name(
-    input::Symbol,
-    ::Type{U},
-    ::Type{V},
-) where {U <: VariableType, V <: PSY.Device}
-    return encode_symbol(input, encode_symbol(V, U))
-end
+get_entry_type(
+    ::ConstraintKey{T, U},
+) where {T <: ConstraintType, U <: Union{PSY.Component, PSY.System}} = T
+# TODO DT: since this can be System, "get_component_type" isn't the best name
+get_component_type(
+    ::ConstraintKey{T, U},
+) where {T <: ConstraintType, U <: Union{PSY.Component, PSY.System}} = U
 
-function make_constraint_name(
-    ::T,
-    ::Type{U},
-    ::Type{V},
-) where {T <: ConstraintType, U <: VariableType, V <: PSY.Device}
-    return encode_symbol(T, encode_symbol(V, U))
+function encode_key(key::ConstraintKey)
+    return encode_symbol(get_component_type(key), get_entry_type(key), key.meta)
 end
-
-make_constraint_name(cons_type, device_type) = encode_symbol(device_type, cons_type)
-make_constraint_name(cons_type) = encode_symbol(cons_type)

--- a/src/core/operations_problem.jl
+++ b/src/core/operations_problem.jl
@@ -1010,9 +1010,11 @@ struct ProblemSerializationWrapper
 end
 
 ################ Functions to debug optimization models#####################################
-""" "Each Tuple corresponds to (con_name, internal_index, moi_index)"""
+"""
+Each Tuple corresponds to (con_name, internal_index, moi_index)
+"""
 function get_all_constraint_index(problem::OperationsProblem)
-    con_index = Vector{Tuple{Symbol, Int, Int}}()
+    con_index = Vector{Tuple{ConstraintKey, Int, Int}}()
     optimization_container = get_optimization_container(problem)
     for (key, value) in get_constraints(optimization_container)
         for (idx, constraint) in enumerate(value)
@@ -1023,7 +1025,9 @@ function get_all_constraint_index(problem::OperationsProblem)
     return con_index
 end
 
-""" "Each Tuple corresponds to (con_name, internal_index, moi_index)"""
+"""
+Each Tuple corresponds to (con_name, internal_index, moi_index)
+"""
 function get_all_var_index(problem::OperationsProblem)
     var_keys = get_all_var_keys(problem)
     return [(encode_key(v[1]), v[2], v[3]) for v in var_keys]

--- a/src/core/update_initial_conditions.jl
+++ b/src/core/update_initial_conditions.jl
@@ -15,7 +15,8 @@ function calculate_ic_quantity(
     current_counter = time_cache[:count]
     last_status = time_cache[:status]
     var_status = isapprox(var_value, 0.0, atol = ABSOLUTE_TOLERANCE) ? 0.0 : 1.0
-    @debug last_status, var_status, abs(last_status - var_status)
+    @debug last_status, var_status, abs(last_status - var_status) _group =
+        LOG_GROUP_INITIAL_CONDITIONS
     @assert abs(last_status - var_status) < ABSOLUTE_TOLERANCE
 
     return last_status >= 1.0 ? current_counter : 0.0
@@ -35,7 +36,8 @@ function calculate_ic_quantity(
     current_counter = time_cache[:count]
     last_status = time_cache[:status]
     var_status = isapprox(var_value, 0.0, atol = ABSOLUTE_TOLERANCE) ? 0.0 : 1.0
-    @debug last_status, var_status, abs(last_status - var_status)
+    @debug last_status, var_status, abs(last_status - var_status) _group =
+        LOG_GROUP_INITIAL_CONDITIONS
     @assert abs(last_status - var_status) < ABSOLUTE_TOLERANCE
 
     return last_status >= 1.0 ? 0.0 : current_counter
@@ -167,7 +169,8 @@ function _make_initial_conditions!(
     parameters = model_has_parameters(optimization_container)
     ic_container = get_initial_conditions(optimization_container)
     if !has_initial_conditions(ic_container, key)
-        @debug "Setting $(get_entry_type(key)) initial conditions for all devices $(T) based on system data"
+        @debug "Setting $(get_entry_type(key)) initial conditions for all devices $(T) based on system data" _group =
+            LOG_GROUP_INITIAL_CONDITIONS
         ini_conds = Vector{InitialCondition}(undef, length_devices)
         set_initial_conditions!(ic_container, key, ini_conds)
         for (ix, dev) in enumerate(devices)
@@ -175,19 +178,20 @@ function _make_initial_conditions!(
             val = parameters ? add_parameter(optimization_container.JuMPmodel, val_) : val_
             ic = make_ic_func(ic_container, dev, val, cache)
             ini_conds[ix] = ic
-            @debug "set initial condition" key ic val_
+            @debug "set initial condition" _group = LOG_GROUP_INITIAL_CONDITIONS key ic val_
         end
     else
         ini_conds = get_initial_conditions(ic_container, key)
         ic_devices = Set((IS.get_uuid(ic.device) for ic in ini_conds))
         for dev in devices
             IS.get_uuid(dev) in ic_devices && continue
-            @debug "Setting $(get_entry_type(key)) initial conditions device $(PSY.get_name(dev)) based on system data"
+            @debug "Setting $(get_entry_type(key)) initial conditions device $(PSY.get_name(dev)) based on system data" _group =
+                LOG_GROUP_INITIAL_CONDITIONS
             val_ = get_val_func(dev, key, device_formulation, variable_type)
             val = parameters ? add_parameter(optimization_container.JuMPmodel, val_) : val_
             ic = make_ic_func(ic_container, dev, val, cache)
             push!(ini_conds, ic)
-            @debug "set initial condition" key ic val_
+            @debug "set initial condition" _group = LOG_GROUP_INITIAL_CONDITIONS key ic val_
         end
     end
 

--- a/src/core/variables.jl
+++ b/src/core/variables.jl
@@ -7,6 +7,7 @@ function VariableKey(
     ::Type{U},
     meta = CONTAINER_KEY_EMPTY_META,
 ) where {T <: VariableType, U <: PSY.Component}
+    check_meta_chars(meta)
     return VariableKey{T, U}(meta)
 end
 

--- a/src/core/variables.jl
+++ b/src/core/variables.jl
@@ -101,6 +101,8 @@ struct FlowReactivePowerFromToVariable <: VariableType end
 
 struct FlowReactivePowerToFromVariable <: VariableType end
 
+struct VariableNotDefined <: VariableType end
+
 ###############################
 
 const START_VARIABLES = (HotStartVariable, WarmStartVariable, ColdStartVariable)

--- a/src/devices_models/device_constructors/hydrogeneration_constructor.jl
+++ b/src/devices_models/device_constructors/hydrogeneration_constructor.jl
@@ -44,7 +44,7 @@ function construct_device!(
     # Constraints
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ActivePowerVariableLimitsConstraint,
         ActivePowerVariable,
         devices,
         model,
@@ -53,7 +53,7 @@ function construct_device!(
     )
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ReactivePowerVariableLimitsConstraint,
         ReactivePowerVariable,
         devices,
         model,
@@ -94,7 +94,7 @@ function construct_device!(
     # Constraints
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ActivePowerVariableLimitsConstraint,
         ActivePowerVariable,
         devices,
         model,
@@ -141,7 +141,7 @@ function construct_device!(
     # Constraints
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ActivePowerVariableLimitsConstraint,
         ActivePowerVariable,
         devices,
         model,
@@ -150,7 +150,7 @@ function construct_device!(
     )
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ReactivePowerVariableLimitsConstraint,
         ReactivePowerVariable,
         devices,
         model,
@@ -202,7 +202,7 @@ function construct_device!(
     # Constraints
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ActivePowerVariableLimitsConstraint,
         ActivePowerVariable,
         devices,
         model,
@@ -283,7 +283,7 @@ function construct_device!(
     # Constraints
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ActivePowerVariableLimitsConstraint,
         ActivePowerVariable,
         devices,
         model,
@@ -292,7 +292,7 @@ function construct_device!(
     )
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ReactivePowerVariableLimitsConstraint,
         ReactivePowerVariable,
         devices,
         model,
@@ -382,7 +382,7 @@ function construct_device!(
     # Constraints
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ActivePowerVariableLimitsConstraint,
         ActivePowerVariable,
         devices,
         model,
@@ -444,7 +444,7 @@ function construct_device!(
     # Constraints
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ActivePowerVariableLimitsConstraint,
         ActivePowerVariable,
         devices,
         model,
@@ -453,7 +453,7 @@ function construct_device!(
     )
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ReactivePowerVariableLimitsConstraint,
         ReactivePowerVariable,
         devices,
         model,
@@ -501,7 +501,7 @@ function construct_device!(
     # Constraints
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ActivePowerVariableLimitsConstraint,
         ActivePowerVariable,
         devices,
         model,
@@ -545,7 +545,7 @@ function construct_device!(
     # Constraints
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ActivePowerVariableLimitsConstraint,
         ActivePowerVariable,
         devices,
         model,
@@ -554,7 +554,7 @@ function construct_device!(
     )
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ReactivePowerVariableLimitsConstraint,
         ReactivePowerVariable,
         devices,
         model,
@@ -605,7 +605,7 @@ function construct_device!(
     # Constraints
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ActivePowerVariableLimitsConstraint,
         ActivePowerVariable,
         devices,
         model,
@@ -690,7 +690,7 @@ function construct_device!(
     # Constraints
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ActivePowerVariableLimitsConstraint,
         ActivePowerVariable,
         devices,
         model,
@@ -699,7 +699,7 @@ function construct_device!(
     )
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ReactivePowerVariableLimitsConstraint,
         ReactivePowerVariable,
         devices,
         model,
@@ -794,7 +794,7 @@ function construct_device!(
     # Constraints
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ActivePowerVariableLimitsConstraint,
         ActivePowerVariable,
         devices,
         model,
@@ -884,7 +884,7 @@ function construct_device!(
     # Constraints
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        OutputActivePowerVariableLimitsConstraint,
         ActivePowerOutVariable,
         devices,
         model,
@@ -893,7 +893,7 @@ function construct_device!(
     )
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        InputActivePowerVariableLimitsConstraint,
         ActivePowerInVariable,
         devices,
         model,
@@ -992,7 +992,7 @@ function construct_device!(
     # Constraints
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        OutputActivePowerVariableLimitsConstraint,
         ActivePowerOutVariable,
         devices,
         model,
@@ -1001,7 +1001,7 @@ function construct_device!(
     )
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        InputActivePowerVariableLimitsConstraint,
         ActivePowerInVariable,
         devices,
         model,

--- a/src/devices_models/device_constructors/load_constructor.jl
+++ b/src/devices_models/device_constructors/load_constructor.jl
@@ -21,7 +21,7 @@ function construct_device!(
     # Constraints
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ActivePowerVariableLimitsConstraint,
         ActivePowerVariable,
         devices,
         model,
@@ -30,7 +30,7 @@ function construct_device!(
     )
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ReactivePowerVariableLimitsConstraint,
         ReactivePowerVariable,
         devices,
         model,
@@ -67,7 +67,7 @@ function construct_device!(
     # Constraints
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ActivePowerVariableLimitsConstraint,
         ActivePowerVariable,
         devices,
         model,
@@ -112,7 +112,7 @@ function construct_device!(
     # Constraints
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ActivePowerVariableLimitsConstraint,
         ActivePowerVariable,
         devices,
         model,
@@ -121,7 +121,7 @@ function construct_device!(
     )
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ReactivePowerVariableLimitsConstraint,
         ReactivePowerVariable,
         devices,
         model,
@@ -160,7 +160,7 @@ function construct_device!(
     # Constraints
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ActivePowerVariableLimitsConstraint,
         ActivePowerVariable,
         devices,
         model,

--- a/src/devices_models/device_constructors/regulationdevice_constructor.jl
+++ b/src/devices_models/device_constructors/regulationdevice_constructor.jl
@@ -47,7 +47,7 @@ function construct_device!(
     nodal_expression!(optimization_container, devices, S)
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        DeltaActivePowerUpVariableLimitsConstraint,
         DeltaActivePowerUpVariable,
         devices,
         model,
@@ -56,7 +56,7 @@ function construct_device!(
     )
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        DeltaActivePowerDownVariableLimitsConstraint,
         DeltaActivePowerDownVariable,
         devices,
         model,
@@ -118,7 +118,7 @@ function construct_device!(
     nodal_expression!(optimization_container, devices, S)
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        DeltaActivePowerUpVariableLimitsConstraint,
         DeltaActivePowerUpVariable,
         devices,
         model,
@@ -127,7 +127,7 @@ function construct_device!(
     )
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        DeltaActivePowerDownVariableLimitsConstraint,
         DeltaActivePowerDownVariable,
         devices,
         model,

--- a/src/devices_models/device_constructors/renewablegeneration_constructor.jl
+++ b/src/devices_models/device_constructors/renewablegeneration_constructor.jl
@@ -21,7 +21,7 @@ function construct_device!(
     # Constraints
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ActivePowerVariableLimitsConstraint,
         ActivePowerVariable,
         devices,
         model,
@@ -30,7 +30,7 @@ function construct_device!(
     )
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ReactivePowerVariableLimitsConstraint,
         ReactivePowerVariable,
         devices,
         model,
@@ -67,7 +67,7 @@ function construct_device!(
     # Constraints
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ActivePowerVariableLimitsConstraint,
         ActivePowerVariable,
         devices,
         model,

--- a/src/devices_models/device_constructors/storage_constructor.jl
+++ b/src/devices_models/device_constructors/storage_constructor.jl
@@ -22,7 +22,7 @@ function construct_device!(
     # Constraints
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        OutputActivePowerVariableLimitsConstraint,
         ActivePowerOutVariable,
         devices,
         model,
@@ -31,7 +31,7 @@ function construct_device!(
     )
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        InputActivePowerVariableLimitsConstraint,
         ActivePowerInVariable,
         devices,
         model,
@@ -40,7 +40,7 @@ function construct_device!(
     )
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ReactivePowerVariableLimitsConstraint,
         ReactivePowerVariable,
         devices,
         model,
@@ -97,7 +97,7 @@ function construct_device!(
     # Constraints
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        OutputActivePowerVariableLimitsConstraint,
         ActivePowerOutVariable,
         devices,
         model,
@@ -106,7 +106,7 @@ function construct_device!(
     )
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        InputActivePowerVariableLimitsConstraint,
         ActivePowerInVariable,
         devices,
         model,
@@ -186,7 +186,7 @@ function construct_device!(
     # Constraints
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        OutputActivePowerVariableLimitsConstraint,
         ActivePowerOutVariable,
         devices,
         model,
@@ -195,7 +195,7 @@ function construct_device!(
     )
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        InputActivePowerVariableLimitsConstraint,
         ActivePowerInVariable,
         devices,
         model,
@@ -204,7 +204,7 @@ function construct_device!(
     )
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ReactivePowerVariableLimitsConstraint,
         ReactivePowerVariable,
         devices,
         model,
@@ -278,7 +278,7 @@ function construct_device!(
     # Constraints
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        OutputActivePowerVariableLimitsConstraint,
         ActivePowerOutVariable,
         devices,
         model,
@@ -287,7 +287,7 @@ function construct_device!(
     )
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        InputActivePowerVariableLimitsConstraint,
         ActivePowerInVariable,
         devices,
         model,
@@ -343,7 +343,7 @@ function construct_device!(
     # Constraints
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        OutputActivePowerVariableLimitsConstraint,
         ActivePowerOutVariable,
         devices,
         model,
@@ -352,7 +352,7 @@ function construct_device!(
     )
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        InputActivePowerVariableLimitsConstraint,
         ActivePowerInVariable,
         devices,
         model,
@@ -361,7 +361,7 @@ function construct_device!(
     )
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ReactivePowerVariableLimitsConstraint,
         ReactivePowerVariable,
         devices,
         model,
@@ -426,7 +426,7 @@ function construct_device!(
     # Constraints
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        OutputActivePowerVariableLimitsConstraint,
         ActivePowerOutVariable,
         devices,
         model,
@@ -435,7 +435,7 @@ function construct_device!(
     )
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        InputActivePowerVariableLimitsConstraint,
         ActivePowerInVariable,
         devices,
         model,
@@ -524,7 +524,7 @@ function construct_device!(
     # Constraints
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        OutputActivePowerVariableLimitsConstraint,
         ActivePowerOutVariable,
         devices,
         model,
@@ -533,7 +533,7 @@ function construct_device!(
     )
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        InputActivePowerVariableLimitsConstraint,
         ActivePowerInVariable,
         devices,
         model,
@@ -542,7 +542,7 @@ function construct_device!(
     )
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ReactivePowerVariableLimitsConstraint,
         ReactivePowerVariable,
         devices,
         model,
@@ -622,7 +622,7 @@ function construct_device!(
     # Constraints
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        OutputActivePowerVariableLimitsConstraint,
         ActivePowerOutVariable,
         devices,
         model,
@@ -631,7 +631,7 @@ function construct_device!(
     )
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        InputActivePowerVariableLimitsConstraint,
         ActivePowerInVariable,
         devices,
         model,

--- a/src/devices_models/device_constructors/thermalgeneration_constructor.jl
+++ b/src/devices_models/device_constructors/thermalgeneration_constructor.jl
@@ -49,9 +49,10 @@ function construct_device!(
     initial_conditions!(optimization_container, devices, D())
 
     # Constraints
+    # TODO DT: why aren't these passing variable and constraint instances?
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ActivePowerVariableLimitsConstraint,
         ActivePowerVariable,
         devices,
         model,
@@ -60,7 +61,7 @@ function construct_device!(
     )
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ReactivePowerVariableLimitsConstraint,
         ReactivePowerVariable,
         devices,
         model,
@@ -119,7 +120,7 @@ function construct_device!(
     # Constraints
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ActivePowerVariableLimitsConstraint,
         ActivePowerVariable,
         devices,
         model,
@@ -198,7 +199,7 @@ function construct_device!(
     # TODO: refactor constraints such that ALL variables for all devices are added first, and then the constraint creation is trigged
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ActivePowerVariableLimitsConstraint,
         ActivePowerVariable,
         devices,
         model,
@@ -207,7 +208,7 @@ function construct_device!(
     )
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ReactivePowerVariableLimitsConstraint,
         ReactivePowerVariable,
         devices,
         model,
@@ -276,7 +277,7 @@ function construct_device!(
     # Constraints
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ActivePowerVariableLimitsConstraint,
         ActivePowerVariable,
         devices,
         model,
@@ -333,7 +334,7 @@ function construct_device!(
     # Constraints
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ActivePowerVariableLimitsConstraint,
         ActivePowerVariable,
         devices,
         model,
@@ -342,7 +343,7 @@ function construct_device!(
     )
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ReactivePowerVariableLimitsConstraint,
         ReactivePowerVariable,
         devices,
         model,
@@ -387,7 +388,7 @@ function construct_device!(
     # Constraints
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ActivePowerVariableLimitsConstraint,
         ActivePowerVariable,
         devices,
         model,
@@ -428,7 +429,7 @@ function construct_device!(
     # Constraints
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ActivePowerVariableLimitsConstraint,
         ActivePowerVariable,
         devices,
         model,
@@ -437,7 +438,7 @@ function construct_device!(
     )
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ReactivePowerVariableLimitsConstraint,
         ReactivePowerVariable,
         devices,
         model,
@@ -476,7 +477,7 @@ function construct_device!(
     # Constraints
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ActivePowerVariableLimitsConstraint,
         ActivePowerVariable,
         devices,
         model,
@@ -574,7 +575,7 @@ function construct_device!(
     # Constraints
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ActivePowerVariableLimitsConstraint,
         ActivePowerVariable,
         devices,
         model,
@@ -583,7 +584,7 @@ function construct_device!(
     )
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ReactivePowerVariableLimitsConstraint,
         ReactivePowerVariable,
         devices,
         model,
@@ -711,7 +712,7 @@ function construct_device!(
     # Constraints
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ActivePowerVariableLimitsConstraint,
         ActivePowerVariable,
         devices,
         model,
@@ -827,7 +828,7 @@ function construct_device!(
     # Constraints
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ActivePowerVariableLimitsConstraint,
         ActivePowerVariable,
         devices,
         model,
@@ -836,7 +837,7 @@ function construct_device!(
     )
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ReactivePowerVariableLimitsConstraint,
         ReactivePowerVariable,
         devices,
         model,
@@ -918,7 +919,7 @@ function construct_device!(
     # Constraints
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ActivePowerVariableLimitsConstraint,
         ActivePowerVariable,
         devices,
         model,
@@ -973,7 +974,7 @@ function construct_device!(
     # Constraints
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ActivePowerVariableLimitsConstraint,
         ActivePowerVariable,
         devices,
         model,
@@ -982,7 +983,7 @@ function construct_device!(
     )
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ReactivePowerVariableLimitsConstraint,
         ReactivePowerVariable,
         devices,
         model,
@@ -1023,7 +1024,7 @@ function construct_device!(
     # Constraints
     add_constraints!(
         optimization_container,
-        RangeConstraint,
+        ActivePowerVariableLimitsConstraint,
         ActivePowerVariable,
         devices,
         model,

--- a/src/devices_models/devices/AC_branches.jl
+++ b/src/devices_models/devices/AC_branches.jl
@@ -116,7 +116,7 @@ function branch_rate_constraints!(
         optimization_container,
         RangeConstraintSpecInternal(
             constraint_infos,
-            make_constraint_name(RATE_LIMIT, B),
+            RateLimitConstraint(),
             FlowActivePowerVariable(),
             B,
         ),
@@ -135,21 +135,17 @@ function branch_rate_constraints!(
     rating_constraint!(
         optimization_container,
         range_data,
-        make_constraint_name(RATE_LIMIT_FT, B),
-        (
-            VariableKey(FlowActivePowerFromToVariable, B),
-            VariableKey(FlowReactivePowerFromToVariable, B),
-        ),
+        RateLimitFTConstraint(),
+        (FlowActivePowerFromToVariable(), FlowReactivePowerFromToVariable()),
+        B,
     )
 
     rating_constraint!(
         optimization_container,
         range_data,
-        make_constraint_name(RATE_LIMIT_TF, B),
-        (
-            VariableKey(FlowActivePowerToFromVariable, B),
-            VariableKey(FlowReactivePowerToFromVariable, B),
-        ),
+        RateLimitTFConstraint(),
+        (FlowActivePowerToFromVariable(), FlowReactivePowerToFromVariable()),
+        B,
     )
     return
 end
@@ -177,9 +173,13 @@ function branch_flow_values!(
     ptdf = get_PTDF(optimization_container)
     branches = PSY.get_name.(devices)
     time_steps = model_time_steps(optimization_container)
-    constraint_name = make_constraint_name(NETWORK_FLOW, B)
-    branch_flow =
-        add_cons_container!(optimization_container, constraint_name, branches, time_steps)
+    branch_flow = add_cons_container!(
+        optimization_container,
+        NetworkFlowConstraint(),
+        B,
+        branches,
+        time_steps,
+    )
     nodal_balance_expressions = optimization_container.expressions[:nodal_balance_active]
     flow_variables = get_variable(optimization_container, FlowActivePowerVariable(), B)
     jump_model = get_jump_model(optimization_container)
@@ -227,8 +227,9 @@ function branch_flow_constraints!(
         optimization_container,
         RangeConstraintSpecInternal(
             constraint_infos,
-            make_constraint_name(FLOW_LIMIT, PSY.MonitoredLine),
-            VariableKey(FlowActivePowerVariable(), PSY.MonitoredLine),
+            FlowLimitConstraint(),
+            FlowActivePowerVariable(),
+            PSY.MonitoredLine,
         ),
     )
     return
@@ -264,16 +265,18 @@ function branch_flow_constraints!(
         optimization_container,
         RangeConstraintSpecInternal(
             to,
-            make_constraint_name(FLOW_LIMIT_FROM_TO, PSY.MonitoredLine),
-            VariableKey(FlowActivePowerFromToVariable, PSY.MonitoredLine),
+            FlowLimitFromToConstraint(),
+            FlowActivePowerFromToVariable(),
+            PSY.MonitoredLine,
         ),
     )
     device_range!(
         optimization_container,
         RangeConstraintSpecInternal(
             from,
-            make_constraint_name(FLOW_LIMIT_TO_FROM, PSY.MonitoredLine),
-            VariableKey(FlowActivePowerToFromVariable, PSY.MonitoredLine),
+            FlowLimitToFromConstraint(),
+            FlowActivePowerToFromVariable(),
+            PSY.MonitoredLine,
         ),
     )
     return

--- a/src/devices_models/devices/DC_branches.jl
+++ b/src/devices_models/devices/DC_branches.jl
@@ -78,7 +78,6 @@ function branch_rate_constraints!(
     constraint = add_cons_container!(
         optimization_container,
         FlowRateConstraint(),
-        FlowActivePowerVariable(),
         B,
         names,
         time_steps,
@@ -122,14 +121,8 @@ function branch_rate_constraints!(
         (FlowRateConstraintFT(), FlowRateConstraintTF()),
     )
         var = get_variable(optimization_container, var_type, B)
-        constraint = add_cons_container!(
-            optimization_container,
-            cons_type,
-            var_type,
-            B,
-            names,
-            time_steps,
-        )
+        constraint =
+            add_cons_container!(optimization_container, cons_type, B, names, time_steps)
         for t in time_steps, d in devices
             min_rate = max(
                 PSY.get_active_power_limits_from(d).min,

--- a/src/devices_models/devices/common/commitment_constraint.jl
+++ b/src/devices_models/devices/common/commitment_constraint.jl
@@ -36,22 +36,29 @@ If t > 1:
 function device_commitment!(
     optimization_container::OptimizationContainer,
     initial_conditions::Vector{InitialCondition},
-    cons_name::Symbol,
-    var_keys::Tuple{VariableKey, VariableKey, VariableKey},
-)
+    cons_type::ConstraintType,
+    var_types::Tuple{VariableType, VariableType, VariableType},
+    ::Type{T},
+) where {T <: PSY.Component}
     time_steps = model_time_steps(optimization_container)
-    varstart = get_variable(optimization_container, var_keys[1])
-    varstop = get_variable(optimization_container, var_keys[2])
-    varon = get_variable(optimization_container, var_keys[3])
+    varstart = get_variable(optimization_container, var_types[1], T)
+    varstop = get_variable(optimization_container, var_types[2], T)
+    varon = get_variable(optimization_container, var_types[3], T)
     varstart_names = axes(varstart, 1)
-    constraint =
-        add_cons_container!(optimization_container, cons_name, varstart_names, time_steps)
-    aux_cons_name = middle_rename(cons_name, PSI_NAME_DELIMITER, "aux")
-    aux_constraint = add_cons_container!(
+    constraint = add_cons_container!(
         optimization_container,
-        aux_cons_name,
+        cons_type,
+        T,
         varstart_names,
         time_steps,
+    )
+    aux_constraint = add_cons_container!(
+        optimization_container,
+        cons_type,
+        T,
+        varstart_names,
+        time_steps,
+        meta = "aux",
     )
 
     for ic in initial_conditions

--- a/src/devices_models/devices/common/constraints_structs.jl
+++ b/src/devices_models/devices/common/constraints_structs.jl
@@ -194,23 +194,31 @@ struct ReserveRangeConstraintInfo
     component_name::String
     limits::MinMax
     efficiency::InOut
-    time_frames::Dict{Symbol, Float64}
-    additional_terms_up::Vector{VariableKey}
-    additional_terms_dn::Vector{VariableKey}
+    time_frames::Dict{Tuple{Symbol, VariableType}, Float64}
+    additional_terms_up::Vector{Tuple{Symbol, VariableType}}
+    additional_terms_dn::Vector{VariableType}
+    component_type::Type{<:PSY.Component}
 end
 
-function ReserveRangeConstraintInfo(name::String, limits::MinMax, efficiency::InOut)
+function ReserveRangeConstraintInfo(
+    name::String,
+    limits::MinMax,
+    efficiency::InOut,
+    ::Type{T},
+) where {T <: PSY.Component}
     return ReserveRangeConstraintInfo(
         name,
         limits,
         efficiency,
         Dict{Symbol, Float64}(),
-        Vector{VariableKey}(),
-        Vector{VariableKey}(),
+        Vector{VariableType}(),
+        Vector{VariableType}(),
+        T,
     )
 end
 
 get_component_name(d::ReserveRangeConstraintInfo) = d.component_name
+get_component_type(d::ReserveRangeConstraintInfo) = d.component_type
 get_time_frames(v::ReserveRangeConstraintInfo) = v.time_frames
 get_time_frame(v::ReserveRangeConstraintInfo, name::Symbol) = v.time_frames[name]
 set_time_frame!(v::ReserveRangeConstraintInfo, value::Pair{Symbol, Float64}) =

--- a/src/devices_models/devices/common/cost_functions.jl
+++ b/src/devices_models/devices/common/cost_functions.jl
@@ -80,7 +80,7 @@ function cost_function!(
 ) where {T <: PSY.Component, U <: AbstractDeviceFormulation}
     for d in devices
         spec = AddCostSpec(T, U, optimization_container)
-        @debug T, spec
+        @debug T, spec _group = LOG_GROUP_COST_FUNCTIONS
         services = PSY.get_services(d)
         add_service_variables!(spec, services)
         add_to_cost!(optimization_container, spec, PSY.get_operation_cost(d), d)
@@ -140,7 +140,7 @@ function slope_convexity_check(slopes::Vector{Float64})
     flag = true
     for ix in 1:(length(slopes) - 1)
         if slopes[ix] > slopes[ix + 1]
-            @debug slopes
+            @debug slopes _group = LOG_GROUP_COST_FUNCTIONS
             return flag = false
         end
     end
@@ -212,23 +212,25 @@ function pwl_gencost_sos!(
     var_key = VariableKey(spec.variable_type, spec.component_type)
     variable = get_variable(optimization_container, var_key)[component_name, time_period]
     export_pwl_vars = get_export_pwl_vars(optimization_container.settings)
-    @debug export_pwl_vars
+    @debug export_pwl_vars _group = LOG_GROUP_COST_FUNCTIONS
     total_gen_cost = JuMP.AffExpr(0.0)
 
     if spec.sos_status == SOSStatusVariable.NO_VARIABLE
         bin = 1.0
-        @debug(
-            "Using Piecewise Linear cost function but no variable/parameter ref for ON status is passed. Default status will be set to online (1.0)"
-        )
+        @debug "Using Piecewise Linear cost function but no variable/parameter ref for ON status is passed. Default status will be set to online (1.0)" _group =
+            LOG_GROUP_COST_FUNCTIONS
+
     elseif spec.sos_status == SOSStatusVariable.PARAMETER
         param_key = encode_symbol("ON", string(spec.component_type))
         bin =
             get_parameter_container(optimization_container, param_key).parameter_array[component_name]
-        @debug("Using Piecewise Linear cost function with parameter $(param_key)")
+        @debug "Using Piecewise Linear cost function with parameter $(param_key)" _group =
+            LOG_GROUP_COST_FUNCTIONS
     elseif spec.sos_status == SOSStatusVariable.VARIABLE
         var_key = VariableKey(OnVariable, spec.component_type)
         bin = get_variable(optimization_container, var_key)[component_name, time_period]
-        @debug("Using Piecewise Linear cost function with variable $(var_key)")
+        @debug "Using Piecewise Linear cost function with variable $(var_key)" _group =
+            LOG_GROUP_COST_FUNCTIONS
     else
         @assert false
     end
@@ -301,7 +303,7 @@ function pwl_gencost_linear!(
     var_key = VariableKey(spec.variable_type, spec.component_type)
     variable = get_variable(optimization_container, var_key)[component_name, time_period]
     export_pwl_vars = get_export_pwl_vars(optimization_container.settings)
-    @debug export_pwl_vars
+    @debug export_pwl_vars _group = LOG_GROUP_COST_FUNCTIONS
     total_gen_cost = JuMP.AffExpr(0.0)
 
     gen_cost = JuMP.AffExpr(0.0)
@@ -339,7 +341,7 @@ function add_to_cost!(
 )
     component_name = PSY.get_name(component)
     time_steps = model_time_steps(optimization_container)
-    @debug "TwoPartCost" component_name
+    @debug "TwoPartCost" _group = LOG_GROUP_COST_FUNCTIONS component_name
     if !(spec.variable_cost === nothing)
         variable_cost = spec.variable_cost(cost_data)
         if spec.uses_compact_power &&
@@ -365,7 +367,7 @@ function add_to_cost!(
     end
 
     if !(spec.fixed_cost === nothing) && spec.has_status_variable
-        @debug "Fixed cost" component_name
+        @debug "Fixed cost" _group = LOG_GROUP_COST_FUNCTIONS component_name
         for t in time_steps
             linear_gen_cost!(
                 optimization_container,
@@ -389,7 +391,7 @@ function add_to_cost!(
     component::PSY.Component,
 )
     component_name = PSY.get_name(component)
-    @debug "ThreePartCost" component_name
+    @debug "ThreePartCost" _group = LOG_GROUP_COST_FUNCTIONS component_name
     resolution = model_resolution(optimization_container)
     dt = Dates.value(Dates.Second(resolution)) / SECONDS_IN_HOUR
     variable_cost = spec.variable_cost(cost_data)
@@ -408,7 +410,7 @@ function add_to_cost!(
     end
 
     if !(spec.start_up_cost === nothing)
-        @debug "Start up cost" component_name
+        @debug "Start up cost" _group = LOG_GROUP_COST_FUNCTIONS component_name
         for t in time_steps
             linear_gen_cost!(
                 optimization_container,
@@ -421,7 +423,7 @@ function add_to_cost!(
     end
 
     if !(spec.shut_down_cost === nothing)
-        @debug "Shut down cost" component_name
+        @debug "Shut down cost" _group = LOG_GROUP_COST_FUNCTIONS component_name
         for t in time_steps
             linear_gen_cost!(
                 optimization_container,
@@ -434,7 +436,7 @@ function add_to_cost!(
     end
 
     if !(spec.fixed_cost === nothing) && spec.has_status_variable
-        @debug "Fixed cost" component_name
+        @debug "Fixed cost" _group = LOG_GROUP_COST_FUNCTIONS component_name
         for t in time_steps
             linear_gen_cost!(
                 optimization_container,
@@ -477,7 +479,7 @@ function add_to_cost!(
     time_steps = model_time_steps(optimization_container)
 
     if !(spec.fixed_cost === nothing) && spec.has_status_variable
-        @debug "Fixed cost" component_name
+        @debug "Fixed cost" _group = LOG_GROUP_COST_FUNCTIONS component_name
         for t in time_steps
             linear_gen_cost!(
                 optimization_container,
@@ -490,7 +492,7 @@ function add_to_cost!(
     end
 
     if !(spec.shut_down_cost === nothing)
-        @debug "Shut down cost" component_name
+        @debug "Shut down cost" _group = LOG_GROUP_COST_FUNCTIONS component_name
         for t in time_steps
             linear_gen_cost!(
                 optimization_container,
@@ -563,7 +565,7 @@ function add_to_cost!(
     component::PSY.ThermalMultiStart,
 )
     component_name = PSY.get_name(component)
-    @debug "Market Bid" component_name
+    @debug "Market Bid" _group = LOG_GROUP_COST_FUNCTIONS component_name
     resolution = model_resolution(optimization_container)
     dt = Dates.value(Dates.Second(resolution)) / SECONDS_IN_HOUR
     time_steps = model_time_steps(optimization_container)
@@ -602,7 +604,7 @@ function add_to_cost!(
     end
 
     if spec.has_status_variable
-        @debug "no_load cost" component_name
+        @debug "no_load cost" _group = LOG_GROUP_COST_FUNCTIONS component_name
         for t in time_steps
             linear_gen_cost!(
                 optimization_container,
@@ -615,7 +617,7 @@ function add_to_cost!(
     end
 
     if !(spec.shut_down_cost === nothing)
-        @debug "Shut down cost" component_name
+        @debug "Shut down cost" _group = LOG_GROUP_COST_FUNCTIONS component_name
         for t in time_steps
             linear_gen_cost!(
                 optimization_container,
@@ -646,7 +648,7 @@ function add_to_cost!(
     component::PSY.Component,
 )
     component_name = PSY.get_name(component)
-    @debug "Market Bid" component_name
+    @debug "Market Bid" _group = LOG_GROUP_COST_FUNCTIONS component_name
     resolution = model_resolution(optimization_container)
     dt = Dates.value(Dates.Second(resolution)) / SECONDS_IN_HOUR
     time_steps = model_time_steps(optimization_container)
@@ -683,7 +685,7 @@ function add_to_cost!(
     end
 
     if spec.has_status_variable
-        @debug "no_load cost" component_name
+        @debug "no_load cost" _group = LOG_GROUP_COST_FUNCTIONS component_name
         for t in time_steps
             linear_gen_cost!(
                 optimization_container,
@@ -696,7 +698,7 @@ function add_to_cost!(
     end
 
     if !(spec.shut_down_cost === nothing)
-        @debug "Shut down cost" component_name
+        @debug "Shut down cost" _group = LOG_GROUP_COST_FUNCTIONS component_name
         for t in time_steps
             linear_gen_cost!(
                 optimization_container,
@@ -779,7 +781,7 @@ function add_to_cost!(
     component::PSY.Component,
 )
     component_name = PSY.get_name(component)
-    @debug "Energy Target Cost" component_name
+    @debug "Energy Target Cost" _group = LOG_GROUP_COST_FUNCTIONS component_name
     resolution = model_resolution(optimization_container)
     dt = Dates.value(Dates.Second(resolution)) / SECONDS_IN_HOUR
     time_steps = model_time_steps(optimization_container)
@@ -791,7 +793,7 @@ function add_to_cost!(
     end
 
     if !(spec.fixed_cost === nothing) && spec.has_status_variable
-        @debug "Fixed cost" component_name
+        @debug "Fixed cost" _group = LOG_GROUP_COST_FUNCTIONS component_name
         for t in time_steps
             linear_gen_cost!(
                 optimization_container,
@@ -804,7 +806,7 @@ function add_to_cost!(
     end
 
     if !(spec.start_up_cost === nothing)
-        @debug "Start up cost" component_name
+        @debug "Start up cost" _group = LOG_GROUP_COST_FUNCTIONS component_name
         for t in time_steps
             linear_gen_cost!(
                 optimization_container,
@@ -817,7 +819,7 @@ function add_to_cost!(
     end
 
     if !(spec.shut_down_cost === nothing)
-        @debug "Shut down cost" component_name
+        @debug "Shut down cost" _group = LOG_GROUP_COST_FUNCTIONS component_name
         for t in time_steps
             linear_gen_cost!(
                 optimization_container,
@@ -829,7 +831,7 @@ function add_to_cost!(
         end
     end
 
-    @debug "Energy Surplus/Shortage cost" component_name
+    @debug "Energy Surplus/Shortage cost" _group = LOG_GROUP_COST_FUNCTIONS component_name
     base_power = get_base_power(optimization_container)
     for t in time_steps
         linear_gen_cost!(
@@ -868,7 +870,7 @@ function variable_cost!(
     ::Nothing,
     ::Int,
 )
-    @debug "Empty Variable Cost" component_name
+    @debug "Empty Variable Cost" _group = LOG_GROUP_COST_FUNCTIONS component_name
     return
 end
 
@@ -889,7 +891,7 @@ function variable_cost!(
     cost_component::PSY.VariableCost{Float64},
     time_period::Int,
 )
-    @debug "Linear Variable Cost" component_name
+    @debug "Linear Variable Cost" _group = LOG_GROUP_COST_FUNCTIONS component_name
     base_power = get_base_power(optimization_container)
     var_name = VariableKey(spec.variable_type, spec.component_type)
     cost_data = PSY.get_cost(cost_component)
@@ -935,7 +937,7 @@ function variable_cost!(
     var_key = VariableKey(spec.variable_type, spec.component_type)
     cost_data = PSY.get_cost(cost_component)
     if cost_data[1] >= eps()
-        @debug "Quadratic Variable Cost" component_name
+        @debug "Quadratic Variable Cost" _group = LOG_GROUP_COST_FUNCTIONS component_name
         resolution = model_resolution(optimization_container)
         dt = Dates.value(Dates.Second(resolution)) / SECONDS_IN_HOUR
         variable =
@@ -945,7 +947,8 @@ function variable_cost!(
             sum(variable .* base_power) * cost_data[2]
         add_to_cost_expression!(optimization_container, spec.multiplier * gen_cost * dt)
     else
-        @debug "Quadratic Variable Cost with only linear term" component_name
+        @debug "Quadratic Variable Cost with only linear term" _group =
+            LOG_GROUP_COST_FUNCTIONS component_name
         linear_gen_cost!(
             optimization_container,
             var_key,
@@ -988,13 +991,14 @@ function variable_cost!(
     cost_component::PSY.VariableCost{Vector{NTuple{2, Float64}}},
     time_period::Int,
 )
-    @debug "PWL Variable Cost" component_name
+    @debug "PWL Variable Cost" _group = LOG_GROUP_COST_FUNCTIONS component_name
     resolution = model_resolution(optimization_container)
     dt = Dates.value(Dates.Second(resolution)) / SECONDS_IN_HOUR
     # If array is full of tuples with zeros return 0.0
     cost_data = PSY.get_cost(cost_component)
     if all(iszero.(last.(cost_data)))
-        @debug "All cost terms for component $(component_name) are 0.0"
+        @debug "All cost terms for component $(component_name) are 0.0" _group =
+            LOG_GROUP_COST_FUNCTIONS
         return JuMP.AffExpr(0.0)
     end
 

--- a/src/devices_models/devices/common/duration_constraints.jl
+++ b/src/devices_models/devices/common/duration_constraints.jl
@@ -42,21 +42,33 @@ function device_duration_retrospective!(
     optimization_container::OptimizationContainer,
     duration_data::Vector{UpDown},
     initial_duration::Matrix{InitialCondition},
-    cons_name::Symbol,
-    var_keys::Tuple{VariableKey, VariableKey, VariableKey},
-)
+    cons_type::ConstraintType,
+    var_types::Tuple{VariableType, VariableType, VariableType},
+    ::Type{T},
+) where {T <: PSY.Component}
     time_steps = model_time_steps(optimization_container)
 
-    varon = get_variable(optimization_container, var_keys[1])
-    varstart = get_variable(optimization_container, var_keys[2])
-    varstop = get_variable(optimization_container, var_keys[3])
-
-    name_up = middle_rename(cons_name, PSI_NAME_DELIMITER, "up")
-    name_down = middle_rename(cons_name, PSI_NAME_DELIMITER, "dn")
+    varon = get_variable(optimization_container, var_types[1], T)
+    varstart = get_variable(optimization_container, var_types[2], T)
+    varstop = get_variable(optimization_container, var_types[3], T)
 
     set_names = [get_device_name(ic) for ic in initial_duration[:, 1]]
-    con_up = add_cons_container!(optimization_container, name_up, set_names, time_steps)
-    con_down = add_cons_container!(optimization_container, name_down, set_names, time_steps)
+    con_up = add_cons_container!(
+        optimization_container,
+        cons_type,
+        T,
+        set_names,
+        time_steps,
+        meta = "up",
+    )
+    con_down = add_cons_container!(
+        optimization_container,
+        cons_type,
+        T,
+        set_names,
+        time_steps,
+        meta = "dn",
+    )
 
     for t in time_steps
         for (ix, ic) in enumerate(initial_duration[:, 1])
@@ -141,20 +153,21 @@ function device_duration_look_ahead!(
     optimization_container::OptimizationContainer,
     duration_data::Vector{UpDown},
     initial_duration::Matrix{InitialCondition},
-    cons_name::Symbol,
-    var_keys::Tuple{VariableKey, VariableKey, VariableKey},
-)
+    cons_type_up::ConstraintType,
+    cons_type_down::ConstraintType,
+    var_types::Tuple{VariableType, VariableType, VariableType},
+    ::Type{T},
+) where {T <: PSY.Component}
     time_steps = model_time_steps(optimization_container)
-    varon = get_variable(optimization_container, var_keys[1])
-    varstart = get_variable(optimization_container, var_keys[2])
-    varstop = get_variable(optimization_container, var_keys[3])
-
-    name_up = middle_rename(cons_name, PSI_NAME_DELIMITER, "up")
-    name_down = middle_rename(cons_name, PSI_NAME_DELIMITER, "dn")
+    varon = get_variable(optimization_container, var_types[1], T)
+    varstart = get_variable(optimization_container, var_types[2], T)
+    varstop = get_variable(optimization_container, var_types[3], T)
 
     set_names = [get_device_name(ic) for ic in initial_duration[:, 1]]
-    con_up = add_cons_container!(optimization_container, name_up, set_names, time_steps)
-    con_down = add_cons_container!(optimization_container, name_down, set_names, time_steps)
+    con_up =
+        add_cons_container!(optimization_container, cons_type_up, set_names, time_steps)
+    con_down =
+        add_cons_container!(optimization_container, cons_type_down, set_names, time_steps)
 
     for t in time_steps
         for (ix, ic) in enumerate(initial_duration[:, 1])
@@ -241,21 +254,33 @@ function device_duration_parameters!(
     optimization_container::OptimizationContainer,
     duration_data::Vector{UpDown},
     initial_duration::Matrix{InitialCondition},
-    cons_name::Symbol,
-    var_keys::Tuple{VariableKey, VariableKey, VariableKey},
-)
+    cons_type::ConstraintType,
+    var_types::Tuple{VariableType, VariableType, VariableType},
+    ::Type{T},
+) where {T <: PSY.Component}
     time_steps = model_time_steps(optimization_container)
 
-    varon = get_variable(optimization_container, var_keys[1])
-    varstart = get_variable(optimization_container, var_keys[2])
-    varstop = get_variable(optimization_container, var_keys[3])
-
-    name_up = middle_rename(cons_name, PSI_NAME_DELIMITER, "up")
-    name_down = middle_rename(cons_name, PSI_NAME_DELIMITER, "dn")
+    varon = get_variable(optimization_container, var_types[1], T)
+    varstart = get_variable(optimization_container, var_types[2], T)
+    varstop = get_variable(optimization_container, var_types[3], T)
 
     set_names = [get_device_name(ic) for ic in initial_duration[:, 1]]
-    con_up = add_cons_container!(optimization_container, name_up, set_names, time_steps)
-    con_down = add_cons_container!(optimization_container, name_down, set_names, time_steps)
+    con_up = add_cons_container!(
+        optimization_container,
+        cons_type,
+        T,
+        set_names,
+        time_steps,
+        meta = "up",
+    )
+    con_down = add_cons_container!(
+        optimization_container,
+        cons_type,
+        T,
+        set_names,
+        time_steps,
+        meta = "dn",
+    )
 
     for t in time_steps
         for (ix, ic) in enumerate(initial_duration[:, 1])
@@ -349,21 +374,33 @@ function device_duration_compact_retrospective!(
     optimization_container::OptimizationContainer,
     duration_data::Vector{UpDown},
     initial_duration::Matrix{InitialCondition},
-    cons_name::Symbol,
-    var_keys::Tuple{VariableKey, VariableKey, VariableKey},
-)
+    cons_type::ConstraintType,
+    var_types::Tuple{VariableType, VariableType, VariableType},
+    ::Type{T},
+) where {T <: PSY.Component}
     time_steps = model_time_steps(optimization_container)
 
-    varon = get_variable(optimization_container, var_keys[1])
-    varstart = get_variable(optimization_container, var_keys[2])
-    varstop = get_variable(optimization_container, var_keys[3])
-
-    name_up = middle_rename(cons_name, PSI_NAME_DELIMITER, "up")
-    name_down = middle_rename(cons_name, PSI_NAME_DELIMITER, "dn")
+    varon = get_variable(optimization_container, var_types[1], T)
+    varstart = get_variable(optimization_container, var_types[2], T)
+    varstop = get_variable(optimization_container, var_types[3], T)
 
     set_names = [get_device_name(ic) for ic in initial_duration[:, 1]]
-    con_up = add_cons_container!(optimization_container, name_up, set_names, time_steps)
-    con_down = add_cons_container!(optimization_container, name_down, set_names, time_steps)
+    con_up = add_cons_container!(
+        optimization_container,
+        cons_type,
+        T,
+        set_names,
+        time_steps,
+        meta = "up",
+    )
+    con_down = add_cons_container!(
+        optimization_container,
+        cons_type,
+        T,
+        set_names,
+        time_steps,
+        meta = "dn",
+    )
     total_time_steps = length(time_steps)
     for t in time_steps
         for (ix, ic) in enumerate(initial_duration[:, 1])

--- a/src/devices_models/devices/common/energy_management_constraints.jl
+++ b/src/devices_models/devices/common/energy_management_constraints.jl
@@ -13,17 +13,18 @@ Constructs constraint energy target data, and variable
 function energy_target!(
     optimization_container::OptimizationContainer,
     target_data::Vector{T},
-    cons_name::Symbol,
-    var_keys::Tuple{VariableKey, VariableKey, VariableKey},
-) where {T <: DeviceTimeSeriesConstraintInfo}
+    cons_type::ConstraintType,
+    var_types::Tuple{VariableType, VariableType, VariableType},
+    ::Type{U},
+) where {T <: DeviceTimeSeriesConstraintInfo, U <: PSY.Component}
     time_steps = model_time_steps(optimization_container)
     name_index = [get_component_name(d) for d in target_data]
-    varenergy = get_variable(optimization_container, var_keys[1])
-    varslack_up = get_variable(optimization_container, var_keys[2])
-    varslack_dn = get_variable(optimization_container, var_keys[3])
+    varenergy = get_variable(optimization_container, var_types[1], U)
+    varslack_up = get_variable(optimization_container, var_types[2], U)
+    varslack_dn = get_variable(optimization_container, var_types[3], U)
 
     target_constraint =
-        add_cons_container!(optimization_container, cons_name, name_index, time_steps)
+        add_cons_container!(optimization_container, cons_type, U, name_index, time_steps)
 
     for data in target_data, t in time_steps
         name = get_component_name(data)
@@ -50,18 +51,20 @@ Constructs constraint energy target data, and variable
 * var_names::Symbol : the name of the energy variable
 * param_reference::UpdateRef : UpdateRef to access the target parameter
 """
+# TODO DT: fix all docstrings that are now invalid
 function energy_target_param!(
     optimization_container::OptimizationContainer,
     target_data::Vector{DeviceTimeSeriesConstraintInfo},
-    cons_name::Symbol,
-    var_keys::Tuple{VariableKey, VariableKey, VariableKey},
+    cons_type::ConstraintType,
+    var_types::Tuple{VariableType, VariableType, VariableType},
     param_reference::UpdateRef,
-)
+    ::Type{T},
+) where {T <: PSY.Component}
     time_steps = model_time_steps(optimization_container)
     name_index = [get_component_name(d) for d in target_data]
-    varenergy = get_variable(optimization_container, var_keys[1])
-    varslack_up = get_variable(optimization_container, var_keys[2])
-    varslack_dn = get_variable(optimization_container, var_keys[3])
+    varenergy = get_variable(optimization_container, var_types[1], T)
+    varslack_up = get_variable(optimization_container, var_types[2], T)
+    varslack_dn = get_variable(optimization_container, var_types[3], T)
 
     container_target = add_param_container!(
         optimization_container,
@@ -72,7 +75,7 @@ function energy_target_param!(
     param_target = get_parameter_array(container_target)
     multiplier_target = get_multiplier_array(container_target)
     target_constraint =
-        add_cons_container!(optimization_container, cons_name, name_index, time_steps)
+        add_cons_container!(optimization_container, cons_type, T, name_index, time_steps)
 
     for d in target_data, t in time_steps
         name = get_component_name(d)

--- a/src/devices_models/devices/common/rateofchange_constraints.jl
+++ b/src/devices_models/devices/common/rateofchange_constraints.jl
@@ -30,19 +30,32 @@ If t > 1:
 function device_linear_rateofchange!(
     optimization_container::OptimizationContainer,
     rate_data::Vector{DeviceRampConstraintInfo},
-    cons_name::Symbol,
-    var_key::VariableKey,
-)
+    cons_type::ConstraintType,
+    var_type::VariableType,
+    ::Type{T},
+) where {T <: PSY.Component}
     parameters = model_has_parameters(optimization_container)
     time_steps = model_time_steps(optimization_container)
-    up_name = middle_rename(cons_name, PSI_NAME_DELIMITER, "up")
-    down_name = middle_rename(cons_name, PSI_NAME_DELIMITER, "dn")
 
-    variable = get_variable(optimization_container, var_key)
+    variable = get_variable(optimization_container, var_type, T)
 
     set_name = [get_component_name(r) for r in rate_data]
-    con_up = add_cons_container!(optimization_container, up_name, set_name, time_steps)
-    con_down = add_cons_container!(optimization_container, down_name, set_name, time_steps)
+    con_up = add_cons_container!(
+        optimization_container,
+        cons_type,
+        T,
+        set_name,
+        time_steps,
+        meta = "up",
+    )
+    con_down = add_cons_container!(
+        optimization_container,
+        cons_type,
+        T,
+        set_name,
+        time_steps,
+        meta = "dn",
+    )
 
     for r in rate_data
         name = get_component_name(r)
@@ -141,21 +154,34 @@ If t > 1:
 function device_mixedinteger_rateofchange!(
     optimization_container::OptimizationContainer,
     rate_data::Vector{DeviceRampConstraintInfo},
-    cons_name::Symbol,
-    var_keys::Tuple{VariableKey, VariableKey, VariableKey},
-)
+    cons_type::ConstraintType,
+    var_types::Tuple{VariableType, VariableType, VariableType},
+    ::Type{T},
+) where {T <: PSY.Component}
     parameters = model_has_parameters(optimization_container)
     time_steps = model_time_steps(optimization_container)
-    up_name = middle_rename(cons_name, PSI_NAME_DELIMITER, "up")
-    down_name = middle_rename(cons_name, PSI_NAME_DELIMITER, "dn")
 
-    variable = get_variable(optimization_container, var_keys[1])
-    varstart = get_variable(optimization_container, var_keys[2])
-    varstop = get_variable(optimization_container, var_keys[3])
+    variable = get_variable(optimization_container, var_types[1], T)
+    varstart = get_variable(optimization_container, var_types[2], T)
+    varstop = get_variable(optimization_container, var_types[3], T)
 
     set_name = [get_component_name(r) for r in rate_data]
-    con_up = add_cons_container!(optimization_container, up_name, set_name, time_steps)
-    con_down = add_cons_container!(optimization_container, down_name, set_name, time_steps)
+    con_up = add_cons_container!(
+        optimization_container,
+        cons_type,
+        T,
+        set_name,
+        time_steps,
+        meta = "up",
+    )
+    con_down = add_cons_container!(
+        optimization_container,
+        cons_type,
+        T,
+        set_name,
+        time_steps,
+        meta = "dn",
+    )
 
     for r in rate_data
         name = get_component_name(r)
@@ -256,18 +282,30 @@ If t > 1:
 function device_multistart_rateofchange!(
     optimization_container::OptimizationContainer,
     rate_data::Vector{DeviceRampConstraintInfo},
-    cons_name::Symbol,
-    var_key::VariableKey,
-)
+    cons_type::ConstraintType,
+    var_type::VariableType,
+    ::Type{T},
+) where {T <: PSY.Component}
     time_steps = model_time_steps(optimization_container)
-    up_name = middle_rename(cons_name, PSI_NAME_DELIMITER, "up")
-    down_name = middle_rename(cons_name, PSI_NAME_DELIMITER, "dn")
-
-    variable = get_variable(optimization_container, var_key)
+    variable = get_variable(optimization_container, var_type, T)
 
     set_name = [get_component_name(r) for r in rate_data]
-    con_up = add_cons_container!(optimization_container, up_name, set_name, time_steps)
-    con_down = add_cons_container!(optimization_container, down_name, set_name, time_steps)
+    con_up = add_cons_container!(
+        optimization_container,
+        cons_type,
+        T,
+        set_name,
+        time_steps,
+        meta = "up",
+    )
+    con_down = add_cons_container!(
+        optimization_container,
+        cons_type,
+        T,
+        set_name,
+        time_steps,
+        meta = "dn",
+    )
 
     for r in rate_data
         name = get_component_name(r)
@@ -330,17 +368,25 @@ end
 function service_upward_rateofchange!(
     optimization_container::OptimizationContainer,
     rate_data::Vector{ServiceRampConstraintInfo},
-    cons_name::Symbol,
-    var_key::VariableKey,
+    cons_type::ConstraintType,
+    var_type::VariableType,
     service_name::AbstractString,
-)
+    ::Type{T},
+) where {T <: PSY.Component}
     time_steps = model_time_steps(optimization_container)
-    up_name = middle_rename(cons_name, PSI_NAME_DELIMITER, "up" * service_name)
 
-    variable = get_variable(optimization_container, var_key)
+    # TODO DT: is this change valid?
+    variable = get_variable(optimization_container, var_type, T, service_name)
 
     set_name = [get_component_name(r) for r in rate_data]
-    con_up = add_cons_container!(optimization_container, up_name, set_name, time_steps)
+    con_up = add_cons_container!(
+        optimization_container,
+        cons_type,
+        T,
+        set_name,
+        time_steps,
+        meta = service_name,
+    )
 
     for r in rate_data, t in time_steps
         name = get_component_name(r)
@@ -356,17 +402,23 @@ end
 function service_downward_rateofchange!(
     optimization_container::OptimizationContainer,
     rate_data::Vector{ServiceRampConstraintInfo},
-    cons_name::Symbol,
-    var_key::VariableKey,
+    cons_type::ConstraintType,
+    var_type::VariableType,
     service_name::AbstractString,
-)
+    ::Type{T},
+) where {T <: PSY.Component}
     time_steps = model_time_steps(optimization_container)
-    down_name = middle_rename(cons_name, PSI_NAME_DELIMITER, "dn" * service_name)
-
-    variable = get_variable(optimization_container, var_key)
-
+    # TODO DT: is this change valid?
+    variable = get_variable(optimization_container, var_type, T, service_name)
     set_name = [get_component_name(r) for r in rate_data]
-    con_down = add_cons_container!(optimization_container, down_name, set_name, time_steps)
+    con_down = add_cons_container!(
+        optimization_container,
+        cons_type,
+        T,
+        set_name,
+        time_steps,
+        meta = service_name,
+    )
 
     for r in rate_data, t in time_steps
         name = get_component_name(r)

--- a/src/devices_models/devices/common/rating_constraints.jl
+++ b/src/devices_models/devices/common/rating_constraints.jl
@@ -22,19 +22,21 @@ where r in rating data and t in time steps.
 function rating_constraint!(
     optimization_container::OptimizationContainer,
     rating_data::Vector{Tuple{String, Float64}},
-    cons_name::Symbol,
-    var_keys::Tuple{VariableKey, VariableKey},
-)
+    cons_type::ConstraintType,
+    var_types::Tuple{VariableType, VariableType},
+    ::Type{T},
+) where {T <: PSY.Component}
     time_steps = model_time_steps(optimization_container)
-    var1 = get_variable(optimization_container, var_keys[1])
-    var2 = get_variable(optimization_container, var_keys[2])
+    var1 = get_variable(optimization_container, var_types[1], T)
+    var2 = get_variable(optimization_container, var_types[2], T)
     add_cons_container!(
         optimization_container,
-        cons_name,
+        cons_type,
+        T,
         [r[1] for r in rating_data],
         time_steps,
     )
-    constraint = get_constraint(optimization_container, cons_name)
+    constraint = get_constraint(optimization_container, cons_type, T)
 
     for r in rating_data
         for t in time_steps

--- a/src/devices_models/devices/common/timeseries_constraint.jl
+++ b/src/devices_models/devices/common/timeseries_constraint.jl
@@ -1,10 +1,11 @@
 
 struct TimeSeriesConstraintSpecInternal
     constraint_infos::Vector{DeviceTimeSeriesConstraintInfo}
-    constraint_name::Symbol
-    variable_key::VariableKey
-    bin_variable_key::Union{Nothing, VariableKey}
+    constraint_type::ConstraintType
+    variable_type::VariableType
+    bin_variable_type::Union{Nothing, VariableType}
     param_reference::Union{Nothing, UpdateRef}
+    component_type::Type{<:PSY.Component}
 end
 
 function lazy_lb!(
@@ -13,9 +14,16 @@ function lazy_lb!(
 )
     time_steps = model_time_steps(optimization_container)
     names = [get_component_name(x) for x in inputs.constraint_infos]
-    variable = get_variable(optimization_container, inputs.variable_key)
-    lb_name = middle_rename(inputs.constraint_name, PSI_NAME_DELIMITER, "lb")
-    con_lb = add_cons_container!(optimization_container, lb_name, names, time_steps)
+    variable =
+        get_variable(optimization_container, inputs.variable_type, inputs.component_type)
+    con_lb = add_cons_container!(
+        optimization_container,
+        inputs.constraint_type,
+        inputs.component_type,
+        names,
+        time_steps,
+        meta = "lb",
+    )
 
     for constraint_info in inputs.constraint_infos
         ci_name = get_component_name(constraint_info)
@@ -58,9 +66,16 @@ function device_timeseries_ub!(
 )
     time_steps = model_time_steps(optimization_container)
     names = [get_component_name(x) for x in inputs.constraint_infos]
-    variable = get_variable(optimization_container, inputs.variable_key)
-    ub_name = middle_rename(inputs.constraint_name, PSI_NAME_DELIMITER, "ub")
-    con_ub = add_cons_container!(optimization_container, ub_name, names, time_steps)
+    variable =
+        get_variable(optimization_container, inputs.variable_type, inputs.component_type)
+    con_ub = add_cons_container!(
+        optimization_container,
+        inputs.constraint_type,
+        inputs.component_type,
+        names,
+        time_steps,
+        meta = "ub",
+    )
     lazy_add_lb = false
 
     for constraint_info in inputs.constraint_infos
@@ -108,10 +123,17 @@ function device_timeseries_lb!(
     inputs::TimeSeriesConstraintSpecInternal,
 )
     time_steps = model_time_steps(optimization_container)
-    variable = get_variable(optimization_container, inputs.variable_key)
-    lb_name = middle_rename(inputs.constraint_name, PSI_NAME_DELIMITER, "lb")
+    variable =
+        get_variable(optimization_container, inputs.variable_type, inputs.component_type)
     names = [get_component_name(x) for x in inputs.constraint_infos]
-    constraint = add_cons_container!(optimization_container, lb_name, names, time_steps)
+    constraint = add_cons_container!(
+        optimization_container,
+        inputs.constraint_type,
+        inputs.component_type,
+        names,
+        time_steps,
+        meta = "lb",
+    )
 
     for constraint_info in inputs.constraint_infos
         ci_name = get_component_name(constraint_info)
@@ -151,9 +173,16 @@ function device_timeseries_param_ub!(
 )
     time_steps = model_time_steps(optimization_container)
     names = [get_component_name(x) for x in inputs.constraint_infos]
-    variable = get_variable(optimization_container, inputs.variable_key)
-    ub_name = middle_rename(inputs.constraint_name, PSI_NAME_DELIMITER, "ub")
-    con_ub = add_cons_container!(optimization_container, ub_name, names, time_steps)
+    variable =
+        get_variable(optimization_container, inputs.variable_type, inputs.component_type)
+    con_ub = add_cons_container!(
+        optimization_container,
+        inputs.constraint_type,
+        inputs.component_type,
+        names,
+        time_steps,
+        meta = "ub",
+    )
     container = add_param_container!(
         optimization_container,
         inputs.param_reference,
@@ -212,10 +241,17 @@ function device_timeseries_param_lb!(
     inputs::TimeSeriesConstraintSpecInternal,
 )
     time_steps = model_time_steps(optimization_container)
-    variable = get_variable(optimization_container, inputs.variable_key)
-    lb_name = middle_rename(inputs.constraint_name, PSI_NAME_DELIMITER, "lb")
+    variable =
+        get_variable(optimization_container, inputs.variable_type, inputs.component_type)
     names = [get_component_name(x) for x in inputs.constraint_infos]
-    constraint = add_cons_container!(optimization_container, lb_name, names, time_steps)
+    add_cons_container!(
+        optimization_container,
+        inputs.constraint_type,
+        inputs.component_type,
+        names,
+        time_steps,
+        meta = "lb",
+    )
     container = add_param_container!(
         optimization_container,
         inputs.param_reference,
@@ -270,11 +306,22 @@ function device_timeseries_ub_bin!(
     inputs::TimeSeriesConstraintSpecInternal,
 )
     time_steps = model_time_steps(optimization_container)
-    ub_name = middle_rename(inputs.constraint_name, PSI_NAME_DELIMITER, "ub")
-    varcts = get_variable(optimization_container, inputs.variable_key)
-    varbin = get_variable(optimization_container, inputs.bin_variable_key)
+    varcts =
+        get_variable(optimization_container, inputs.variable_type, inputs.component_type)
+    varbin = get_variable(
+        optimization_container,
+        inputs.bin_variable_type,
+        inputs.component_type,
+    )
     names = [get_component_name(x) for x in inputs.constraint_infos]
-    con_ub = add_cons_container!(optimization_container, ub_name, names, time_steps)
+    con_ub = add_cons_container!(
+        optimization_container,
+        inputs.constraint_type,
+        inputs.component_type,
+        names,
+        time_steps,
+        meta = "ub",
+    )
     for constraint_info in inputs.constraint_infos
         ci_name = get_component_name(constraint_info)
         for t in time_steps
@@ -317,14 +364,31 @@ function device_timeseries_ub_bigM!(
     inputs::TimeSeriesConstraintSpecInternal,
 )
     time_steps = model_time_steps(optimization_container)
-    ub_name = middle_rename(inputs.constraint_name, PSI_NAME_DELIMITER, "ub")
-    key_status = middle_rename(inputs.constraint_name, PSI_NAME_DELIMITER, "status")
 
-    varcts = get_variable(optimization_container, inputs.variable_key)
-    varbin = get_variable(optimization_container, inputs.bin_variable_key)
+    varcts =
+        get_variable(optimization_container, inputs.variable_type, inputs.component_type)
+    varbin = get_variable(
+        optimization_container,
+        inputs.bin_variable_type,
+        inputs.component_type,
+    )
     names = [get_component_name(x) for x in inputs.constraint_infos]
-    con_ub = add_cons_container!(optimization_container, ub_name, names, time_steps)
-    con_status = add_cons_container!(optimization_container, key_status, names, time_steps)
+    con_ub = add_cons_container!(
+        optimization_container,
+        inputs.constraint_type,
+        inputs.component_type,
+        names,
+        time_steps,
+        meta = "ub",
+    )
+    con_status = add_cons_container!(
+        optimization_container,
+        inputs.constraint_type,
+        inputs.component_type,
+        names,
+        time_steps,
+        meta = "status",
+    )
     container = add_param_container!(
         optimization_container,
         inputs.param_reference,

--- a/src/devices_models/devices/hydro_generation.jl
+++ b/src/devices_models/devices/hydro_generation.jl
@@ -112,7 +112,7 @@ This function define the range constraint specs for the
 reactive power for dispatch formulations.
 """
 function DeviceRangeConstraintSpec(
-    ::Type{<:RangeConstraint},
+    ::Type{<:ReactivePowerVariableLimitsConstraint},
     ::Type{ReactivePowerVariable},
     ::Type{T},
     ::Type{<:AbstractHydroDispatchFormulation},
@@ -123,15 +123,12 @@ function DeviceRangeConstraintSpec(
 ) where {T <: PSY.HydroGen}
     return DeviceRangeConstraintSpec(;
         range_constraint_spec = RangeConstraintSpec(;
-            constraint_name = make_constraint_name(
-                RangeConstraint,
-                ReactivePowerVariable,
-                T,
-            ),
-            variable_key = VariableKey(ReactivePowerVariable, T),
+            constraint_type = ReactivePowerVariableLimitsConstraint(),
+            variable_type = ReactivePowerVariable(),
             limits_func = x -> PSY.get_reactive_power_limits(x),
             constraint_func = device_range!,
             constraint_struct = DeviceRangeConstraintInfo,
+            component_type = T,
         ),
     )
 end
@@ -141,7 +138,7 @@ This function define the range constraint specs for the
 active power for dispatch Run of River formulations.
 """
 function DeviceRangeConstraintSpec(
-    ::Type{<:RangeConstraint},
+    ::Type{<:ActivePowerVariableLimitsConstraint},
     ::Type{ActivePowerVariable},
     ::Type{T},
     ::Type{<:AbstractHydroDispatchFormulation},
@@ -153,28 +150,26 @@ function DeviceRangeConstraintSpec(
     if !use_parameters && !use_forecasts
         return DeviceRangeConstraintSpec(;
             range_constraint_spec = RangeConstraintSpec(;
-                constraint_name = make_constraint_name(
-                    RangeConstraint,
-                    ActivePowerVariable,
-                    T,
-                ),
-                variable_key = VariableKey(ActivePowerVariable, T),
+                constraint_type = ActivePowerVariableLimitsConstraint(),
+                variable_type = ActivePowerVariable(),
                 limits_func = x -> (min = 0.0, max = PSY.get_active_power(x)),
                 constraint_func = device_range!,
                 constraint_struct = DeviceRangeConstraintInfo,
+                component_type = T,
             ),
         )
     end
 
     return DeviceRangeConstraintSpec(;
         timeseries_range_constraint_spec = TimeSeriesConstraintSpec(
-            constraint_name = make_constraint_name(RangeConstraint, ActivePowerVariable, T),
-            variable_key = VariableKey(ActivePowerVariable, T),
+            constraint_type = ActivePowerVariableLimitsConstraint(),
+            variable_type = ActivePowerVariable(),
             parameter_name = use_parameters ? "P" : nothing,
             forecast_label = "max_active_power",
             multiplier_func = x -> PSY.get_max_active_power(x),
             constraint_func = use_parameters ? device_timeseries_param_ub! :
                               device_timeseries_ub!,
+            component_type = T,
         ),
     )
 end
@@ -184,7 +179,7 @@ This function define the range constraint specs for the
 active power for dispatch Reservoir formulations.
 """
 function DeviceRangeConstraintSpec(
-    ::Type{<:RangeConstraint},
+    ::Type{<:ActivePowerVariableLimitsConstraint},
     ::Type{ActivePowerVariable},
     ::Type{T},
     ::Type{<:AbstractHydroReservoirFormulation},
@@ -195,11 +190,12 @@ function DeviceRangeConstraintSpec(
 ) where {T <: PSY.HydroGen}
     return DeviceRangeConstraintSpec(;
         range_constraint_spec = RangeConstraintSpec(;
-            constraint_name = make_constraint_name(RangeConstraint, ActivePowerVariable, T),
-            variable_key = VariableKey(ActivePowerVariable, T),
+            constraint_type = ActivePowerVariableLimitsConstraint(),
+            variable_type = ActivePowerVariable(),
             limits_func = x -> PSY.get_active_power_limits(x),
             constraint_func = device_range!,
             constraint_struct = DeviceRangeConstraintInfo,
+            component_type = T,
         ),
     )
 end
@@ -209,7 +205,7 @@ This function define the range constraint specs for the
 active power for commitment formulations (semi continuous).
 """
 function DeviceRangeConstraintSpec(
-    ::Type{<:RangeConstraint},
+    ::Type{<:ActivePowerVariableLimitsConstraint},
     ::Type{ActivePowerVariable},
     ::Type{T},
     ::Type{<:AbstractHydroUnitCommitment},
@@ -220,12 +216,13 @@ function DeviceRangeConstraintSpec(
 ) where {T <: PSY.HydroGen}
     return DeviceRangeConstraintSpec(;
         range_constraint_spec = RangeConstraintSpec(;
-            constraint_name = make_constraint_name(RangeConstraint, ActivePowerVariable, T),
-            variable_key = VariableKey(ActivePowerVariable, T),
-            bin_variable_keys = [VariableKey(OnVariable, T)],
+            constraint_type = ActivePowerVariableLimitsConstraint(),
+            variable_type = ActivePowerVariable(),
+            bin_variable_types = [OnVariable()],
             limits_func = x -> PSY.get_active_power_limits(x),
             constraint_func = device_semicontinuousrange!,
             constraint_struct = DeviceRangeConstraintInfo,
+            component_type = T,
         ),
     )
 end
@@ -235,7 +232,7 @@ This function define the range constraint specs for the
 reactive power for commitment formulations (semi continuous).
 """
 function DeviceRangeConstraintSpec(
-    ::Type{<:RangeConstraint},
+    ::Type{<:ReactivePowerVariableLimitsConstraint},
     ::Type{ReactivePowerVariable},
     ::Type{T},
     ::Type{<:AbstractHydroUnitCommitment},
@@ -246,22 +243,19 @@ function DeviceRangeConstraintSpec(
 ) where {T <: PSY.HydroGen}
     return DeviceRangeConstraintSpec(;
         range_constraint_spec = RangeConstraintSpec(;
-            constraint_name = make_constraint_name(
-                RangeConstraint,
-                ReactivePowerVariable,
-                T,
-            ),
-            variable_key = VariableKey(ReactivePowerVariable, T),
-            bin_variable_keys = [VariableKey(OnVariable, T)],
+            constraint_type = ReactivePowerVariableLimitsConstraint(),
+            variable_type = ReactivePowerVariable(),
+            bin_variable_types = [OnVariable()],
             limits_func = x -> PSY.get_active_power_limits(x),
             constraint_func = device_semicontinuousrange!,
             constraint_struct = DeviceRangeConstraintInfo,
+            component_type = T,
         ),
     )
 end
 
 function DeviceRangeConstraintSpec(
-    ::Type{<:RangeConstraint},
+    ::Type{<:OutputActivePowerVariableLimitsConstraint},
     ::Type{ActivePowerOutVariable},
     ::Type{T},
     ::Type{<:HydroDispatchPumpedStorage},
@@ -272,21 +266,18 @@ function DeviceRangeConstraintSpec(
 ) where {T <: PSY.HydroGen}
     return DeviceRangeConstraintSpec(;
         range_constraint_spec = RangeConstraintSpec(;
-            constraint_name = make_constraint_name(
-                RangeConstraint,
-                ActivePowerOutVariable,
-                T,
-            ),
-            variable_key = VariableKey(ActivePowerOutVariable, T),
+            constraint_type = OutputActivePowerVariableLimitsConstraint(),
+            variable_type = ActivePowerOutVariable(),
             limits_func = x -> PSY.get_active_power_limits(x),
             constraint_func = device_range!,
             constraint_struct = DeviceRangeConstraintInfo,
+            component_type = T,
         ),
     )
 end
 
 function DeviceRangeConstraintSpec(
-    ::Type{<:RangeConstraint},
+    ::Type{<:InputActivePowerVariableLimitsConstraint},
     ::Type{ActivePowerInVariable},
     ::Type{T},
     ::Type{<:HydroDispatchPumpedStorage},
@@ -297,21 +288,18 @@ function DeviceRangeConstraintSpec(
 ) where {T <: PSY.HydroGen}
     return DeviceRangeConstraintSpec(;
         range_constraint_spec = RangeConstraintSpec(;
-            constraint_name = make_constraint_name(
-                RangeConstraint,
-                ActivePowerInVariable,
-                T,
-            ),
-            variable_key = VariableKey(ActivePowerInVariable, T),
+            constraint_type = InputActivePowerVariableLimitsConstraint(),
+            variable_type = ActivePowerInVariable(),
             limits_func = x -> PSY.get_active_power_limits_pump(x),
             constraint_func = device_range!,
             constraint_struct = DeviceRangeConstraintInfo,
+            component_type = T,
         ),
     )
 end
 
 function DeviceRangeConstraintSpec(
-    ::Type{<:RangeConstraint},
+    ::Type{<:OutputActivePowerVariableLimitsConstraint},
     ::Type{ActivePowerOutVariable},
     ::Type{T},
     ::Type{<:HydroDispatchPumpedStoragewReservation},
@@ -322,22 +310,19 @@ function DeviceRangeConstraintSpec(
 ) where {T <: PSY.HydroGen}
     return DeviceRangeConstraintSpec(;
         range_constraint_spec = RangeConstraintSpec(;
-            constraint_name = make_constraint_name(
-                RangeConstraint,
-                ActivePowerOutVariable,
-                T,
-            ),
-            variable_key = VariableKey(ActivePowerOutVariable, T),
-            bin_variable_keys = [VariableKey(ReservationVariable, T)],
+            constraint_type = OutputActivePowerVariableLimitsConstraint(),
+            variable_type = ActivePowerOutVariable(),
+            bin_variable_types = [ReservationVariable()],
             limits_func = x -> PSY.get_active_power_limits(x),
             constraint_func = reserve_device_semicontinuousrange!,
             constraint_struct = DeviceRangeConstraintInfo,
+            component_type = T,
         ),
     )
 end
 
 function DeviceRangeConstraintSpec(
-    ::Type{<:RangeConstraint},
+    ::Type{<:InputActivePowerVariableLimitsConstraint},
     ::Type{ActivePowerInVariable},
     ::Type{T},
     ::Type{<:HydroDispatchPumpedStoragewReservation},
@@ -348,16 +333,13 @@ function DeviceRangeConstraintSpec(
 ) where {T <: PSY.HydroGen}
     return DeviceRangeConstraintSpec(;
         range_constraint_spec = RangeConstraintSpec(;
-            constraint_name = make_constraint_name(
-                RangeConstraint,
-                ActivePowerInVariable,
-                T,
-            ),
-            variable_key = VariableKey(ActivePowerInVariable, T),
-            bin_variable_keys = [VariableKey(ReservationVariable, T)],
+            constraint_type = InputActivePowerVariableLimitsConstraint(),
+            variable_type = ActivePowerInVariable(),
+            bin_variable_types = [ReservationVariable()],
             limits_func = x -> PSY.get_active_power_limits_pump(x),
             constraint_func = reserve_device_semicontinuousrange!,
             constraint_struct = DeviceRangeConstraintInfo,
+            component_type = T,
         ),
     )
 end
@@ -379,13 +361,14 @@ function commit_hydro_active_power_ub!(
     if use_parameters || use_forecasts
         spec = DeviceRangeConstraintSpec(;
             timeseries_range_constraint_spec = TimeSeriesConstraintSpec(
-                constraint_name = make_constraint_name(COMMITMENT, V),
-                variable_key = VariableKey(ActivePowerVariable, V),
+                constraint_type = CommitmentConstraint(),
+                variable_type = ActivePowerVariable(),
                 parameter_name = use_parameters ? "P" : nothing,
                 forecast_label = "max_active_power",
                 multiplier_func = x -> PSY.get_max_active_power(x),
                 constraint_func = use_parameters ? device_timeseries_param_ub! :
                                   device_timeseries_ub!,
+                component_type = V,
             ),
         )
         device_range_constraints!(optimization_container, devices, model, feedforward, spec)
@@ -409,14 +392,12 @@ function DeviceEnergyBalanceConstraintSpec(
     use_forecasts::Bool,
 ) where {H <: PSY.HydroEnergyReservoir}
     return DeviceEnergyBalanceConstraintSpec(;
-        constraint_name = make_constraint_name(ENERGY_CAPACITY, H),
-        energy_variable = VariableKey(EnergyVariable, H),
+        constraint_type = EnergyCapacityConstraint(),
+        energy_variable = EnergyVariable(),
         initial_condition = InitialEnergyLevel,
-        pout_variable_keys = [
-            VariableKey(ActivePowerVariable, H),
-            VariableKey(WaterSpillageVariable, H),
-        ],
+        pout_variable_types = [ActivePowerVariable(), WaterSpillageVariable()],
         constraint_func = use_parameters ? energy_balance_param! : energy_balance!,
+        component_type = H,
         parameter_name = "inflow",
         forecast_label = "inflow",
         multiplier_func = x -> PSY.get_inflow(x) * PSY.get_conversion_factor(x),
@@ -438,15 +419,13 @@ function DeviceEnergyBalanceConstraintSpec(
     use_forecasts::Bool,
 ) where {H <: PSY.HydroPumpedStorage}
     return DeviceEnergyBalanceConstraintSpec(;
-        constraint_name = make_constraint_name(ENERGY_CAPACITY_UP, H),
-        energy_variable = VariableKey(EnergyVariableUp, H),
+        constraint_type = EnergyCapacityUpConstraint(),
+        energy_variable = EnergyVariableUp(),
         initial_condition = InitialEnergyLevelUp,
-        pin_variable_keys = [VariableKey(ActivePowerInVariable, H)],
-        pout_variable_keys = [
-            VariableKey(ActivePowerOutVariable, H),
-            VariableKey(WaterSpillageVariable, H),
-        ],
+        pin_variable_types = [ActivePowerInVariable()],
+        pout_variable_types = [ActivePowerOutVariable(), WaterSpillageVariable()],
         constraint_func = use_parameters ? energy_balance_param! : energy_balance!,
+        component_type = H,
         parameter_name = "inflow",
         forecast_label = "inflow",
         multiplier_func = x -> PSY.get_inflow(x) * PSY.get_conversion_factor(x),
@@ -464,15 +443,13 @@ function DeviceEnergyBalanceConstraintSpec(
     use_forecasts::Bool,
 ) where {H <: PSY.HydroPumpedStorage}
     return DeviceEnergyBalanceConstraintSpec(;
-        constraint_name = make_constraint_name(ENERGY_CAPACITY_DOWN, H),
-        energy_variable = VariableKey(EnergyVariableDown, H),
+        constraint_type = EnergyCapacityDownConstraint(),
+        energy_variable = EnergyVariableDown(),
         initial_condition = InitialEnergyLevelDown,
-        pout_variable_keys = [VariableKey(ActivePowerInVariable, H)],
-        pin_variable_keys = [
-            VariableKey(ActivePowerOutVariable, H),
-            VariableKey(WaterSpillageVariable, H),
-        ],
+        pout_variable_types = [ActivePowerInVariable()],
+        pin_variable_types = [ActivePowerOutVariable(), WaterSpillageVariable()],
         constraint_func = use_parameters ? energy_balance_param! : energy_balance!,
+        component_type = H,
         parameter_name = "outflow",
         forecast_label = "outflow",
         multiplier_func = x -> PSY.get_outflow(x) * PSY.get_conversion_factor(x),
@@ -521,24 +498,18 @@ function energy_target_constraint!(
         energy_target_param!(
             optimization_container,
             constraint_infos_target,
-            make_constraint_name(ENERGY_TARGET, T),
-            (
-                VariableKey(EnergyVariable, T),
-                VariableKey(EnergyShortageVariable, T),
-                VariableKey(EnergySurplusVariable, T),
-            ),
+            EnergyTargetConstraint(),
+            (EnergyVariable(), EnergyShortageVariable(), EnergySurplusVariable()),
             UpdateRef{T}("target", target_forecast_label),
+            T,
         )
     else
         energy_target!(
             optimization_container,
             constraint_infos_target,
-            make_constraint_name(ENERGY_TARGET, T),
-            (
-                VariableKey(EnergyVariable, T),
-                VariableKey(EnergyShortageVariable, T),
-                VariableKey(EnergySurplusVariable, T),
-            ),
+            EnergyTargetConstraint(),
+            (EnergyVariable(), EnergyShortageVariable(), EnergySurplusVariable()),
+            T,
         )
     end
 
@@ -560,9 +531,10 @@ function energy_target_constraint!(
             optimization_container,
             RangeConstraintSpecInternal(
                 constraint_infos,
-                make_constraint_name(RangeConstraint, EnergyShortageVariable, T),
-                VariableKey(EnergyShortageVariable, T),
-                Vector{VariableKey}(),
+                EnergyShortageVariableLimitsConstraint(),
+                EnergyShortageVariable(),
+                Vector{VariableType}(),
+                T,
             ),
         )
     end
@@ -769,16 +741,18 @@ function energy_budget_constraints!(
         device_energy_budget_param_ub(
             optimization_container,
             constraint_data,
-            make_constraint_name("energy_budget", H),
+            EnergyBudgetConstraint(),
             UpdateRef{H}("energy_budget", forecast_label),
-            VariableKey(ActivePowerVariable, H),
+            ActivePowerVariable(),
+            H,
         )
     else
         device_energy_budget_ub(
             optimization_container,
             constraint_data,
-            make_constraint_name("energy_budget"),
-            VariableKey(ActivePowerVariable, H),
+            EnergyBudgetConstraint(),
+            ActivePowerVariable(),
+            H,
         )
     end
 end
@@ -790,16 +764,17 @@ for the active power budget formulation.
 function device_energy_budget_param_ub(
     optimization_container::OptimizationContainer,
     energy_budget_data::Vector{DeviceTimeSeriesConstraintInfo},
-    cons_name::Symbol,
+    cons_type::ConstraintType,
     param_reference::UpdateRef,
-    var_key::VariableKey,
-)
+    var_type::VariableType,
+    ::Type{T},
+) where {T <: PSY.Component}
     time_steps = model_time_steps(optimization_container)
     resolution = model_resolution(optimization_container)
     inv_dt = 1.0 / (Dates.value(Dates.Second(resolution)) / SECONDS_IN_HOUR)
-    variable_out = get_variable(optimization_container, var_key)
+    variable_out = get_variable(optimization_container, var_type, T)
     set_name = [get_component_name(r) for r in energy_budget_data]
-    constraint = add_cons_container!(optimization_container, cons_name, set_name)
+    constraint = add_cons_container!(optimization_container, cons_type, T, set_name)
     container =
         add_param_container!(optimization_container, param_reference, set_name, time_steps)
     multiplier = get_multiplier_array(container)
@@ -829,13 +804,14 @@ for the active power budget formulation.
 function device_energy_budget_ub(
     optimization_container::OptimizationContainer,
     energy_budget_constraints::Vector{DeviceTimeSeriesConstraintInfo},
-    cons_name::Symbol,
-    var_key::VariableKey,
-)
+    cons_type::ConstraintType,
+    var_type::VariableType,
+    ::Type{T},
+) where {T <: PSY.Component}
     time_steps = model_time_steps(optimization_container)
-    variable_out = get_variable(optimization_container, var_key)
+    variable_out = get_variable(optimization_container, var_type, T)
     names = [get_component_name(x) for x in energy_budget_constraints]
-    constraint = add_cons_container!(optimization_container, cons_name, names)
+    constraint = add_cons_container!(optimization_container, cons_type, T, names)
 
     for constraint_info in energy_budget_constraints
         name = get_component_name(constraint_info)

--- a/src/devices_models/devices/thermal_generation.jl
+++ b/src/devices_models/devices/thermal_generation.jl
@@ -62,7 +62,7 @@ get_variable_binary(::Union{ColdStartVariable, WarmStartVariable, HotStartVariab
 ######## CONSTRAINTS ############
 
 function DeviceRangeConstraintSpec(
-    ::Type{<:RangeConstraint},
+    ::Type{<:ConstraintType},
     ::Type{<:VariableType},
     ::Type{T},
     ::Type{<:AbstractThermalFormulation},
@@ -78,7 +78,7 @@ end
 This function adds the active power limits of generators when there are no CommitmentVariables
 """
 function DeviceRangeConstraintSpec(
-    ::Type{<:RangeConstraint},
+    ::Type{<:ActivePowerVariableLimitsConstraint},
     ::Type{ActivePowerVariable},
     ::Type{T},
     ::Type{<:AbstractThermalDispatchFormulation},
@@ -89,11 +89,12 @@ function DeviceRangeConstraintSpec(
 ) where {T <: PSY.ThermalGen}
     return DeviceRangeConstraintSpec(;
         range_constraint_spec = RangeConstraintSpec(;
-            constraint_name = make_constraint_name(RangeConstraint, ActivePowerVariable, T),
-            variable_key = VariableKey(ActivePowerVariable, T),
+            constraint_type = ActivePowerVariableLimitsConstraint(),
+            variable_type = ActivePowerVariable(),
             limits_func = x -> PSY.get_active_power_limits(x),
             constraint_func = device_range!,
             constraint_struct = DeviceRangeConstraintInfo,
+            component_type = T,
         ),
     )
 end
@@ -102,7 +103,7 @@ end
 This function adds the active power limits of generators when there are CommitmentVariables
 """
 function DeviceRangeConstraintSpec(
-    ::Type{<:RangeConstraint},
+    ::Type{<:ActivePowerVariableLimitsConstraint},
     ::Type{ActivePowerVariable},
     ::Type{T},
     ::Type{<:AbstractThermalUnitCommitment},
@@ -113,12 +114,13 @@ function DeviceRangeConstraintSpec(
 ) where {T <: PSY.ThermalGen}
     return DeviceRangeConstraintSpec(;
         range_constraint_spec = RangeConstraintSpec(;
-            constraint_name = make_constraint_name(RangeConstraint, ActivePowerVariable, T),
-            variable_key = VariableKey(ActivePowerVariable, T),
-            bin_variable_keys = [VariableKey(OnVariable, T)],
+            constraint_type = ActivePowerVariableLimitsConstraint(),
+            variable_type = ActivePowerVariable(),
+            bin_variable_types = [OnVariable()],
             limits_func = x -> PSY.get_active_power_limits(x),
             constraint_func = device_semicontinuousrange!,
             constraint_struct = DeviceRangeConstraintInfo,
+            component_type = T,
         ),
     )
 end
@@ -127,7 +129,7 @@ end
 This function adds the active power limits of generators when there are no CommitmentVariables
 """
 function DeviceRangeConstraintSpec(
-    ::Type{<:RangeConstraint},
+    ::Type{<:ActivePowerVariableLimitsConstraint},
     ::Type{ActivePowerVariable},
     ::Type{T},
     ::Type{<:ThermalDispatchNoMin},
@@ -138,11 +140,12 @@ function DeviceRangeConstraintSpec(
 ) where {T <: PSY.ThermalGen}
     return DeviceRangeConstraintSpec(;
         range_constraint_spec = RangeConstraintSpec(;
-            constraint_name = make_constraint_name(RangeConstraint, ActivePowerVariable, T),
-            variable_key = VariableKey(ActivePowerVariable, T),
+            constraint_type = ActivePowerVariableLimitsConstraint(),
+            variable_type = ActivePowerVariable(),
             limits_func = x -> (min = 0.0, max = PSY.get_active_power_limits(x).max),
             constraint_func = device_range!,
             constraint_struct = DeviceRangeConstraintInfo,
+            component_type = T,
         ),
         custom_optimization_container_func = custom_active_power_constraints!,
     )
@@ -167,7 +170,7 @@ end
 This function adds the active power limits of generators. Constraint (17) & (18) from PGLIB
 """
 function DeviceRangeConstraintSpec(
-    ::Type{<:RangeConstraint},
+    ::Type{<:ActivePowerVariableLimitsConstraint},
     ::Type{ActivePowerVariable},
     ::Type{T},
     ::Type{<:ThermalMultiStartUnitCommitment},
@@ -178,27 +181,24 @@ function DeviceRangeConstraintSpec(
 ) where {T <: PSY.ThermalMultiStart}
     return DeviceRangeConstraintSpec(;
         range_constraint_spec = RangeConstraintSpec(;
-            constraint_name = make_constraint_name(RangeConstraint, ActivePowerVariable, T),
-            variable_key = VariableKey(ActivePowerVariable, T),
+            constraint_type = ActivePowerVariableLimitsConstraint(),
+            variable_type = ActivePowerVariable(),
             limits_func = x -> (
                 min = 0.0,
                 max = PSY.get_active_power_limits(x).max -
                       PSY.get_active_power_limits(x).min,
             ),
-            bin_variable_keys = [
-                VariableKey(OnVariable, T),
-                VariableKey(StartVariable, T),
-                VariableKey(StopVariable, T),
-            ],
+            bin_variable_types = [OnVariable(), StartVariable(), StopVariable()],
             constraint_func = device_multistart_range!,
             constraint_struct = DeviceMultiStartRangeConstraintsInfo,
             lag_limits_func = PSY.get_power_trajectory,
+            component_type = T,
         ),
     )
 end
 
 function DeviceRangeConstraintSpec(
-    ::Type{<:RangeConstraint},
+    ::Type{<:ActivePowerVariableLimitsConstraint},
     ::Type{ActivePowerVariable},
     ::Type{T},
     ::Type{<:AbstractCompactUnitCommitment},
@@ -209,23 +209,20 @@ function DeviceRangeConstraintSpec(
 ) where {T <: PSY.ThermalGen}
     return DeviceRangeConstraintSpec(;
         range_constraint_spec = RangeConstraintSpec(;
-            constraint_name = make_constraint_name(RangeConstraint, ActivePowerVariable, T),
-            variable_key = VariableKey(ActivePowerVariable, T),
+            constraint_type = ActivePowerVariableLimitsConstraint(),
+            variable_type = ActivePowerVariable(),
             limits_func = x -> (
                 min = PSY.get_active_power_limits(x).min,
                 max = PSY.get_active_power_limits(x).max,
             ),
-            bin_variable_keys = [
-                VariableKey(OnVariable, T),
-                VariableKey(StartVariable, T),
-                VariableKey(StopVariable, T),
-            ],
+            bin_variable_types = [OnVariable(), StartVariable(), StopVariable()],
             constraint_func = device_multistart_range!,
             constraint_struct = DeviceMultiStartRangeConstraintsInfo,
             lag_limits_func = x -> (
                 startup = PSY.get_active_power_limits(x).max,
                 shutdown = PSY.get_active_power_limits(x).max,
             ),
+            component_type = T,
         ),
     )
 end
@@ -285,8 +282,9 @@ function initial_range_constraints!(
             optimization_container,
             constraint_data,
             ini_conds,
-            make_constraint_name(ACTIVE_RANGE_IC, T),
-            VariableKey(StopVariable, T),
+            ActiveRangeICConstraint(),
+            StopVariable(),
+            T,
         )
     else
         @warn "Data doesn't contain generators with ramp limits, consider adjusting your formulation"
@@ -298,7 +296,7 @@ end
 This function adds the reactive  power limits of generators when there are CommitmentVariables
 """
 function DeviceRangeConstraintSpec(
-    ::Type{<:RangeConstraint},
+    ::Type{<:ReactivePowerVariableLimitsConstraint},
     ::Type{ReactivePowerVariable},
     ::Type{T},
     ::Type{<:AbstractThermalDispatchFormulation},
@@ -309,21 +307,18 @@ function DeviceRangeConstraintSpec(
 ) where {T <: PSY.ThermalGen}
     return DeviceRangeConstraintSpec(;
         range_constraint_spec = RangeConstraintSpec(;
-            constraint_name = make_constraint_name(
-                RangeConstraint,
-                ReactivePowerVariable,
-                T,
-            ),
-            variable_key = VariableKey(ReactivePowerVariable, T),
+            constraint_type = ReactivePowerVariableLimitsConstraint(),
+            variable_type = ReactivePowerVariable(),
             limits_func = x -> PSY.get_reactive_power_limits(x),
             constraint_func = device_range!,
             constraint_struct = DeviceRangeConstraintInfo,
+            component_type = T,
         ),
     )
 end
 
 function DeviceRangeConstraintSpec(
-    ::Type{<:RangeConstraint},
+    ::Type{<:ReactivePowerVariableLimitsConstraint},
     ::Type{ReactivePowerVariable},
     ::Type{T},
     ::Type{<:AbstractThermalDispatchFormulation},
@@ -339,7 +334,7 @@ end
 This function adds the reactive power limits of generators when there CommitmentVariables
 """
 function DeviceRangeConstraintSpec(
-    ::Type{<:RangeConstraint},
+    ::Type{<:ReactivePowerVariableLimitsConstraint},
     ::Type{ReactivePowerVariable},
     ::Type{T},
     ::Type{<:AbstractThermalUnitCommitment},
@@ -350,22 +345,19 @@ function DeviceRangeConstraintSpec(
 ) where {T <: PSY.ThermalGen}
     return DeviceRangeConstraintSpec(;
         range_constraint_spec = RangeConstraintSpec(;
-            constraint_name = make_constraint_name(
-                RangeConstraint,
-                ReactivePowerVariable,
-                T,
-            ),
-            variable_key = VariableKey(ReactivePowerVariable, T),
-            bin_variable_keys = [VariableKey(OnVariable, T)],
+            constraint_type = ReactivePowerVariableLimitsConstraint(),
+            variable_type = ReactivePowerVariable(),
+            bin_variable_types = [OnVariable()],
             limits_func = x -> PSY.get_reactive_power_limits(x),
             constraint_func = device_semicontinuousrange!,
             constraint_struct = DeviceRangeConstraintInfo,
+            component_type = T,
         ),
     )
 end
 
 function DeviceRangeConstraintSpec(
-    ::Type{<:RangeConstraint},
+    ::Type{<:ReactivePowerVariableLimitsConstraint},
     ::Type{ReactivePowerVariable},
     ::Type{T},
     ::Type{<:AbstractThermalUnitCommitment},
@@ -395,12 +387,9 @@ function commitment_constraints!(
     device_commitment!(
         optimization_container,
         get_initial_conditions(optimization_container, ICKey(DeviceStatus, T)),
-        make_constraint_name(COMMITMENT, T),
-        (
-            VariableKey(StartVariable, T),
-            VariableKey(StopVariable, T),
-            VariableKey(OnVariable, T),
-        ),
+        CommitmentConstraint(),
+        (StartVariable(), StopVariable(), OnVariable()),
+        T,
     )
     return
 end
@@ -690,12 +679,9 @@ function ramp_constraints!(
         device_mixedinteger_rateofchange!(
             optimization_container,
             data,
-            make_constraint_name(RAMP, T),
-            (
-                VariableKey(ActivePowerVariable, T),
-                VariableKey(StartVariable, T),
-                VariableKey(StopVariable, T),
-            ),
+            RampConstraint(),
+            (ActivePowerVariable(), StartVariable(), StopVariable()),
+            T,
         )
     else
         @warn "Data doesn't contain generators with ramp limits, consider adjusting your formulation"
@@ -723,8 +709,9 @@ function ramp_constraints!(
         device_linear_rateofchange!(
             optimization_container,
             data,
-            make_constraint_name(RAMP, T),
-            VariableKey(ActivePowerVariable, T),
+            RampConstraint(),
+            ActivePowerVariable(),
+            T,
         )
     else
         @warn "Data doesn't contain generators with ramp limits, consider adjusting your formulation"
@@ -734,11 +721,11 @@ end
 
 function ramp_constraints!(
     optimization_container::OptimizationContainer,
-    ::IS.FlattenIteratorWrapper{PSY.ThermalMultiStart},
+    ::IS.FlattenIteratorWrapper{T},
     model::DeviceModel{PSY.ThermalMultiStart, ThermalMultiStartUnitCommitment},
     ::Type{S},
     feedforward::Union{Nothing, AbstractAffectFeedForward},
-) where {S <: PM.AbstractPowerModel}
+) where {S <: PM.AbstractPowerModel, T <: PSY.ThermalMultiStart}
     data = _get_data_for_rocc(optimization_container, PSY.ThermalMultiStart)
 
     # TODO: Refactor this to a cleaner format that doesn't require passing the device and rate_data this way
@@ -749,8 +736,9 @@ function ramp_constraints!(
         device_multistart_rateofchange!(
             optimization_container,
             data,
-            make_constraint_name(RAMP, PSY.ThermalMultiStart),
-            VariableKey(ActivePowerVariable, PSY.ThermalMultiStart),
+            RampConstraint(),
+            ActivePowerVariable(),
+            T,
         )
     else
         @warn "Data doesn't contain generators with ramp limits, consider adjusting your formulation"
@@ -800,36 +788,38 @@ for t in time_limits[s+1]:T
 function turbine_temperature(
     optimization_container::OptimizationContainer,
     startup_data::Vector{DeviceStartUpConstraintInfo},
-    cons_name::Symbol,
-    var_stop::VariableKey,
-    var_starts::Tuple{VariableKey, VariableKey},
-)
+    cons_type::ConstraintType,
+    var_stop::VariableType,
+    var_starts::Tuple{VariableType, VariableType},
+    ::Type{T},
+) where {T <: PSY.Component}
     time_steps = model_time_steps(optimization_container)
     start_vars = [
-        get_variable(optimization_container, var_starts[1]),
-        get_variable(optimization_container, var_starts[2]),
+        get_variable(optimization_container, var_starts[1], T),
+        get_variable(optimization_container, var_starts[2], T),
     ]
-    varstop = get_variable(optimization_container, var_stop)
-
-    hot_name = middle_rename(cons_name, PSI_NAME_DELIMITER, "hot")
-    warm_name = middle_rename(cons_name, PSI_NAME_DELIMITER, "warm")
+    varstop = get_variable(optimization_container, var_stop, T)
 
     names = [get_component_name(st) for st in startup_data]
 
     con = [
         add_cons_container!(
             optimization_container,
-            hot_name,
+            cons_type,
+            T,
             names,
             time_steps;
             sparse = true,
+            meta = "hot",
         ),
         add_cons_container!(
             optimization_container,
-            warm_name,
+            cons_type,
+            T,
             names,
             time_steps;
             sparse = true,
+            meta = "warm",
         ),
     ]
 
@@ -876,23 +866,24 @@ Constructs contraints that restricts devices to one type of start at a time
 * var_start::Symbol : name of the startup variable
 * var_starts::Tuple{Symbol, Symbol} : the names of the different start variables
 """
-function device_start_type_constraint(
+function device_start_type_constraint!(
     optimization_container::OptimizationContainer,
     data::Vector{DeviceStartTypesConstraintInfo},
-    cons_name::Symbol,
-    var_start::VariableKey,
-    var_keys::Tuple{VariableKey, VariableKey, VariableKey},
-)
+    cons_type::ConstraintType,
+    var_start::VariableType,
+    var_types::Tuple{VariableType, VariableType, VariableType},
+    ::Type{T},
+) where {T <: PSY.Component}
     time_steps = model_time_steps(optimization_container)
-    varstart = get_variable(optimization_container, var_start)
+    varstart = get_variable(optimization_container, var_start, T)
     start_vars = [
-        get_variable(optimization_container, var_keys[1]),
-        get_variable(optimization_container, var_keys[2]),
-        get_variable(optimization_container, var_keys[3]),
+        get_variable(optimization_container, var_types[1], T),
+        get_variable(optimization_container, var_types[2], T),
+        get_variable(optimization_container, var_types[3], T),
     ]
 
     set_name = [get_component_name(d) for d in data]
-    con = add_cons_container!(optimization_container, cons_name, set_name, time_steps)
+    con = add_cons_container!(optimization_container, cons_type, T, set_name, time_steps)
 
     for t in time_steps, d in data
         name = get_component_name(d)
@@ -933,40 +924,43 @@ lb:
 * var_names::Tuple{VariableKey, VariableKey} : the names of the different start variables
 * bin_name::VariableKey : name of the status variable
 """
-function device_startup_initial_condition(
+function device_startup_initial_condition!(
     optimization_container::OptimizationContainer,
     data::Vector{DeviceStartUpConstraintInfo},
     initial_conditions::Vector{InitialCondition},
-    cons_name::Symbol,
-    var_keys::Tuple{VariableKey, VariableKey},
-    bin_name::VariableKey,
-)
+    cons_type::ConstraintType,
+    var_types::Tuple{VariableType, VariableType},
+    bin_var::VariableType,
+    ::Type{T},
+) where {T <: PSY.Component}
     time_steps = model_time_steps(optimization_container)
 
     set_name = [get_device_name(ic) for ic in initial_conditions]
-    up_name = middle_rename(cons_name, PSI_NAME_DELIMITER, "ub")
-    down_name = middle_rename(cons_name, PSI_NAME_DELIMITER, "lb")
-    varbin = get_variable(optimization_container, bin_name)
+    varbin = get_variable(optimization_container, bin_var, T)
     varstarts = [
-        get_variable(optimization_container, var_keys[1]),
-        get_variable(optimization_container, var_keys[2]),
+        get_variable(optimization_container, var_types[1], T),
+        get_variable(optimization_container, var_types[2], T),
     ]
 
     con_ub = add_cons_container!(
         optimization_container,
-        up_name,
+        cons_type,
+        T,
         set_name,
         time_steps,
         1:(MAX_START_STAGES - 1);
         sparse = true,
+        meta = "ub",
     )
     con_lb = add_cons_container!(
         optimization_container,
-        down_name,
+        cons_type,
+        T,
         set_name,
         time_steps,
         1:(MAX_START_STAGES - 1);
         sparse = true,
+        meta = "lb",
     )
 
     for t in time_steps, (ix, d) in enumerate(data)
@@ -997,11 +991,11 @@ This function creates the contraints for different types of starts based on gene
 """
 function startup_time_constraints!(
     optimization_container::OptimizationContainer,
-    devices::IS.FlattenIteratorWrapper{PSY.ThermalMultiStart},
+    devices::IS.FlattenIteratorWrapper{T},
     ::DeviceModel{PSY.ThermalMultiStart, ThermalMultiStartUnitCommitment},
     ::Type{S},
     feedforward::Union{Nothing, AbstractAffectFeedForward},
-) where {S <: PM.AbstractPowerModel}
+) where {S <: PM.AbstractPowerModel, T <: PSY.ThermalMultiStart}
     resolution = model_resolution(optimization_container)
     lenght_devices = length(devices)
     start_time_params = Vector{DeviceStartUpConstraintInfo}(undef, lenght_devices)
@@ -1017,12 +1011,10 @@ function startup_time_constraints!(
     turbine_temperature(
         optimization_container,
         start_time_params,
-        make_constraint_name(STARTUP_TIMELIMIT, PSY.ThermalMultiStart),
-        VariableKey(StopVariable, PSY.ThermalMultiStart),
-        (
-            VariableKey(HotStartVariable, PSY.ThermalMultiStart),
-            VariableKey(WarmStartVariable, PSY.ThermalMultiStart),
-        ),
+        StartupTimeLimitTemperatureConstraint(),
+        StopVariable(),
+        (HotStartVariable(), WarmStartVariable()),
+        T,
     )
     return
 end
@@ -1032,11 +1024,11 @@ This function creates constraints to select a single type of startup based on of
 """
 function startup_type_constraints!(
     optimization_container::OptimizationContainer,
-    devices::IS.FlattenIteratorWrapper{PSY.ThermalMultiStart},
-    ::DeviceModel{PSY.ThermalMultiStart, ThermalMultiStartUnitCommitment},
+    devices::IS.FlattenIteratorWrapper{T},
+    ::DeviceModel{T, ThermalMultiStartUnitCommitment},
     ::Type{S},
     feedforward::Union{Nothing, AbstractAffectFeedForward},
-) where {S <: PM.AbstractPowerModel}
+) where {S <: PM.AbstractPowerModel, T <: PSY.ThermalMultiStart}
     constraint_data = Vector{DeviceStartTypesConstraintInfo}(undef, length(devices))
     for (ix, d) in enumerate(devices)
         name = PSY.get_name(d)
@@ -1045,16 +1037,13 @@ function startup_type_constraints!(
         constraint_data[ix] = range_data
     end
 
-    device_start_type_constraint(
+    device_start_type_constraint!(
         optimization_container,
         constraint_data,
-        make_constraint_name(START_TYPE, PSY.ThermalMultiStart),
-        VariableKey(StartVariable, PSY.ThermalMultiStart),
-        (
-            VariableKey(HotStartVariable, PSY.ThermalMultiStart),
-            VariableKey(WarmStartVariable, PSY.ThermalMultiStart),
-            VariableKey(ColdStartVariable, PSY.ThermalMultiStart),
-        ),
+        StartTypeConstraint(),
+        StartVariable(),
+        (HotStartVariable(), WarmStartVariable(), ColdStartVariable()),
+        T,
     )
     return
 end
@@ -1092,26 +1081,24 @@ This function creates the initial conditions for multi-start devices
 """
 function startup_initial_condition_constraints!(
     optimization_container::OptimizationContainer,
-    ::IS.FlattenIteratorWrapper{PSY.ThermalMultiStart},
+    ::IS.FlattenIteratorWrapper{T},
     ::DeviceModel{PSY.ThermalMultiStart, ThermalMultiStartUnitCommitment},
     ::Type{S},
     feedforward::Union{Nothing, AbstractAffectFeedForward},
-) where {S <: PM.AbstractPowerModel}
+) where {S <: PM.AbstractPowerModel, T <: PSY.ThermalMultiStart}
     resolution = model_resolution(optimization_container)
     key_off = ICKey(InitialTimeDurationOff, PSY.ThermalMultiStart)
     initial_conditions_offtime = get_initial_conditions(optimization_container, key_off)
     constraint_data = _get_data_startup_ic(initial_conditions_offtime, resolution)
 
-    device_startup_initial_condition(
+    device_startup_initial_condition!(
         optimization_container,
         constraint_data,
         initial_conditions_offtime,
-        make_constraint_name(STARTUP_INITIAL_CONDITION, PSY.ThermalMultiStart),
-        (
-            VariableKey(HotStartVariable, PSY.ThermalMultiStart),
-            VariableKey(WarmStartVariable, PSY.ThermalMultiStart),
-        ),
-        VariableKey(OnVariable, PSY.ThermalMultiStart),
+        StartupInitialConditionConstraint(),
+        (HotStartVariable(), WarmStartVariable()),
+        OnVariable(),
+        T,
     )
     return
 end
@@ -1121,11 +1108,11 @@ This function creates constraints that keep must run devices online
 """
 function must_run_constraints!(
     optimization_container::OptimizationContainer,
-    devices::IS.FlattenIteratorWrapper{PSY.ThermalMultiStart},
+    devices::IS.FlattenIteratorWrapper{T},
     ::DeviceModel{PSY.ThermalMultiStart, ThermalMultiStartUnitCommitment},
     ::Type{S},
     feedforward::Union{Nothing, AbstractAffectFeedForward},
-) where {S <: PM.AbstractPowerModel}
+) where {S <: PM.AbstractPowerModel, T <: PSY.ThermalMultiStart}
     time_steps = model_time_steps(optimization_container)
     constraint_infos = Vector{DeviceTimeSeriesConstraintInfo}(undef, length(devices))
     for (ix, d) in enumerate(devices)
@@ -1136,10 +1123,11 @@ function must_run_constraints!(
     end
     ts_inputs = TimeSeriesConstraintSpecInternal(
         constraint_infos,
-        make_constraint_name(MUST_RUN, PSY.ThermalMultiStart),
-        VariableKey(OnVariable, PSY.ThermalMultiStart),
+        MustRunConstraint(),
+        OnVariable(),
         nothing,
         nothing,
+        T,
     )
 
     device_timeseries_lb!(optimization_container, ts_inputs)
@@ -1215,24 +1203,18 @@ function time_constraints!(
                 optimization_container,
                 time_params,
                 ini_conds,
-                make_constraint_name(DURATION, T),
-                (
-                    VariableKey(OnVariable, T),
-                    VariableKey(StartVariable, T),
-                    VariableKey(StopVariable, T),
-                ),
+                DurationConstraint(),
+                (OnVariable(), StartVariable(), StopVariable()),
+                T,
             )
         else
             device_duration_retrospective!(
                 optimization_container,
                 time_params,
                 ini_conds,
-                make_constraint_name(DURATION, T),
-                (
-                    VariableKey(OnVariable, T),
-                    VariableKey(StartVariable, T),
-                    VariableKey(StopVariable, T),
-                ),
+                DurationConstraint(),
+                (OnVariable(), StartVariable(), StopVariable()),
+                T,
             )
         end
     else
@@ -1262,24 +1244,18 @@ function time_constraints!(
                 optimization_container,
                 time_params,
                 ini_conds,
-                make_constraint_name(DURATION, T),
-                (
-                    VariableKey(OnVariable, T),
-                    VariableKey(StartVariable, T),
-                    VariableKey(StopVariable, T),
-                ),
+                DurationConstraint(),
+                (OnVariable(), StartVariable(), StopVariable()),
+                T,
             )
         else
             device_duration_compact_retrospective!(
                 optimization_container,
                 time_params,
                 ini_conds,
-                make_constraint_name(DURATION, T),
-                (
-                    VariableKey(OnVariable, T),
-                    VariableKey(StartVariable, T),
-                    VariableKey(StopVariable, T),
-                ),
+                DurationConstraint(),
+                (OnVariable(), StartVariable(), StopVariable()),
+                T,
             )
         end
     else

--- a/src/logging.jl
+++ b/src/logging.jl
@@ -1,0 +1,2 @@
+
+LOG_GROUP_OPTIMZATION_CONTAINER = :OptimizationContainer

--- a/src/logging.jl
+++ b/src/logging.jl
@@ -1,2 +1,4 @@
 
+LOG_GROUP_COST_FUNCTIONS = :CostFunctions
+LOG_GROUP_INITIAL_CONDITIONS = :InitialConditions
 LOG_GROUP_OPTIMZATION_CONTAINER = :OptimizationContainer

--- a/src/network_models/area_balance_model.jl
+++ b/src/network_models/area_balance_model.jl
@@ -9,7 +9,8 @@ function area_balance(
     nodal_net_balance = optimization_container.expressions[expression]
     constraint = add_cons_container!(
         optimization_container,
-        :area_dispatch_balance,
+        AreaDispatchBalanceConstraint(),
+        PSY.Area,  # TODO DT: is this correct?
         keys(area_mapping),
         time_steps,
     )
@@ -34,15 +35,19 @@ function area_balance(
 
     participation_assignment_up = add_cons_container!(
         optimization_container,
-        :area_participation_assignment_up,
+        AreaParticipationAssignmentConstraint(),
+        PSY.Area,  # # TODO DT: correct?
         keys(area_mapping),
         time_steps,
+        meta = "up",
     )
     participation_assignment_dn = add_cons_container!(
         optimization_container,
-        :area_participation_assignment_dn,
+        AreaParticipationAssignmentConstraint(),
+        PSY.Area,  # TODO DT: correct?
         keys(area_mapping),
         time_steps,
+        meta = "dn",
     )
 
     for area in keys(area_mapping), t in time_steps

--- a/src/network_models/copperplate_model.jl
+++ b/src/network_models/copperplate_model.jl
@@ -6,8 +6,12 @@ function copper_plate(
     time_steps = model_time_steps(optimization_container)
     expressions = get_expression(optimization_container, expression)
     remove_undef!(optimization_container.expressions[expression])
-    constraint =
-        add_cons_container!(optimization_container, :CopperPlateBalance, time_steps)
+    constraint = add_cons_container!(
+        optimization_container,
+        CopperPlateBalanceConstraint(),
+        PSY.System,
+        time_steps,
+    )
     for t in time_steps
         constraint[t] = JuMP.@constraint(
             optimization_container.JuMPmodel,

--- a/src/services_models/group_reserve.jl
+++ b/src/services_models/group_reserve.jl
@@ -32,8 +32,7 @@ function service_requirement_constraint!(
     @debug initial_time
     time_steps = model_time_steps(optimization_container)
     name = PSY.get_name(service)
-    constraint =
-        get_constraint(optimization_container, make_constraint_name(REQUIREMENT, SR))
+    constraint = get_constraint(optimization_container, RequirementConstraint(), SR)
     use_slacks = get_services_slack_variables(optimization_container.settings)
     reserve_variables = [
         get_variable(

--- a/src/services_models/services_constructor.jl
+++ b/src/services_models/services_constructor.jl
@@ -77,7 +77,8 @@ function construct_service!(
 
     add_cons_container!(
         optimization_container,
-        make_constraint_name(REQUIREMENT, SR),
+        RequirementConstraint(),
+        SR,
         names,
         time_steps,
     )
@@ -129,7 +130,8 @@ function construct_service!(
     )
     add_cons_container!(
         optimization_container,
-        make_constraint_name(REQUIREMENT, SR),
+        RequirementConstraint(),
+        SR,
         names,
         time_steps,
     )
@@ -224,7 +226,8 @@ function construct_service!(
 
     add_cons_container!(
         optimization_container,
-        make_constraint_name(REQUIREMENT, SR),
+        RequirementConstraint(),
+        SR,
         names,
         time_steps,
     )
@@ -268,7 +271,8 @@ function construct_service!(
 
     add_cons_container!(
         optimization_container,
-        make_constraint_name(REQUIREMENT, SR),
+        RequirementConstraint(),
+        SR,
         names,
         time_steps,
     )

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -347,12 +347,6 @@ function sparse_container_spec(::Type{T}, axs...) where {T <: Any}
     return JuMP.Containers.SparseAxisArray(contents)
 end
 
-function middle_rename(original::Symbol, split_char::String, addition::String)
-    parts = split(String(original), split_char)
-    parts[1] = parts[1] * "_" * addition
-    return Symbol(join(parts, split_char))
-end
-
 "Replaces the string in `char` with the string`replacement`"
 function replace_chars(s::String, char::String, replacement::String)
     return replace(s, Regex("[$char]") => replacement)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -118,17 +118,33 @@ macro includetests(testarg...)
     end
 end
 
-function run_tests()
-    console_level = get_logging_level("SYS_CONSOLE_LOG_LEVEL", "Error")
-    console_logger = ConsoleLogger(stderr, console_level)
-    file_level = get_logging_level("SYS_LOG_LEVEL", "Info")
+function get_logging_level_from_env(env_name::String, default)
+    level = get(ENV, env_name, default)
+    return IS.get_logging_level(level)
+end
 
-    IS.open_file_logger(LOG_FILE, file_level) do file_logger
-        multi_logger = IS.MultiLogger(
-            [console_logger, file_logger],
-            IS.LogEventTracker((Logging.Info, Logging.Warn, Logging.Error)),
+function run_tests()
+    logging_config_filename = get(ENV, "SIIP_LOGGING_CONFIG", nothing)
+    if logging_config_filename !== nothing
+        config = IS.LoggingConfiguration(logging_config_filename)
+    else
+        config = IS.LoggingConfiguration(
+            filename = LOG_FILE,
+            file_level = Logging.Info,
+            console_level = Logging.Error,
         )
+    end
+    console_logger = ConsoleLogger(config.console_stream, config.console_level)
+
+    IS.open_file_logger(LOG_FILE, config.file_level) do file_logger
+        levels = (Logging.Info, Logging.Warn, Logging.Error)
+        multi_logger =
+            IS.MultiLogger([console_logger, file_logger], IS.LogEventTracker(levels))
         global_logger(multi_logger)
+
+        if !isempty(config.group_levels)
+            IS.set_group_levels!(multi_logger, config.group_levels)
+        end
 
         @time @testset "Begin PowerSimulations tests" begin
             @includetests ARGS

--- a/test/test_device_branch_constructors.jl
+++ b/test/test_device_branch_constructors.jl
@@ -85,11 +85,11 @@ end
 end
 
 @testset "DC Power Flow Models for HVDCLine with with Line Flow Constraints, TapTransformer & Transformer2W Unbounded" begin
-    ratelimit_constraint_names = [
-        :RateLimit_ub__Transformer2W,
-        :RateLimit_lb__Transformer2W,
-        :RateLimit_ub__TapTransformer,
-        :RateLimit_lb__TapTransformer,
+    ratelimit_constraint_keys = [
+        PSI.ConstraintKey(RateLimitConstraint, Transformer2W, "ub"),
+        PSI.ConstraintKey(RateLimitConstraint, Transformer2W, "lb"),
+        PSI.ConstraintKey(RateLimitConstraint, TapTransformer, "ub"),
+        PSI.ConstraintKey(RateLimitConstraint, TapTransformer, "lb"),
     ]
 
     system = PSB.build_system(PSITestSystems, "c_sys14_dc")
@@ -127,7 +127,7 @@ end
         )
         @test check_variable_unbounded(op_problem_m, FlowActivePowerVariable, Transformer2W)
 
-        psi_constraint_test(op_problem_m, ratelimit_constraint_names)
+        psi_constraint_test(op_problem_m, ratelimit_constraint_keys)
 
         @test solve!(op_problem_m) == RunStatus.SUCCESSFUL
 
@@ -232,13 +232,13 @@ end
 end
 
 @testset "AC Power Flow Models for HVDCLine Flow Constraints and TapTransformer & Transformer2W Unbounded" begin
-    ratelimit_constraint_names = [
-        :RateLimitFT__Transformer2W,
-        :RateLimitTF__Transformer2W,
-        :RateLimitFT__TapTransformer,
-        :RateLimitTF__TapTransformer,
-        :FlowActivePowerVariable_HVDCLine__FlowRateConstraintFT,
-        :FlowActivePowerVariable_HVDCLine__FlowRateConstraintTF,
+    ratelimit_constraint_keys = [
+        PSI.ConstraintKey(RateLimitFTConstraint, Transformer2W),
+        PSI.ConstraintKey(RateLimitTFConstraint, Transformer2W),
+        PSI.ConstraintKey(RateLimitFTConstraint, TapTransformer),
+        PSI.ConstraintKey(RateLimitTFConstraint, TapTransformer),
+        PSI.ConstraintKey(FlowRateConstraintFT, HVDCLine),
+        PSI.ConstraintKey(FlowRateConstraintTF, HVDCLine),
     ]
 
     system = PSB.build_system(PSITestSystems, "c_sys14_dc")
@@ -280,7 +280,7 @@ end
         Transformer2W,
     )
 
-    psi_constraint_test(op_problem_m, ratelimit_constraint_names)
+    psi_constraint_test(op_problem_m, ratelimit_constraint_keys)
 
     @test solve!(op_problem_m) == RunStatus.SUCCESSFUL
 

--- a/test/test_device_thermal_generation_constructors.jl
+++ b/test/test_device_thermal_generation_constructors.jl
@@ -1,5 +1,4 @@
 test_path = mktempdir()
-const RANGE_LB_CONSTRAINT = :ActivePowerVariable_ThermalStandard_lb__RangeConstraint
 @testset "ThermalGen data misspecification" begin
     # See https://discourse.julialang.org/t/how-to-use-test-warn/15557/5 about testing for warning throwing
     warn_message = "The data doesn't include devices of type ThermalStandard, consider changing the device models"
@@ -20,11 +19,11 @@ end
         PSI.VariableKey(StopVariable, PSY.ThermalStandard),
     ]
 
-    uc_constraint_names = [
-        PSI.make_constraint_name(PSI.RAMP_UP, PSY.ThermalStandard),
-        PSI.make_constraint_name(PSI.RAMP_DOWN, PSY.ThermalStandard),
-        PSI.make_constraint_name(PSI.DURATION_UP, PSY.ThermalStandard),
-        PSI.make_constraint_name(PSI.DURATION_DOWN, PSY.ThermalStandard),
+    uc_constraint_keys = [
+        PSI.ConstraintKey(RampConstraint, PSY.ThermalStandard, "up"),
+        PSI.ConstraintKey(RampConstraint, PSY.ThermalStandard, "dn"),
+        PSI.ConstraintKey(DurationConstraint, PSY.ThermalStandard, "up"),
+        PSI.ConstraintKey(DurationConstraint, PSY.ThermalStandard, "dn"),
     ]
 
     aux_vars_keys = [
@@ -37,7 +36,7 @@ end
     op_problem = OperationsProblem(MockOperationProblem, DCPPowerModel, c_sys5_uc)
     mock_construct_device!(op_problem, model)
     moi_tests(op_problem, false, 480, 0, 480, 120, 120, true)
-    psi_constraint_test(op_problem, uc_constraint_names)
+    psi_constraint_test(op_problem, uc_constraint_keys)
     psi_checkbinvar_test(op_problem, bin_variable_keys)
     psi_checkobjfun_test(op_problem, GAEVF)
     psi_aux_var_test(op_problem, aux_vars_keys)
@@ -50,7 +49,7 @@ end
     )
     mock_construct_device!(op_problem, model)
     moi_tests(op_problem, true, 480, 0, 480, 120, 120, true)
-    psi_constraint_test(op_problem, uc_constraint_names)
+    psi_constraint_test(op_problem, uc_constraint_keys)
     psi_checkbinvar_test(op_problem, bin_variable_keys)
     psi_checkobjfun_test(op_problem, GAEVF)
 
@@ -75,11 +74,11 @@ end
         PSI.VariableKey(StartVariable, PSY.ThermalStandard),
         PSI.VariableKey(StopVariable, PSY.ThermalStandard),
     ]
-    uc_constraint_names = [
-        PSI.make_constraint_name(PSI.RAMP_UP, PSY.ThermalStandard),
-        PSI.make_constraint_name(PSI.RAMP_DOWN, PSY.ThermalStandard),
-        PSI.make_constraint_name(PSI.DURATION_UP, PSY.ThermalStandard),
-        PSI.make_constraint_name(PSI.DURATION_DOWN, PSY.ThermalStandard),
+    uc_constraint_keys = [
+        PSI.ConstraintKey(RampConstraint, PSY.ThermalStandard, "up"),
+        PSI.ConstraintKey(RampConstraint, PSY.ThermalStandard, "dn"),
+        PSI.ConstraintKey(DurationConstraint, PSY.ThermalStandard, "up"),
+        PSI.ConstraintKey(DurationConstraint, PSY.ThermalStandard, "dn"),
     ]
 
     aux_vars_keys = [
@@ -93,7 +92,7 @@ end
     op_problem = OperationsProblem(MockOperationProblem, ACPPowerModel, c_sys5_uc)
     mock_construct_device!(op_problem, model)
     moi_tests(op_problem, false, 600, 0, 600, 240, 120, true)
-    psi_constraint_test(op_problem, uc_constraint_names)
+    psi_constraint_test(op_problem, uc_constraint_keys)
     psi_checkbinvar_test(op_problem, bin_variable_keys)
     psi_checkobjfun_test(op_problem, GAEVF)
     psi_aux_var_test(op_problem, aux_vars_keys)
@@ -106,7 +105,7 @@ end
     )
     mock_construct_device!(op_problem, model)
     moi_tests(op_problem, true, 600, 0, 600, 240, 120, true)
-    psi_constraint_test(op_problem, uc_constraint_names)
+    psi_constraint_test(op_problem, uc_constraint_keys)
     psi_checkbinvar_test(op_problem, bin_variable_keys)
     psi_checkobjfun_test(op_problem, GAEVF)
 
@@ -131,11 +130,11 @@ end
         PSI.VariableKey(StartVariable, PSY.ThermalMultiStart),
         PSI.VariableKey(StopVariable, PSY.ThermalMultiStart),
     ]
-    uc_constraint_names = [
-        PSI.make_constraint_name(PSI.RAMP_UP, PSY.ThermalMultiStart),
-        PSI.make_constraint_name(PSI.RAMP_DOWN, PSY.ThermalMultiStart),
-        PSI.make_constraint_name(PSI.DURATION_UP, PSY.ThermalMultiStart),
-        PSI.make_constraint_name(PSI.DURATION_DOWN, PSY.ThermalMultiStart),
+    uc_constraint_keys = [
+        PSI.ConstraintKey(RampConstraint, PSY.ThermalMultiStart, "up"),
+        PSI.ConstraintKey(RampConstraint, PSY.ThermalMultiStart, "dn"),
+        PSI.ConstraintKey(DurationConstraint, PSY.ThermalMultiStart, "up"),
+        PSI.ConstraintKey(DurationConstraint, PSY.ThermalMultiStart, "dn"),
     ]
     model = DeviceModel(ThermalMultiStart, ThermalStandardUnitCommitment)
 
@@ -149,7 +148,7 @@ end
         )
         mock_construct_device!(op_problem, model)
         moi_tests(op_problem, p, 384, 0, 240, 48, 96, true)
-        psi_constraint_test(op_problem, uc_constraint_names)
+        psi_constraint_test(op_problem, uc_constraint_keys)
         psi_checkbinvar_test(op_problem, bin_variable_keys)
         psi_checkobjfun_test(op_problem, GAEVF)
     end
@@ -161,11 +160,11 @@ end
         PSI.VariableKey(StartVariable, PSY.ThermalMultiStart),
         PSI.VariableKey(StopVariable, PSY.ThermalMultiStart),
     ]
-    uc_constraint_names = [
-        PSI.make_constraint_name(PSI.RAMP_UP, PSY.ThermalMultiStart),
-        PSI.make_constraint_name(PSI.RAMP_DOWN, PSY.ThermalMultiStart),
-        PSI.make_constraint_name(PSI.DURATION_UP, PSY.ThermalMultiStart),
-        PSI.make_constraint_name(PSI.DURATION_DOWN, PSY.ThermalMultiStart),
+    uc_constraint_keys = [
+        PSI.ConstraintKey(RampConstraint, PSY.ThermalMultiStart, "up"),
+        PSI.ConstraintKey(RampConstraint, PSY.ThermalMultiStart, "dn"),
+        PSI.ConstraintKey(DurationConstraint, PSY.ThermalMultiStart, "up"),
+        PSI.ConstraintKey(DurationConstraint, PSY.ThermalMultiStart, "dn"),
     ]
     model = DeviceModel(ThermalMultiStart, ThermalStandardUnitCommitment)
 
@@ -179,7 +178,7 @@ end
         )
         mock_construct_device!(op_problem, model)
         moi_tests(op_problem, p, 432, 0, 288, 96, 96, true)
-        psi_constraint_test(op_problem, uc_constraint_names)
+        psi_constraint_test(op_problem, uc_constraint_keys)
         psi_checkbinvar_test(op_problem, bin_variable_keys)
         psi_checkobjfun_test(op_problem, GAEVF)
     end
@@ -420,7 +419,8 @@ end
         )
         mock_construct_device!(op_problem, model)
         moi_tests(op_problem, p, 120, 0, 120, 120, 0, false)
-        moi_lbvalue_test(op_problem, RANGE_LB_CONSTRAINT, 0.0)
+        key = PSI.ConstraintKey(ActivePowerVariableLimitsConstraint, ThermalStandard, "lb")
+        moi_lbvalue_test(op_problem, key, 0.0)
         psi_checkobjfun_test(op_problem, GAEVF)
     end
 
@@ -434,7 +434,8 @@ end
         )
         mock_construct_device!(op_problem, model)
         moi_tests(op_problem, p, 120, 0, 120, 120, 0, false)
-        moi_lbvalue_test(op_problem, RANGE_LB_CONSTRAINT, 0.0)
+        key = PSI.ConstraintKey(ActivePowerVariableLimitsConstraint, ThermalStandard, "lb")
+        moi_lbvalue_test(op_problem, key, 0.0)
         psi_checkobjfun_test(op_problem, GQEVF)
     end
 end
@@ -451,7 +452,8 @@ end
         )
         mock_construct_device!(op_problem, model)
         moi_tests(op_problem, p, 240, 0, 240, 240, 0, false)
-        moi_lbvalue_test(op_problem, RANGE_LB_CONSTRAINT, 0.0)
+        key = PSI.ConstraintKey(ActivePowerVariableLimitsConstraint, ThermalStandard, "lb")
+        moi_lbvalue_test(op_problem, key, 0.0)
         psi_checkobjfun_test(op_problem, GAEVF)
     end
 
@@ -465,7 +467,8 @@ end
         )
         mock_construct_device!(op_problem, model)
         moi_tests(op_problem, p, 240, 0, 240, 240, 0, false)
-        moi_lbvalue_test(op_problem, RANGE_LB_CONSTRAINT, 0.0)
+        key = PSI.ConstraintKey(ActivePowerVariableLimitsConstraint, ThermalStandard, "lb")
+        moi_lbvalue_test(op_problem, key, 0.0)
         psi_checkobjfun_test(op_problem, GQEVF)
     end
 end
@@ -506,11 +509,11 @@ end
     end
 end
 =#
-################################### Ramp Limited Testing ##################################
+################################## Ramp Limited Testing ##################################
 @testset "Thermal Ramp Limited Dispatch With DC - PF" begin
-    constraint_names = [
-        PSI.make_constraint_name(PSI.RAMP_UP, PSY.ThermalStandard),
-        PSI.make_constraint_name(PSI.RAMP_DOWN, PSY.ThermalStandard),
+    constraint_keys = [
+        PSI.ConstraintKey(RampConstraint, PSY.ThermalStandard, "up"),
+        PSI.ConstraintKey(RampConstraint, PSY.ThermalStandard, "dn"),
     ]
     model = DeviceModel(ThermalStandard, ThermalRampLimited)
     c_sys5_uc = PSB.build_system(PSITestSystems, "c_sys5_uc")
@@ -523,7 +526,7 @@ end
         )
         mock_construct_device!(op_problem, model)
         moi_tests(op_problem, p, 120, 0, 216, 120, 0, false)
-        psi_constraint_test(op_problem, constraint_names)
+        psi_constraint_test(op_problem, constraint_keys)
         psi_checkobjfun_test(op_problem, GAEVF)
     end
 
@@ -542,9 +545,9 @@ end
 end
 
 @testset "Thermal Ramp Limited Dispatch With AC - PF" begin
-    constraint_names = [
-        PSI.make_constraint_name(PSI.RAMP_UP, PSY.ThermalStandard),
-        PSI.make_constraint_name(PSI.RAMP_DOWN, PSY.ThermalStandard),
+    constraint_keys = [
+        PSI.ConstraintKey(RampConstraint, PSY.ThermalStandard, "up"),
+        PSI.ConstraintKey(RampConstraint, PSY.ThermalStandard, "dn"),
     ]
     model = DeviceModel(ThermalStandard, ThermalRampLimited)
     c_sys5_uc = PSB.build_system(PSITestSystems, "c_sys5_uc")
@@ -557,7 +560,7 @@ end
         )
         mock_construct_device!(op_problem, model)
         moi_tests(op_problem, p, 240, 0, 336, 240, 0, false)
-        psi_constraint_test(op_problem, constraint_names)
+        psi_constraint_test(op_problem, constraint_keys)
         psi_checkobjfun_test(op_problem, GAEVF)
     end
 
@@ -576,9 +579,9 @@ end
 end
 
 @testset "Thermal Ramp Limited Dispatch With DC - PF" begin
-    constraint_names = [
-        PSI.make_constraint_name(PSI.RAMP_UP, PSY.ThermalMultiStart),
-        PSI.make_constraint_name(PSI.RAMP_DOWN, PSY.ThermalMultiStart),
+    constraint_keys = [
+        PSI.ConstraintKey(RampConstraint, PSY.ThermalMultiStart, "up"),
+        PSI.ConstraintKey(RampConstraint, PSY.ThermalMultiStart, "dn"),
     ]
     model = DeviceModel(ThermalMultiStart, ThermalRampLimited)
     c_sys5_uc = PSB.build_system(PSITestSystems, "c_sys5_pglib")
@@ -591,15 +594,15 @@ end
         )
         mock_construct_device!(op_problem, model)
         moi_tests(op_problem, p, 240, 0, 144, 48, 48, false)
-        psi_constraint_test(op_problem, constraint_names)
+        psi_constraint_test(op_problem, constraint_keys)
         psi_checkobjfun_test(op_problem, GAEVF)
     end
 end
 
 @testset "Thermal Ramp Limited Dispatch With AC - PF" begin
-    constraint_names = [
-        PSI.make_constraint_name(PSI.RAMP_UP, PSY.ThermalMultiStart),
-        PSI.make_constraint_name(PSI.RAMP_DOWN, PSY.ThermalMultiStart),
+    constraint_keys = [
+        PSI.ConstraintKey(RampConstraint, PSY.ThermalMultiStart, "up"),
+        PSI.ConstraintKey(RampConstraint, PSY.ThermalMultiStart, "dn"),
     ]
     model = DeviceModel(ThermalMultiStart, ThermalRampLimited)
     c_sys5_uc = PSB.build_system(PSITestSystems, "c_sys5_pglib")
@@ -612,7 +615,7 @@ end
         )
         mock_construct_device!(op_problem, model)
         moi_tests(op_problem, p, 288, 0, 192, 96, 48, false)
-        psi_constraint_test(op_problem, constraint_names)
+        psi_constraint_test(op_problem, constraint_keys)
         psi_checkobjfun_test(op_problem, GAEVF)
     end
 end
@@ -620,14 +623,22 @@ end
 ################################### ThermalMultiStart Testing ##################################
 
 @testset "Thermal MultiStart with MultiStart UC and DC - PF" begin
-    constraint_names = [
-        PSI.make_constraint_name(PSI.ACTIVE_RANGE_IC, PSY.ThermalMultiStart),
-        PSI.make_constraint_name(PSI.START_TYPE, PSY.ThermalMultiStart),
-        PSI.make_constraint_name(PSI.MUST_RUN_LB, PSY.ThermalMultiStart),
-        PSI.make_constraint_name(PSI.STARTUP_TIMELIMIT_WARM, PSY.ThermalMultiStart),
-        PSI.make_constraint_name(PSI.STARTUP_TIMELIMIT_HOT, PSY.ThermalMultiStart),
-        PSI.make_constraint_name(PSI.STARTUP_INITIAL_CONDITION_LB, PSY.ThermalMultiStart),
-        PSI.make_constraint_name(PSI.STARTUP_INITIAL_CONDITION_UB, PSY.ThermalMultiStart),
+    constraint_keys = [
+        PSI.ConstraintKey(ActiveRangeICConstraint, PSY.ThermalMultiStart),
+        PSI.ConstraintKey(StartTypeConstraint, PSY.ThermalMultiStart),
+        PSI.ConstraintKey(MustRunConstraint, PSY.ThermalMultiStart, "lb"),
+        PSI.ConstraintKey(
+            StartupTimeLimitTemperatureConstraint,
+            PSY.ThermalMultiStart,
+            "warm",
+        ),
+        PSI.ConstraintKey(
+            StartupTimeLimitTemperatureConstraint,
+            PSY.ThermalMultiStart,
+            "hot",
+        ),
+        PSI.ConstraintKey(StartupInitialConditionConstraint, PSY.ThermalMultiStart, "lb"),
+        PSI.ConstraintKey(StartupInitialConditionConstraint, PSY.ThermalMultiStart, "ub"),
     ]
     model = DeviceModel(PSY.ThermalMultiStart, PSI.ThermalMultiStartUnitCommitment)
     no_less_than = Dict(true => 334, false => 330)
@@ -641,20 +652,28 @@ end
         )
         mock_construct_device!(op_problem, model)
         moi_tests(op_problem, p, 528, 0, no_less_than[p], 106, 144, true)
-        psi_constraint_test(op_problem, constraint_names)
+        psi_constraint_test(op_problem, constraint_keys)
         psi_checkobjfun_test(op_problem, GAEVF)
     end
 end
 
 @testset "Thermal MultiStart with MultiStart UC and AC - PF" begin
-    constraint_names = [
-        PSI.make_constraint_name(PSI.ACTIVE_RANGE_IC, PSY.ThermalMultiStart),
-        PSI.make_constraint_name(PSI.START_TYPE, PSY.ThermalMultiStart),
-        PSI.make_constraint_name(PSI.MUST_RUN_LB, PSY.ThermalMultiStart),
-        PSI.make_constraint_name(PSI.STARTUP_TIMELIMIT_WARM, PSY.ThermalMultiStart),
-        PSI.make_constraint_name(PSI.STARTUP_TIMELIMIT_HOT, PSY.ThermalMultiStart),
-        PSI.make_constraint_name(PSI.STARTUP_INITIAL_CONDITION_LB, PSY.ThermalMultiStart),
-        PSI.make_constraint_name(PSI.STARTUP_INITIAL_CONDITION_UB, PSY.ThermalMultiStart),
+    constraint_keys = [
+        PSI.ConstraintKey(ActiveRangeICConstraint, PSY.ThermalMultiStart),
+        PSI.ConstraintKey(StartTypeConstraint, PSY.ThermalMultiStart),
+        PSI.ConstraintKey(MustRunConstraint, PSY.ThermalMultiStart, "lb"),
+        PSI.ConstraintKey(
+            StartupTimeLimitTemperatureConstraint,
+            PSY.ThermalMultiStart,
+            "warm",
+        ),
+        PSI.ConstraintKey(
+            StartupTimeLimitTemperatureConstraint,
+            PSY.ThermalMultiStart,
+            "hot",
+        ),
+        PSI.ConstraintKey(StartupInitialConditionConstraint, PSY.ThermalMultiStart, "lb"),
+        PSI.ConstraintKey(StartupInitialConditionConstraint, PSY.ThermalMultiStart, "ub"),
     ]
     model = DeviceModel(PSY.ThermalMultiStart, PSI.ThermalMultiStartUnitCommitment)
     no_less_than = Dict(true => 382, false => 378)
@@ -668,12 +687,12 @@ end
         )
         mock_construct_device!(op_problem, model)
         moi_tests(op_problem, p, 576, 0, no_less_than[p], 154, 144, true)
-        psi_constraint_test(op_problem, constraint_names)
+        psi_constraint_test(op_problem, constraint_keys)
         psi_checkobjfun_test(op_problem, GAEVF)
     end
 end
 
-################################### Thermal Compact UC Testing ##################################
+################################## Thermal Compact UC Testing ##################################
 @testset "Thermal Standard with Compact UC and DC - PF" begin
     model = DeviceModel(PSY.ThermalStandard, PSI.ThermalCompactUnitCommitment)
     c_sys5 = PSB.build_system(PSITestSystems, "c_sys5")
@@ -738,7 +757,7 @@ end
     end
 end
 
-################################### Thermal Compact Dispatch Testing ##################################
+################################## Thermal Compact Dispatch Testing ##################################
 
 @testset "Thermal Standard with Compact Dispatch and DC - PF" begin
     model = DeviceModel(PSY.ThermalStandard, PSI.ThermalCompactDispatch)

--- a/test/test_network_constructors.jl
+++ b/test/test_network_constructors.jl
@@ -46,7 +46,7 @@ end
         c_sys14 => [120, 0, 120, 120, 24],
         c_sys14_dc => [120, 0, 120, 120, 24],
     )
-    constraint_names = [:CopperPlateBalance]
+    constraint_keys = [PSI.ConstraintKey(CopperPlateBalanceConstraint, PSY.System)]
     objfuncs = [GAEVF, GQEVF, GQEVF]
     test_obj_values = IdDict{System, Float64}(
         c_sys5 => 240000.0,
@@ -60,7 +60,7 @@ end
 
         @test build!(ps_model; output_dir = mktempdir(cleanup = true)) ==
               PSI.BuildStatus.BUILT
-        psi_constraint_test(ps_model, constraint_names)
+        psi_constraint_test(ps_model, constraint_keys)
         moi_tests(
             ps_model,
             p,
@@ -93,8 +93,12 @@ end
     c_sys14_dc = PSB.build_system(PSITestSystems, "c_sys14_dc")
     systems = [c_sys5, c_sys14, c_sys14_dc]
     objfuncs = [GAEVF, GQEVF, GQEVF]
-    constraint_names =
-        [:RateLimit_lb__Line, :RateLimit_ub__Line, :CopperPlateBalance, :network_flow__Line]
+    constraint_keys = [
+        PSI.ConstraintKey(RateLimitConstraint, PSY.Line, "lb"),
+        PSI.ConstraintKey(RateLimitConstraint, PSY.Line, "ub"),
+        PSI.ConstraintKey(CopperPlateBalanceConstraint, PSY.System),
+        PSI.ConstraintKey(NetworkFlowConstraint, PSY.Line),
+    ]
     parameters = [true, false]
     PTDF_ref = IdDict{System, PTDF}(
         c_sys5 => PTDF(c_sys5),
@@ -122,7 +126,7 @@ end
 
         @test build!(ps_model; output_dir = mktempdir(cleanup = true)) ==
               PSI.BuildStatus.BUILT
-        psi_constraint_test(ps_model, constraint_names)
+        psi_constraint_test(ps_model, constraint_keys)
         moi_tests(
             ps_model,
             p,
@@ -157,8 +161,12 @@ end
     c_sys14_dc = PSB.build_system(PSITestSystems, "c_sys14_dc")
     systems = [c_sys5, c_sys14, c_sys14_dc]
     objfuncs = [GAEVF, GQEVF, GQEVF]
-    constraint_names =
-        [:RateLimit_lb__Line, :RateLimit_ub__Line, :CopperPlateBalance, :network_flow__Line]
+    constraint_keys = [
+        PSI.ConstraintKey(RateLimitConstraint, PSY.Line, "lb"),
+        PSI.ConstraintKey(RateLimitConstraint, PSY.Line, "ub"),
+        PSI.ConstraintKey(CopperPlateBalanceConstraint, PSY.System),
+        PSI.ConstraintKey(NetworkFlowConstraint, PSY.Line),
+    ]
     parameters = [true, false]
     test_results = IdDict{System, Vector{Int}}(
         c_sys5 => [264, 0, 264, 264, 168],
@@ -176,7 +184,7 @@ end
 
         @test build!(ps_model; output_dir = mktempdir(cleanup = true)) ==
               PSI.BuildStatus.BUILT
-        psi_constraint_test(ps_model, constraint_names)
+        psi_constraint_test(ps_model, constraint_keys)
         moi_tests(
             ps_model,
             p,
@@ -204,10 +212,10 @@ end
     c_sys14_dc = PSB.build_system(PSITestSystems, "c_sys14_dc")
     systems = [c_sys5, c_sys14, c_sys14_dc]
     objfuncs = [GAEVF, GQEVF, GQEVF]
-    constraint_names = [
-        :RateLimit_ub__Line,
-        :RateLimit_lb__Line,
-        PSI.make_constraint_name(PSI.NODAL_BALANCE_ACTIVE, PSY.Bus),
+    constraint_keys = [
+        PSI.ConstraintKey(PSI.RateLimitConstraint, PSY.Line, "ub"),
+        PSI.ConstraintKey(PSI.RateLimitConstraint, PSY.Line, "lb"),
+        PSI.ConstraintKey(PSI.NodalBalanceActiveConstraint, PSY.Bus),
     ]
     parameters = [true, false]
     test_results = IdDict{System, Vector{Int}}(
@@ -225,7 +233,7 @@ end
             OperationsProblem(template, sys; optimizer = OSQP_optimizer, use_parameters = p)
         @test build!(ps_model; output_dir = mktempdir(cleanup = true)) ==
               PSI.BuildStatus.BUILT
-        psi_constraint_test(ps_model, constraint_names)
+        psi_constraint_test(ps_model, constraint_keys)
         moi_tests(
             ps_model,
             p,
@@ -254,11 +262,11 @@ end
     systems = [c_sys5, c_sys14, c_sys14_dc]
     objfuncs = [GAEVF, GQEVF, GQEVF]
     # Check for voltage and angle constraints
-    constraint_names = [
-        :RateLimitFT__Line,
-        :RateLimitTF__Line,
-        PSI.make_constraint_name(PSI.NODAL_BALANCE_ACTIVE, PSY.Bus),
-        PSI.make_constraint_name(PSI.NODAL_BALANCE_REACTIVE, PSY.Bus),
+    constraint_keys = [
+        PSI.ConstraintKey(RateLimitFTConstraint, PSY.Line),
+        PSI.ConstraintKey(RateLimitTFConstraint, PSY.Line),
+        PSI.ConstraintKey(PSI.NodalBalanceActiveConstraint, PSY.Bus),
+        PSI.ConstraintKey(PSI.NodalBalanceReactiveConstraint, PSY.Bus),
     ]
     parameters = [true, false]
     test_results = IdDict{System, Vector{Int}}(
@@ -280,7 +288,7 @@ end
         )
         @test build!(ps_model; output_dir = mktempdir(cleanup = true)) ==
               PSI.BuildStatus.BUILT
-        psi_constraint_test(ps_model, constraint_names)
+        psi_constraint_test(ps_model, constraint_keys)
         moi_tests(
             ps_model,
             p,
@@ -309,7 +317,7 @@ end
     c_sys14_dc = PSB.build_system(PSITestSystems, "c_sys14_dc")
     systems = [c_sys5, c_sys14, c_sys14_dc]
     objfuncs = [GAEVF, GQEVF, GQEVF]
-    constraint_names = [PSI.make_constraint_name(PSI.NODAL_BALANCE_ACTIVE, PSY.Bus)]
+    constraint_keys = [PSI.ConstraintKey(PSI.NodalBalanceActiveConstraint, PSY.Bus)]
     parameters = [true, false]
     test_results = Dict{System, Vector{Int}}(
         c_sys5 => [264, 0, 264, 264, 120],
@@ -326,7 +334,7 @@ end
             OperationsProblem(template, sys; optimizer = OSQP_optimizer, use_parameters = p)
         @test build!(ps_model; output_dir = mktempdir(cleanup = true)) ==
               PSI.BuildStatus.BUILT
-        psi_constraint_test(ps_model, constraint_names)
+        psi_constraint_test(ps_model, constraint_keys)
         moi_tests(
             ps_model,
             p,
@@ -359,9 +367,9 @@ end
     systems = [c_sys5, c_sys14, c_sys14_dc]
     parameters = [true, false]
     # TODO: add model specific constraints to this list. Voltages, etc.
-    constraint_names = [
-        PSI.make_constraint_name(PSI.NODAL_BALANCE_ACTIVE, PSY.Bus),
-        PSI.make_constraint_name(PSI.NODAL_BALANCE_REACTIVE, PSY.Bus),
+    constraint_keys = [
+        PSI.ConstraintKey(PSI.NodalBalanceActiveConstraint, PSY.Bus),
+        PSI.ConstraintKey(PSI.NodalBalanceReactiveConstraint, PSY.Bus),
     ]
     ACR_test_results = Dict{System, Vector{Int}}(
         c_sys5 => [1056, 0, 240, 240, 264],
@@ -384,7 +392,7 @@ end
         )
         @test build!(ps_model; output_dir = mktempdir(cleanup = true)) ==
               PSI.BuildStatus.BUILT
-        psi_constraint_test(ps_model, constraint_names)
+        psi_constraint_test(ps_model, constraint_keys)
         moi_tests(
             ps_model,
             p,
@@ -407,8 +415,8 @@ end
     c_sys14_dc = PSB.build_system(PSITestSystems, "c_sys14_dc")
     systems = [c_sys5, c_sys14, c_sys14_dc]
     parameters = [true, false]
-    # TODO: add model specific constraints to this list. Bi-direccional flows etc
-    constraint_names = [PSI.make_constraint_name(PSI.NODAL_BALANCE_ACTIVE, PSY.Bus)]
+    # TODO: add model specific constraints to this list. Bi-directional flows etc
+    constraint_keys = [PSI.ConstraintKey(PSI.NodalBalanceActiveConstraint, PSY.Bus)]
     test_obj_values = IdDict{System, Float64}(
         c_sys5 => 340000.0,
         c_sys14 => 142000.0,
@@ -435,7 +443,7 @@ end
         )
         @test build!(ps_model; output_dir = mktempdir(cleanup = true)) ==
               PSI.BuildStatus.BUILT
-        psi_constraint_test(ps_model, constraint_names)
+        psi_constraint_test(ps_model, constraint_keys)
         moi_tests(
             ps_model,
             p,

--- a/test/test_operations_problem.jl
+++ b/test/test_operations_problem.jl
@@ -208,7 +208,10 @@ end
     @test solve!(op_problem) == RunStatus.SUCCESSFUL
 
     optimization_container = PSI.get_optimization_container(op_problem)
-    constraints = PSI.get_constraints(optimization_container)[:CopperPlateBalance]
+    constraints = PSI.get_constraints(optimization_container)[PSI.ConstraintKey(
+        CopperPlateBalanceConstraint,
+        PSY.System,
+    )]
     dual_results = read_duals(optimization_container, [:CopperPlateBalance])
     for i in axes(constraints)[1]
         dual = JuMP.dual(constraints[i])

--- a/test/test_utils/model_checks.jl
+++ b/test/test_utils/model_checks.jl
@@ -26,10 +26,10 @@ end
 
 function psi_constraint_test(
     op_problem::OperationsProblem,
-    constraint_names::Vector{Symbol},
+    constraint_keys::Vector{<:PSI.ConstraintKey},
 )
     constraints = PSI.get_constraints(op_problem)
-    for con in constraint_names
+    for con in constraint_keys
         @test !isnothing(get(constraints, con, nothing))
     end
     return
@@ -66,8 +66,12 @@ function psi_checkobjfun_test(op_problem::OperationsProblem, exp_type)
     return
 end
 
-function moi_lbvalue_test(op_problem::OperationsProblem, con_name::Symbol, value::Number)
-    for con in PSI.get_constraints(op_problem)[con_name]
+function moi_lbvalue_test(
+    op_problem::OperationsProblem,
+    con_key::PSI.ConstraintKey,
+    value::Number,
+)
+    for con in PSI.get_constraints(op_problem)[con_key]
         @test JuMP.constraint_object(con).set.lower == value
     end
     return


### PR DESCRIPTION
This PR adds constraint keys to replace use of symbols.

All tests pass except for two that try to read duals. Those are broken because dual symbols are not yet handled.