### PR TITLE
Fix handling of simulation execution directory

### DIFF
--- a/test/test_simulation_partitions.jl
+++ b/test/test_simulation_partitions.jl
@@ -56,8 +56,8 @@ end
     )
     @test execute_simulation(regular_sim) == PSI.RunStatus.SUCCESSFUL
 
-    regular_results = SimulationResults(joinpath(sim_dir, regular_name))
-    partitioned_results = SimulationResults(joinpath(sim_dir, partition_name))
+    regular_results = SimulationResults(sim_dir, regular_name)
+    partitioned_results = SimulationResults(sim_dir, partition_name)
 
     functions = (
         read_realized_aux_variables,

--- a/test/test_simulation_results.jl
+++ b/test/test_simulation_results.jl
@@ -496,7 +496,7 @@ function test_decision_problem_results(
 
     test_decision_problem_results_values(results_ed, results_uc, c_sys5_hy_ed, c_sys5_hy_uc)
     if !in_memory
-        test_simulation_results_from_file(results.path, c_sys5_hy_ed, c_sys5_hy_uc)
+        test_simulation_results_from_file(dirname(results.path), c_sys5_hy_ed, c_sys5_hy_uc)
     end
 end
 
@@ -666,7 +666,7 @@ function test_emulation_problem_results(results::SimulationResults, in_memory)
 end
 
 function test_simulation_results_from_file(path::AbstractString, c_sys5_hy_ed, c_sys5_hy_uc)
-    results = SimulationResults(path)
+    results = SimulationResults(path, "no_cache")
     @test list_decision_problems(results) == ["ED", "UC"]
     results_uc = get_decision_problem_results(results, "UC")
     results_ed = get_decision_problem_results(results, "ED")


### PR DESCRIPTION
#874 caused a regression in handling of simulation output directories when a single simulation is run multiple times. This fixes that issue.