### PR TITLE
Cb/problem results timestamps

### DIFF
--- a/test/test_model_decision.jl
+++ b/test/test_model_decision.jl
@@ -56,10 +56,10 @@ end
     @test isapprox(get_objective_value(res), 340000.0; atol=100000.0)
     vars = res.variable_values
     @test PSI.VariableKey(ActivePowerVariable, PSY.ThermalStandard) in keys(vars)
-    @test size(read_variable(res, "StartVariable__ThermalStandard")) == (24, 5)
-    @test size(read_parameter(res, "ActivePowerTimeSeriesParameter__PowerLoad")) == (24, 3)
-    @test size(read_expression(res, "ProductionCostExpression__ThermalStandard")) == (24, 5)
-    @test size(read_aux_variable(res, "TimeDurationOn__ThermalStandard")) == (24, 5)
+    @test size(read_variable(res, "StartVariable__ThermalStandard")) == (24, 6)
+    @test size(read_parameter(res, "ActivePowerTimeSeriesParameter__PowerLoad")) == (24, 4)
+    @test size(read_expression(res, "ProductionCostExpression__ThermalStandard")) == (24, 6)
+    @test size(read_aux_variable(res, "TimeDurationOn__ThermalStandard")) == (24, 6)
     @test length(read_variables(res)) == 4
     @test length(read_parameters(res)) == 1
     @test length(read_duals(res)) == 0
@@ -225,9 +225,12 @@ end
             constraint_key,
         )]
     @test dual_results ==
-          dual_results_read ==
-          realized_dual_results ==
-          realized_dual_results_string
+          dual_results_read[:, propertynames(dual_results_read) .!= :DateTime] ==
+          realized_dual_results[:, propertynames(realized_dual_results) .!= :DateTime] ==
+          realized_dual_results_string[
+              :,
+              propertynames(realized_dual_results_string) .!= :DateTime,
+          ]
     for i in axes(constraints)[1]
         dual = JuMP.dual(constraints[i])
         @test isapprox(dual, dual_results[i, :CopperPlateBalanceConstraint__System])
@@ -368,7 +371,7 @@ end
         joinpath(path, "results", "variables", "ActivePowerVariable__ThermalStandard.csv")
     var4 = PSI.read_dataframe(exp_file)
     # Manually Multiply by the base power var1_a has natural units and export writes directly from the solver
-    @test var1_a == var4 .* 100.0
+    @test var1_a[:, propertynames(var1_a) .!= :DateTime] == var4 .* 100.0
 
     @test length(readdir(export_realized_results(results1))) === 6
 end

--- a/test/test_model_emulation.jl
+++ b/test/test_model_emulation.jl
@@ -440,7 +440,7 @@ end
         joinpath(path, "results", "variables", "ActivePowerVariable__ThermalStandard.csv")
     var4 = PSI.read_dataframe(exp_file)
     # Manually Multiply by the base power var1_a has natural units and export writes directly from the solver
-    @test var1_a == var4 .* 100.0
+    @test var1_a[:, propertynames(var1_a) .!= :DateTime] == var4 .* 100.0
 end
 
 @testset "Test deserialization and re-run of EmulationModel" begin

--- a/test/test_utils/model_checks.jl
+++ b/test/test_utils/model_checks.jl
@@ -89,7 +89,7 @@ end
 
 function psi_ptdf_lmps(res::ProblemResults, ptdf)
     cp_duals = read_dual(res, PSI.ConstraintKey(CopperPlateBalanceConstraint, PSY.System))
-    λ = Matrix{Float64}(cp_duals)
+    λ = Matrix{Float64}(cp_duals[:, propertynames(cp_duals) .!= :DateTime])
 
     flow_duals = read_dual(res, PSI.ConstraintKey(NetworkFlowConstraint, PSY.Line))
     μ = Matrix{Float64}(flow_duals[:, ptdf.axes[1]])


### PR DESCRIPTION
makes the dataframes returned by `read_XXX(problemresults, xxx)` consistent with `read_realized_XXX(simulationproblemresults, xxx)` by adding a timestamp column to the problem results 