### PR TITLE
ignore not assigned entries

### DIFF
--- a/src/operation/model_numerical_analysis_utils.jl
+++ b/src/operation/model_numerical_analysis_utils.jl
@@ -116,6 +116,7 @@ function get_constraint_numerical_bounds(model::OperationModel)
             end
         else
             for idx in Iterators.product(constriant_array.axes...)
+                !isassigned(constriant_array, idx...) && continue
                 con_obj = JuMP.constraint_object(constriant_array[idx...])
                 update_coefficient_bounds(bounds, con_obj, (const_key, idx))
                 update_rhs_bounds(bounds, con_obj, (const_key, idx))


### PR DESCRIPTION
In some cases, we skip constraints when the data would make it an irrelevant constraint. This can cause trouble when checking the numerical bounds. 