### PR TITLE
Refactor OperationProblem results handling

### DIFF
--- a/src/PowerSimulations.jl
+++ b/src/PowerSimulations.jl
@@ -113,6 +113,7 @@ export build!
 ## Op Model Exports
 export get_initial_conditions
 export serialize_problem
+export serialize_results
 export serialize_optimization_model
 ## Decision Model Export
 export solve!

--- a/src/core/optimization_container.jl
+++ b/src/core/optimization_container.jl
@@ -11,7 +11,7 @@ function deserialize_metadata(
     output_dir::String,
     model_name,
 )
-    filename = _make_metadata_filename(output_dir, model_name)
+    filename = _make_metadata_filename(output_dir)
     return Serialization.deserialize(filename)
 end
 
@@ -489,14 +489,9 @@ end
 
 const _CONTAINER_METADATA_FILE = "optimization_container_metadata.bin"
 
-_make_metadata_filename(output_dir, model_name) =
-    joinpath(output_dir, "$(model_name)_$(_CONTAINER_METADATA_FILE)")
+_make_metadata_filename(output_dir) = joinpath(output_dir, _CONTAINER_METADATA_FILE)
 
-function serialize_metadata!(
-    container::OptimizationContainer,
-    output_dir::String,
-    model_name,
-)
+function serialize_metadata!(container::OptimizationContainer, output_dir::String)
     for key in Iterators.flatten((
         keys(container.constraints),
         keys(container.duals),
@@ -511,7 +506,7 @@ function serialize_metadata!(
         add_container_key!(container.metadata, encoded_key, key)
     end
 
-    filename = _make_metadata_filename(output_dir, model_name)
+    filename = _make_metadata_filename(output_dir)
     Serialization.serialize(filename, container.metadata)
     @debug "Serialized container keys to $filename" _group = IS.LOG_GROUP_SERIALIZATION
 end

--- a/src/operation/decision_model.jl
+++ b/src/operation/decision_model.jl
@@ -158,12 +158,12 @@ function DecisionModel(
 end
 
 """
-    DecisionModel(filename::AbstractString)
+    DecisionModel(directory::AbstractString)
 
 Construct an DecisionProblem from a serialized file.
 
 # Arguments
-- `filename::AbstractString`: path to serialized file
+- `directory::AbstractString`: Directory containing a serialized model
 - `jump_model::Union{Nothing, JuMP.Model}` = nothing: The JuMP model does not get
    serialized. Callers should pass whatever they passed to the original problem.
 - `optimizer::Union{Nothing,MOI.OptimizerWithAttributes}` = nothing: The optimizer does
@@ -173,14 +173,14 @@ Construct an DecisionProblem from a serialized file.
    be deserialized from a file.
 """
 function DecisionModel(
-    filename::AbstractString;
+    directory::AbstractString;
     jump_model::Union{Nothing, JuMP.Model} = nothing,
     optimizer::Union{Nothing, MOI.OptimizerWithAttributes} = nothing,
     system::Union{Nothing, PSY.System} = nothing,
 )
     return deserialize_problem(
         DecisionModel,
-        filename;
+        directory;
         jump_model = jump_model,
         optimizer = optimizer,
         system = system,
@@ -226,44 +226,12 @@ function build_pre_step!(model::DecisionModel)
         # Initial time are set here because the information is specified in the
         # Simulation Sequence object and not at the problem creation.
 
-        @info "Initializing Optimization Container For a DecisionModel"
-        init_optimization_container!(
-            get_optimization_container(model),
-            get_network_formulation(get_template(model)),
-            get_system(model),
-        )
-        @info "Initializing ModelStoreParams"
-        init_model_store!(model)
         set_status!(model, BuildStatus.IN_PROGRESS)
     end
     return
 end
 
 get_horizon(model::DecisionModel) = get_horizon(get_settings(model))
-
-function _build!(model::DecisionModel{<:DecisionProblem}, serialize::Bool)
-    TimerOutputs.@timeit BUILD_PROBLEMS_TIMER "Problem $(get_name(model))" begin
-        try
-            build_pre_step!(model)
-            build_problem!(model)
-            serialize && serialize_problem(model)
-            serialize && serialize_optimization_model(model)
-            serialize_metadata!(
-                get_optimization_container(model),
-                get_output_dir(model),
-                get_name(model),
-            )
-            set_status!(model, BuildStatus.BUILT)
-            log_values(get_settings(model))
-            !built_for_recurrent_solves(model) && @info "\n$(BUILD_PROBLEMS_TIMER)\n"
-        catch e
-            set_status!(model, BuildStatus.FAILED)
-            bt = catch_backtrace()
-            @error "Operation Problem Build Failed" exception = e, bt
-        end
-    end
-    return get_status(model)
-end
 
 """Implementation of build for any DecisionProblem"""
 function build!(
@@ -283,7 +251,7 @@ function build!(
     logger = configure_logging(model.internal, "w")
     try
         Logging.with_logger(logger) do
-            return _build!(model, serialize)
+            return build_impl!(model, serialize)
         end
     finally
         close(logger)
@@ -295,10 +263,18 @@ Default implementation of build method for Operational Problems for models confo
 """
 
 function build_problem!(model::DecisionModel)
+    @info "Initializing Optimization Container For a DecisionModel"
     populate_aggregated_service_model!(get_template(model), get_system(model))
     populate_contributing_devices!(get_template(model), get_system(model))
     add_services_to_device_model!(get_template(model))
-    build_impl!(get_optimization_container(model), get_template(model), get_system(model))
+
+    container = get_optimization_container(model)
+    init_optimization_container!(
+        container,
+        get_network_formulation(get_template(model)),
+        get_system(model),
+    )
+    build_impl!(container, get_template(model), get_system(model))
 end
 
 function reset!(model::OperationModel)
@@ -315,13 +291,6 @@ function reset!(model::OperationModel)
     empty_time_series_cache!(model)
     set_status!(model, BuildStatus.EMPTY)
     return
-end
-
-function serialize_optimization_model(model::DecisionModel{<:DecisionProblem})
-    problem_name = "$(get_name(model))_DecisionModel"
-    json_file_name = "$(problem_name).json"
-    json_file_name = joinpath(get_output_dir(model), json_file_name)
-    serialize_optimization_model(get_optimization_container(model), json_file_name)
 end
 
 function calculate_aux_variables!(model::DecisionModel)
@@ -344,8 +313,8 @@ function calculate_dual_variables!(model::DecisionModel)
     return
 end
 
-function solve_impl(model::DecisionModel; optimizer = nothing)
-    status = _pre_solve_model_checks(model, optimizer)
+function solve_impl(model::DecisionModel; optimizer = nothing, kwargs...)
+    status = _pre_solve_model_checks(model, optimizer; kwargs...)
     timed_log = get_solve_timed_log(model)
     jump_model = get_jump_model(model)
     _, timed_log[:timed_solve_time], timed_log[:solve_bytes_alloc], timed_log[:sec_in_gc] =
@@ -363,25 +332,44 @@ end
 
 """
 Default solve method the operational model for a single instance. Solves problems
-    that conform to the requirements of DecisionModel{<: DecisionProblem}
+that conform to the requirements of DecisionModel{<: DecisionProblem}
+
+This will call [`build!`](@ref) on the model if it is not already built. It will forward all
+keyword arguments to that function.
+
 # Arguments
 - `model::OperationModel = model`: operation model
+- `optimizer::MOI.OptimizerWithAttributes`: The optimizer that is used to solve the model
+- `serialize_problem_results::Bool`: If true, serialize ProblemResults to a binary file that
+  can be deserialized.
+- `export_problem_results::Bool`: If true, export ProblemResults DataFrames to CSV files.
+
 # Examples
 ```julia
 results = solve!(OpModel)
+results = solve!(OpModel, output_dir = "output")
 ```
-# Accepted Key Words
-- `output_dir::String`: If a file path is provided the results
-automatically get written to file
-- `optimizer::MOI.OptimizerWithAttributes`: The optimizer that is used to solve the model
 """
-function solve!(model::DecisionModel{<:DecisionProblem}; kwargs...)
+function solve!(
+    model::DecisionModel{<:DecisionProblem};
+    serialize_problem_results = false,
+    export_problem_results = false,
+    kwargs...,
+)
     status = solve_impl(model; kwargs...)
     set_run_status!(model, status)
+    if status == RunStatus.SUCCESSFUL
+        if serialize_problem_results || export_problem_results
+            results = ProblemResults(model)
+            serialize_problem_results && serialize_results(results, get_output_dir(model))
+            export_problem_results && export_results(results)
+        end
+    end
+
     return status
 end
 
-function write_problem_results!(
+function write_results!(
     step::Int,
     model::DecisionModel{<:DecisionProblem},
     start_time::Dates.DateTime,
@@ -390,7 +378,7 @@ function write_problem_results!(
 )
     stats = OptimizerStats(model, step)
     write_optimizer_stats!(store, get_name(model), stats, start_time)
-    write_model_results!(store, model, start_time; exports = exports)
+    write_results!(store, model, start_time; exports = exports)
     return
 end
 
@@ -415,14 +403,14 @@ function solve!(
 )
     solve_status = solve!(model)
     if solve_status == RunStatus.SUCCESSFUL
-        write_problem_results!(step, model, start_time, store, exports)
+        write_results!(step, model, start_time, store, exports)
         advance_execution_count!(model)
     end
 
     return solve_status
 end
 
-function write_model_results!(store, model::DecisionModel, timestamp; exports = nothing)
+function write_results!(store, model::DecisionModel, timestamp; exports = nothing)
     if exports !== nothing
         export_params = Dict{Symbol, Any}(
             :exports => exports,

--- a/src/operation/problem_results.jl
+++ b/src/operation/problem_results.jl
@@ -1,14 +1,15 @@
 # This needs renaming to avoid collision with the DecionModelResults/EmulationModelResults
-struct ProblemResults <: PSIResults
+mutable struct ProblemResults <: PSIResults
     base_power::Float64
     timestamps::StepRange{Dates.DateTime, Dates.Millisecond}
     system::Union{Nothing, PSY.System}
+    system_uuid::Base.UUID
     aux_variable_values::Dict{AuxVarKey, DataFrames.DataFrame}
     variable_values::Dict{VariableKey, DataFrames.DataFrame}
     dual_values::Dict{ConstraintKey, DataFrames.DataFrame}
     parameter_values::Dict{ParameterKey, DataFrames.DataFrame}
     optimizer_stats::DataFrames.DataFrame
-    container::OptimizationContainer
+    optimization_container_metadata::OptimizationContainerMetadata
     model_type::String
     output_dir::String
 end
@@ -37,6 +38,9 @@ function get_objective_value(res::ProblemResults, execution = 1)
     res.optimizer_stats[execution, :objective_value]
 end
 
+"""
+Construct ProblemResults from a solved DecisionModel.
+"""
 function ProblemResults(model::DecisionModel)
     status = get_run_status(model)
     status != RunStatus.SUCCESSFUL && error("problem was not solved successfully: $status")
@@ -52,21 +56,26 @@ function ProblemResults(model::DecisionModel)
         DataFrames.insertcols!(df, 1, :DateTime => timestamps)
     end
 
+    sys = get_system(model)
     return ProblemResults(
         get_problem_base_power(model),
         timestamps,
-        model.sys,
+        sys,
+        IS.get_uuid(sys),
         Dict{VariableKey, DataFrames.DataFrame}(),
         variables,
         duals,
         parameters,
         optimizer_stats,
-        container,
+        get_metadata(container),
         IS.strip_module_name(typeof(model)),
         mkpath(joinpath(get_output_dir(model), "results")),
     )
 end
 
+"""
+Construct ProblemResults from a solved EmulationModel.
+"""
 function ProblemResults(model::EmulationModel)
     status = get_run_status(model)
     status != RunStatus.SUCCESSFUL && error("problem was not solved successfully: $status")
@@ -79,17 +88,19 @@ function ProblemResults(model::EmulationModel)
     optimizer_stats = read_optimizer_stats(model)
     initial_time = get_initial_time(model)
     container = get_optimization_container(model)
+    sys = get_system(model)
 
     return ProblemResults(
         get_problem_base_power(model),
         StepRange(initial_time, get_resolution(model), initial_time),
-        model.sys,
+        sys,
+        IS.get_uuid(sys),
         aux_variables,
         variables,
         duals,
         parameters,
         optimizer_stats,
-        container,
+        get_metadata(container),
         IS.strip_module_name(typeof(model)),
         mkpath(joinpath(get_output_dir(model), "results")),
     )
@@ -159,7 +170,7 @@ function _deserialize_key(
     results::ProblemResults,
     name::AbstractString,
 )
-    return deserialize_key(results.container.metadata, name)
+    return deserialize_key(results.optimization_container_metadata, name)
 end
 
 function _deserialize_key(
@@ -212,6 +223,24 @@ end
 
 read_optimizer_stats(res::ProblemResults) = res.optimizer_stats
 
+"""
+Set the system in the results instance.
+
+Throws InvalidValue if the system UUID is incorrect.
+"""
+function set_system!(res::ProblemResults, system::PSY.System)
+    sys_uuid = IS.get_uuid(system)
+    if sys_uuid != res.system_uuid
+        throw(
+            IS.InvalidValue(
+                "System mismatch. $sys_uuid does not match the stored value of $(res.system_uuid)",
+            ),
+        )
+    end
+
+    res.system = system
+end
+
 # TODO:
 # - Handle PER-UNIT conversion of variables according to type
 
@@ -247,6 +276,67 @@ end
 function write_optimizer_stats(res::ProblemResults, directory::AbstractString)
     data = to_dict(res.optimizer_stats)
     JSON.write(joinpath(directory, "optimizer_stats.json"), JSON.json(data))
+end
+
+const _PROBLEM_RESULTS_FILENAME = "problem_results.bin"
+
+"""
+Serialize the results to a binary file.
+
+It is recommended that `directory` be the directory that contains a serialized
+OperationModel. That will allow automatic deserialization of the PowerSystems.System.
+The `ProblemResults` instance can be deserialized with `ProblemResults(directory)`.
+"""
+function serialize_results(res::ProblemResults, directory::AbstractString; force = false)
+    mkpath(directory)
+    filename = joinpath(directory, _PROBLEM_RESULTS_FILENAME)
+    if isfile(filename) && !force
+        error("$filename already exists. Pass force = true to overwrite")
+    end
+
+    Serialization.serialize(filename, _copy_for_serialization(res))
+    @info "Serialize ProblemResults to $filename"
+end
+
+"""
+Construct a ProblemResults instance from a serialized directory.
+
+If the directory contains a serialized PowerSystems.System then it will deserialize that
+system and add it to the results. Otherwise, it is up to the caller to call
+[`set_system!`](@ref) on the returned instance to restore it.
+"""
+function ProblemResults(directory::AbstractString)
+    filename = joinpath(directory, _PROBLEM_RESULTS_FILENAME)
+    if !isfile(filename)
+        error("No results file exists in $directory")
+    end
+
+    results = Serialization.deserialize(filename)
+    possible_sys_file = joinpath(directory, make_system_filename(results.system_uuid))
+    if isfile(possible_sys_file)
+        set_system!(results, PSY.System(possible_sys_file))
+    else
+        @info "$directory does not contain a serialized System, skipping deserialization."
+    end
+
+    return results
+end
+
+function _copy_for_serialization(res::ProblemResults)
+    return ProblemResults(
+        res.base_power,
+        res.timestamps,
+        nothing,
+        res.system_uuid,
+        res.aux_variable_values,
+        res.variable_values,
+        res.dual_values,
+        res.parameter_values,
+        res.optimizer_stats,
+        res.optimization_container_metadata,
+        res.model_type,
+        res.output_dir,
+    )
 end
 
 # TODO: These are not likely needed for v015.

--- a/src/operation/problem_results.jl
+++ b/src/operation/problem_results.jl
@@ -287,13 +287,10 @@ It is recommended that `directory` be the directory that contains a serialized
 OperationModel. That will allow automatic deserialization of the PowerSystems.System.
 The `ProblemResults` instance can be deserialized with `ProblemResults(directory)`.
 """
-function serialize_results(res::ProblemResults, directory::AbstractString; force = false)
+function serialize_results(res::ProblemResults, directory::AbstractString)
     mkpath(directory)
     filename = joinpath(directory, _PROBLEM_RESULTS_FILENAME)
-    if isfile(filename) && !force
-        error("$filename already exists. Pass force = true to overwrite")
-    end
-
+    isfile(filename) && rm(filename)
     Serialization.serialize(filename, _copy_for_serialization(res))
     @info "Serialize ProblemResults to $filename"
 end

--- a/src/simulation/simulation_problem_results.jl
+++ b/src/simulation/simulation_problem_results.jl
@@ -159,7 +159,7 @@ function set_system!(results::SimulationProblemResults, system::PSY.System)
     if sys_uuid != results.system_uuid
         throw(
             IS.InvalidValue(
-                "System mismatch. $sys_uuid does not match the stored value of $results.system_uuid",
+                "System mismatch. $sys_uuid does not match the stored value of $(results.system_uuid)",
             ),
         )
     end

--- a/src/utils/dataframes_utils.jl
+++ b/src/utils/dataframes_utils.jl
@@ -75,7 +75,11 @@ function axis_array_to_dataframe(
             result[t] = _jump_value(input_array[t])
         end
 
-        @assert columns !== nothing
+        # TODO v015: This is a hack to workaround lack of support for this scenario.
+        # @assert columns !== nothing
+        if columns === nothing
+            columns = ["System"]
+        end
         return DataFrames.DataFrame(columns[1] => result)
     elseif length(axes(input_array)) == 2
         result = Array{Float64, length(input_array.axes)}(

--- a/src/utils/powersystems_utils.jl
+++ b/src/utils/powersystems_utils.jl
@@ -14,4 +14,4 @@ function get_available_components(
 end
 
 make_system_filename(sys::PSY.System) = "system-$(IS.get_uuid(sys)).json"
-make_system_filename(sys_uuid::Base.UUID) = "system-$(sys_uuid).json"
+make_system_filename(sys_uuid::Union{Base.UUID, AbstractString}) = "system-$(sys_uuid).json"

--- a/test/test_model_decision.jl
+++ b/test/test_model_decision.jl
@@ -219,6 +219,20 @@ end
     @test length(get_timestamps(res)) == 24
 end
 
+@testset "Solve DecisionModelModel with auto-build" begin
+    c_sys5 = PSB.build_system(PSITestSystems, "c_sys5")
+    template = get_thermal_standard_uc_template()
+    set_service_model!(
+        template,
+        ServiceModel(VariableReserve{ReserveUp}, RangeReserve, "test"),
+    )
+    UC = DecisionModel(template, c_sys5)
+    output_dir = mktempdir(cleanup = true)
+    @test_throws ErrorException solve!(UC; optimizer = GLPK_optimizer)
+    @test solve!(UC; optimizer = GLPK_optimizer, output_dir = output_dir) ==
+          RunStatus.SUCCESSFUL
+end
+
 @testset "Test Serialization, deserialization and write optimizer problem" begin
     path = mktempdir(cleanup = true)
     sys = PSB.build_system(PSITestSystems, "c_sys5_re")
@@ -231,13 +245,11 @@ end
 
     file_list = sort!(collect(readdir(path)))
     model_name = PSI.get_name(model)
-    expected_json = "$(model_name)_DecisionModel.json"
-    @test expected_json in file_list
-    expected_bin = "$(model_name).bin"
-    @test expected_bin in file_list
-    filename = joinpath(path, expected_bin)
-    ED2 = DecisionModel(filename, optimizer = OSQP_optimizer)
+    @test PSI._JUMP_MODEL_FILENAME in file_list
+    @test PSI._SERIALIZED_MODEL_FILENAME in file_list
+    ED2 = DecisionModel(path, optimizer = OSQP_optimizer)
     build!(ED2, output_dir = path)
+    solve!(ED2)
     psi_checksolve_test(ED2, [MOI.OPTIMAL], 240000.0, 10000)
 
     path2 = mktempdir(cleanup = true)
@@ -245,12 +257,49 @@ end
         DecisionModel(template, sys; optimizer = OSQP_optimizer, system_to_file = false)
 
     @test build!(model_no_sys; output_dir = path2) == PSI.BuildStatus.BUILT
-    @test solve!(model) == RunStatus.SUCCESSFUL
+    @test solve!(model_no_sys) == RunStatus.SUCCESSFUL
 
     file_list = sort!(collect(readdir(path2)))
     @test .!all(occursin.(r".h5", file_list))
-    filename = joinpath(path2, "$(model_name).bin")
-    ED3 = DecisionModel(filename; system = sys, optimizer = OSQP_optimizer)
+    ED3 = DecisionModel(path2; system = sys, optimizer = OSQP_optimizer)
     build!(ED3, output_dir = path2)
+    solve!(ED3)
     psi_checksolve_test(ED3, [MOI.OPTIMAL], 240000.0, 10000)
+end
+
+@testset "Test serialization/deserialization of DecisionModel results" begin
+    path = mktempdir(cleanup = true)
+    sys = PSB.build_system(PSITestSystems, "c_sys5_re")
+    template = get_template_dispatch_with_network(
+        NetworkModel(CopperPlatePowerModel; duals = [CopperPlateBalanceConstraint]),
+    )
+    model = DecisionModel(template, sys; optimizer = OSQP_optimizer)
+    @test build!(model; output_dir = path) == PSI.BuildStatus.BUILT
+    @test solve!(model, serialize_problem_results = true, export_problem_results = true) ==
+          RunStatus.SUCCESSFUL
+    results1 = ProblemResults(model)
+    var1_a = read_variable(results1, ActivePowerVariable, ThermalStandard)
+    # Ensure that we can deserialize strings into keys.
+    var1_b = read_variable(results1, "ActivePowerVariable_ThermalStandard")
+
+    # Results were automatically serialized here.
+    results2 = ProblemResults(PSI.get_output_dir(model))
+    var2 = read_variable(results2, ActivePowerVariable, ThermalStandard)
+    @test var1_a == var2
+
+    # Serialize to a new directory with the exported function.
+    results_path = joinpath(path, "results")
+    serialize_results(results1, results_path)
+    @test isfile(joinpath(results_path, PSI._PROBLEM_RESULTS_FILENAME))
+    results3 = ProblemResults(results_path)
+    var3 = read_variable(results3, ActivePowerVariable, ThermalStandard)
+    @test var1_a == var3
+    @test get_system(results3) === nothing
+    set_system!(results3, get_system(results1))
+    @test get_system(results3) !== nothing
+
+    exp_file =
+        joinpath(path, "results", "variables", "ActivePowerVariable_ThermalStandard.csv")
+    var4 = PSI.read_dataframe(exp_file)
+    @test var1_a == var4
 end

--- a/test/test_model_decision.jl
+++ b/test/test_model_decision.jl
@@ -247,7 +247,7 @@ end
     model_name = PSI.get_name(model)
     @test PSI._JUMP_MODEL_FILENAME in file_list
     @test PSI._SERIALIZED_MODEL_FILENAME in file_list
-    ED2 = DecisionModel(path, optimizer = OSQP_optimizer)
+    ED2 = DecisionModel(path, OSQP_optimizer)
     build!(ED2, output_dir = path)
     solve!(ED2)
     psi_checksolve_test(ED2, [MOI.OPTIMAL], 240000.0, 10000)
@@ -261,7 +261,7 @@ end
 
     file_list = sort!(collect(readdir(path2)))
     @test .!all(occursin.(r".h5", file_list))
-    ED3 = DecisionModel(path2; system = sys, optimizer = OSQP_optimizer)
+    ED3 = DecisionModel(path2, OSQP_optimizer; system = sys)
     build!(ED3, output_dir = path2)
     solve!(ED3)
     psi_checksolve_test(ED3, [MOI.OPTIMAL], 240000.0, 10000)
@@ -275,8 +275,7 @@ end
     )
     model = DecisionModel(template, sys; optimizer = OSQP_optimizer)
     @test build!(model; output_dir = path) == PSI.BuildStatus.BUILT
-    @test solve!(model, serialize_problem_results = true, export_problem_results = true) ==
-          RunStatus.SUCCESSFUL
+    @test solve!(model, export_problem_results = true) == RunStatus.SUCCESSFUL
     results1 = ProblemResults(model)
     var1_a = read_variable(results1, ActivePowerVariable, ThermalStandard)
     # Ensure that we can deserialize strings into keys.

--- a/test/test_model_emulation.jl
+++ b/test/test_model_emulation.jl
@@ -9,7 +9,6 @@
     # c_sys5_re = PSB.build_system(PSITestSystems, "c_sys5_re"; add_single_time_series = true)
     # c_sys5_re = PSB.build_system(PSITestSystems, "c_sys5_uc_re"; add_single_time_series = true)
 
-    # The initial time kwarg can be removed when
     model = EmulationModel(template, c_sys5; optimizer = Cbc_optimizer)
     executions = 10
     @test build!(model; executions = executions, output_dir = mktempdir(cleanup = true)) ==
@@ -45,4 +44,93 @@
     for i in 1:executions
         @test get_objective_value(results, i) isa Float64
     end
+end
+
+@testset "Run EmulationModel with auto-build" begin
+    template = get_thermal_dispatch_template_network()
+    c_sys5 = PSB.build_system(
+        PSITestSystems,
+        "c_sys5_uc";
+        add_single_time_series = true,
+        force_build = true,
+    )
+
+    model = EmulationModel(template, c_sys5; optimizer = Cbc_optimizer)
+    @test_throws ErrorException run!(model, executions = 10)
+    @test run!(model, executions = 10, output_dir = mktempdir(cleanup = true)) ==
+          RunStatus.SUCCESSFUL
+end
+
+@testset "Test serialization/deserialization of EmulationModel results" begin
+    path = mktempdir(cleanup = true)
+    template = get_thermal_dispatch_template_network()
+    c_sys5 = PSB.build_system(
+        PSITestSystems,
+        "c_sys5_uc";
+        add_single_time_series = true,
+        force_build = true,
+    )
+
+    model = EmulationModel(template, c_sys5; optimizer = Cbc_optimizer)
+    executions = 10
+    @test build!(model; executions = executions, output_dir = path) == BuildStatus.BUILT
+    @test run!(model, serialize_problem_results = true, export_problem_results = true) ==
+          RunStatus.SUCCESSFUL
+    results1 = ProblemResults(model)
+    var1_a = read_variable(results1, ActivePowerVariable, ThermalStandard)
+    # Ensure that we can deserialize strings into keys.
+    var1_b = read_variable(results1, "ActivePowerVariable_ThermalStandard")
+    @test var1_a == var1_b
+
+    # Results were automatically serialized here.
+    results2 = ProblemResults(joinpath(PSI.get_output_dir(model)))
+    var2 = read_variable(results2, ActivePowerVariable, ThermalStandard)
+    @test var1_a == var2
+    @test get_system(results2) !== nothing
+
+    # Serialize to a new directory with the exported function.
+    results_path = joinpath(path, "results")
+    serialize_results(results1, results_path)
+    @test isfile(joinpath(results_path, PSI._PROBLEM_RESULTS_FILENAME))
+    results3 = ProblemResults(results_path)
+    var3 = read_variable(results3, ActivePowerVariable, ThermalStandard)
+    @test var1_a == var3
+    @test get_system(results3) === nothing
+    set_system!(results3, get_system(results1))
+    @test get_system(results3) !== nothing
+
+    exp_file =
+        joinpath(path, "results", "variables", "ActivePowerVariable_ThermalStandard.csv")
+    var4 = PSI.read_dataframe(exp_file)
+    @test var1_a == var4
+end
+
+@testset "Test deserialization and re-run of EmulationModel" begin
+    path = mktempdir(cleanup = true)
+    template = get_thermal_dispatch_template_network()
+    c_sys5 = PSB.build_system(
+        PSITestSystems,
+        "c_sys5_uc";
+        add_single_time_series = true,
+        force_build = true,
+    )
+
+    model = EmulationModel(template, c_sys5; optimizer = Cbc_optimizer)
+    executions = 10
+    @test build!(model; executions = executions, output_dir = path) == BuildStatus.BUILT
+    @test run!(model) == RunStatus.SUCCESSFUL
+    results = ProblemResults(model)
+    var1 = read_variable(results, ActivePowerVariable, ThermalStandard)
+
+    file_list = sort!(collect(readdir(path)))
+    @test PSI._JUMP_MODEL_FILENAME in file_list
+    @test PSI._SERIALIZED_MODEL_FILENAME in file_list
+    path2 = joinpath(path, "tmp")
+    model2 = EmulationModel(path, optimizer = Cbc_optimizer)
+    build!(model2, output_dir = path2)
+    @test run!(model2) == RunStatus.SUCCESSFUL
+    results2 = ProblemResults(model2)
+    var2 = read_variable(results, ActivePowerVariable, ThermalStandard)
+
+    @test var1 == var2
 end

--- a/test/test_model_emulation.jl
+++ b/test/test_model_emulation.jl
@@ -74,8 +74,7 @@ end
     model = EmulationModel(template, c_sys5; optimizer = Cbc_optimizer)
     executions = 10
     @test build!(model; executions = executions, output_dir = path) == BuildStatus.BUILT
-    @test run!(model, serialize_problem_results = true, export_problem_results = true) ==
-          RunStatus.SUCCESSFUL
+    @test run!(model, export_problem_results = true) == RunStatus.SUCCESSFUL
     results1 = ProblemResults(model)
     var1_a = read_variable(results1, ActivePowerVariable, ThermalStandard)
     # Ensure that we can deserialize strings into keys.
@@ -126,7 +125,7 @@ end
     @test PSI._JUMP_MODEL_FILENAME in file_list
     @test PSI._SERIALIZED_MODEL_FILENAME in file_list
     path2 = joinpath(path, "tmp")
-    model2 = EmulationModel(path, optimizer = Cbc_optimizer)
+    model2 = EmulationModel(path, Cbc_optimizer)
     build!(model2, output_dir = path2)
     @test run!(model2) == RunStatus.SUCCESSFUL
     results2 = ProblemResults(model2)


### PR DESCRIPTION
1. DecisionModel and EmulationModel can be deserialized and re-run as long as the optimizer and JuMP model are provided.
2. ProblemResults can be constructed from either DecisionModel or EmulationModel.
3. ProblemResults can be serialized in binary form. The PSY.System can be restored upon deserialization if the file is stored in the same location as the serialized model.
4. Change the solve!/run! functions to support automatic build, results serialization, and results export.
5. Consolidated some common functions between DecisionModel and EmulationModel.