### PR TITLE
ps power control

### DIFF
--- a/docs/src/formulation_library/Branch.md
+++ b/docs/src/formulation_library/Branch.md
@@ -44,24 +44,24 @@ StaticBranchUnbounded
 
 ---
 
-## `HVDCLossless`
+## `HVDCP2PLossless`
 
 ```@docs
-HVDCLossless
+HVDCP2PLossless
 ```
 
 ---
 
-## `HVDCDispatch`
+## `HVDCP2PDispatch`
 
 ```@docs
-HVDCDispatch
+HVDCP2PDispatch
 ```
 
 ---
 
-## `HVDCUnbounded`
+## `HVDCP2PUnbounded`
 
 ```@docs
-HVDCUnbounded
+HVDCP2PUnbounded
 ```

--- a/src/PowerSimulations.jl
+++ b/src/PowerSimulations.jl
@@ -247,6 +247,7 @@ export FlowActivePowerToFromVariable
 export FlowReactivePowerFromToVariable
 export FlowReactivePowerToFromVariable
 export PowerAboveMinimumVariable
+export PhaseShifterAngle
 
 # Auxiliary variables
 export TimeDurationOn
@@ -306,7 +307,7 @@ export OutputActivePowerVariableLimitsConstraint
 export PieceWiseLinearCostConstraint
 export PowerOutputRangeConstraint
 export ParticipationAssignmentConstraint
-export PhaseShifterAngle
+export PhaseAngleControlLimit
 export RampConstraint
 export RampLimitConstraint
 export RangeLimitConstraint

--- a/src/PowerSimulations.jl
+++ b/src/PowerSimulations.jl
@@ -42,6 +42,7 @@ export StaticBranchUnbounded
 export HVDCP2PLossless
 export HVDCP2PDispatch
 export HVDCP2PUnbounded
+export PhaseAngleControl
 # export VoltageSourceDC
 ######## Load Models ########
 export StaticPowerLoad

--- a/src/PowerSimulations.jl
+++ b/src/PowerSimulations.jl
@@ -306,6 +306,7 @@ export OutputActivePowerVariableLimitsConstraint
 export PieceWiseLinearCostConstraint
 export PowerOutputRangeConstraint
 export ParticipationAssignmentConstraint
+export PhaseShifterAngle
 export RampConstraint
 export RampLimitConstraint
 export RangeLimitConstraint

--- a/src/PowerSimulations.jl
+++ b/src/PowerSimulations.jl
@@ -39,9 +39,9 @@ export GroupReserve
 export StaticBranch
 export StaticBranchBounds
 export StaticBranchUnbounded
-export HVDCLossless
-export HVDCDispatch
-export HVDCUnbounded
+export HVDCP2PLossless
+export HVDCP2PDispatch
+export HVDCP2PUnbounded
 # export VoltageSourceDC
 ######## Load Models ########
 export StaticPowerLoad
@@ -295,7 +295,7 @@ export FlowReactivePowerFromToConstraint
 export FlowReactivePowerToFromConstraint
 export FrequencyResponseConstraint
 export HVDCPowerBalance
-export HVDCTotalPowerDeliveredVariable
+export HVDCLosses
 export InflowRangeConstraint
 export InputActivePowerVariableLimitsConstraint
 export InputPowerRangeConstraint

--- a/src/core/constraints.jl
+++ b/src/core/constraints.jl
@@ -91,6 +91,7 @@ struct SACEPIDAreaConstraint <: ConstraintType end
 struct StartTypeConstraint <: ConstraintType end
 struct StartupInitialConditionConstraint <: ConstraintType end
 struct StartupTimeLimitTemperatureConstraint <: ConstraintType end
+struct PhaseAngleControlLimit <: ConstraintType end
 
 abstract type PowerVariableLimitsConstraint <: ConstraintType end
 struct EnergyVariableLimitUpConstraint <: ConstraintType end

--- a/src/core/constraints.jl
+++ b/src/core/constraints.jl
@@ -92,6 +92,8 @@ struct StartTypeConstraint <: ConstraintType end
 struct StartupInitialConditionConstraint <: ConstraintType end
 struct StartupTimeLimitTemperatureConstraint <: ConstraintType end
 struct PhaseAngleControlLimit <: ConstraintType end
+struct HVDCLossesAbsoluteValue <: ConstraintType end
+struct HVDCDirection <: ConstraintType end
 
 abstract type PowerVariableLimitsConstraint <: ConstraintType end
 struct EnergyVariableLimitUpConstraint <: ConstraintType end

--- a/src/core/formulations.jl
+++ b/src/core/formulations.jl
@@ -185,7 +185,7 @@ struct StaticBranchUnbounded <: AbstractBranchFormulation end
 """
 Branch formulation for PhaseShiftingTransformer flow control
 """
-struct PhaseControl <: AbstractBranchFormulation end
+struct PhaseAngleControl <: AbstractBranchFormulation end
 
 ############################### DC Branch Formulations #####################################
 abstract type AbstractDCLineFormulation <: AbstractBranchFormulation end

--- a/src/core/formulations.jl
+++ b/src/core/formulations.jl
@@ -192,15 +192,15 @@ abstract type AbstractDCLineFormulation <: AbstractBranchFormulation end
 """
 Branch type to avoid flow constraints
 """
-struct HVDCUnbounded <: AbstractDCLineFormulation end
+struct HVDCP2PUnbounded <: AbstractDCLineFormulation end
 """
 Branch type to represent lossless power flow on DC lines
 """
-struct HVDCLossless <: AbstractDCLineFormulation end
+struct HVDCP2PLossless <: AbstractDCLineFormulation end
 """
 Branch type to represent lossy power flow on DC lines
 """
-struct HVDCDispatch <: AbstractDCLineFormulation end
+struct HVDCP2PDispatch <: AbstractDCLineFormulation end
 # Not Implemented
 # struct VoltageSourceDC <: AbstractDCLineFormulation end
 

--- a/src/core/formulations.jl
+++ b/src/core/formulations.jl
@@ -182,6 +182,10 @@ struct StaticBranchBounds <: AbstractBranchFormulation end
 Branch type to avoid flow constraints
 """
 struct StaticBranchUnbounded <: AbstractBranchFormulation end
+"""
+Branch formulation for PhaseShiftingTransformer flow control
+"""
+struct PhaseControl <: AbstractBranchFormulation end
 
 ############################### DC Branch Formulations #####################################
 abstract type AbstractDCLineFormulation <: AbstractBranchFormulation end

--- a/src/core/optimization_container.jl
+++ b/src/core/optimization_container.jl
@@ -1175,7 +1175,11 @@ end
 function get_expression(container::OptimizationContainer, key::ExpressionKey)
     var = get(container.expressions, key, nothing)
     if var === nothing
-        throw(IS.InvalidValue("constraint $key is not stored"))
+        throw(
+            IS.InvalidValue(
+                "constraint $key is not stored. $(collect(keys(container.expressions)))",
+            ),
+        )
     end
 
     return var

--- a/src/core/optimization_container.jl
+++ b/src/core/optimization_container.jl
@@ -702,8 +702,6 @@ function _add_variable_container!(
 ) where {T <: VariableType, U <: Union{PSY.Component, PSY.System}}
     if sparse
         var_container = sparse_container_spec(JuMP.VariableRef, axs...)
-        # We initialize sparse containers with Float64, not ideal and introduces type instability,
-        # because JuMP.Containers.SparseAxisArrays can't be initialized with undef
     else
         var_container = container_spec(JuMP.VariableRef, axs...)
     end

--- a/src/core/variables.jl
+++ b/src/core/variables.jl
@@ -205,7 +205,7 @@ Docs abbreviation: ``\\overleftarrow{Q}``
 """
 struct FlowReactivePowerToFromVariable <: VariableType end
 
-struct VariableNotDefined <: VariableType end
+struct PhaseShifterAngle <: VariableType end
 
 struct ComponentActivePowerVariable <: SubComponentVariableType end
 
@@ -215,7 +215,7 @@ struct ComponentActivePowerReserveUpVariable <: SubComponentVariableType end
 
 struct ComponentActivePowerReserveDownVariable <: SubComponentVariableType end
 
-# Necessary as a work around ofr HVDC models with losses
+# Necessary as a work around for HVDC models with losses
 struct HVDCTotalPowerDeliveredVariable <: VariableType end
 
 struct PieceWiseLinearCostVariable <: VariableType end

--- a/src/core/variables.jl
+++ b/src/core/variables.jl
@@ -215,8 +215,9 @@ struct ComponentActivePowerReserveUpVariable <: SubComponentVariableType end
 
 struct ComponentActivePowerReserveDownVariable <: SubComponentVariableType end
 
-# Necessary as a work around for HVDC models with losses
-struct HVDCTotalPowerDeliveredVariable <: VariableType end
+# Necessary as a work around for HVDCP2P models with losses
+struct HVDCLosses <: VariableType end
+struct HVDCFlowDirectionVariable <: VariableType end
 
 struct PieceWiseLinearCostVariable <: VariableType end
 
@@ -258,4 +259,4 @@ convert_result_to_natural_units(::Type{ComponentActivePowerVariable}) = true
 convert_result_to_natural_units(::Type{ComponentReactivePowerVariable}) = true
 convert_result_to_natural_units(::Type{ComponentActivePowerReserveUpVariable}) = true
 convert_result_to_natural_units(::Type{ComponentActivePowerReserveDownVariable}) = true
-convert_result_to_natural_units(::Type{HVDCTotalPowerDeliveredVariable}) = true
+convert_result_to_natural_units(::Type{HVDCLosses}) = true

--- a/src/devices_models/devices/AC_branches.jl
+++ b/src/devices_models/devices/AC_branches.jl
@@ -213,7 +213,7 @@ function add_constraints!(
         branches,
         time_steps,
     )
-    nodal_balance_expressions = get_expression(container, ActivePowerBalance(), S)
+    nodal_balance_expressions = get_expression(container, ActivePowerBalance(), StandardPTDFModel)
     flow_variables = get_variable(container, FlowActivePowerVariable(), B)
     jump_model = get_jump_model(container)
     for br in devices

--- a/src/devices_models/devices/AC_branches.jl
+++ b/src/devices_models/devices/AC_branches.jl
@@ -215,6 +215,7 @@ function add_constraints!(
     )
     nodal_balance_expressions =
         get_expression(container, ActivePowerBalance(), StandardPTDFModel)
+
     flow_variables = get_variable(container, FlowActivePowerVariable(), B)
     jump_model = get_jump_model(container)
     for br in devices

--- a/src/devices_models/devices/AC_branches.jl
+++ b/src/devices_models/devices/AC_branches.jl
@@ -254,7 +254,7 @@ function add_constraints!(
         branches,
         time_steps,
     )
-    nodal_balance_expressions = get_expression(container, ActivePowerBalance(), U)
+    nodal_balance_expressions = get_expression(container, ActivePowerBalance(), PSY.Bus)
     flow_variables = get_variable(container, FlowActivePowerVariable(), T)
     angle_variables = get_variable(container, PhaseShifterAngle(), T)
     jump_model = get_jump_model(container)

--- a/src/devices_models/devices/AC_branches.jl
+++ b/src/devices_models/devices/AC_branches.jl
@@ -12,7 +12,6 @@
 
 # Not implemented yet
 # struct TapControl <: AbstractBranchFormulation end
-# struct PhaseControl <: AbstractBranchFormulation end
 
 #################################### Branch Variables ##################################################
 # Because of the way we integrate with PowerModels, most of the time PowerSimulations will create variables

--- a/src/devices_models/devices/AC_branches.jl
+++ b/src/devices_models/devices/AC_branches.jl
@@ -213,7 +213,8 @@ function add_constraints!(
         branches,
         time_steps,
     )
-    nodal_balance_expressions = get_expression(container, ActivePowerBalance(), StandardPTDFModel)
+    nodal_balance_expressions =
+        get_expression(container, ActivePowerBalance(), StandardPTDFModel)
     flow_variables = get_variable(container, FlowActivePowerVariable(), B)
     jump_model = get_jump_model(container)
     for br in devices

--- a/src/devices_models/devices/DC_branches.jl
+++ b/src/devices_models/devices/DC_branches.jl
@@ -1,6 +1,11 @@
-
 #################################### Branch Variables ##################################################
 get_variable_binary(_, ::Type{<:PSY.DCBranch}, ::AbstractDCLineFormulation) = false
+
+get_variable_binary(
+    ::HVDCFlowDirectionVariable,
+    ::Type{<:PSY.DCBranch},
+    ::AbstractDCLineFormulation,
+) = true
 
 get_variable_multiplier(::FlowActivePowerVariable, ::Type{<:PSY.DCBranch}, _) = NaN
 
@@ -9,31 +14,52 @@ get_variable_multiplier(
     ::Type{<:PSY.DCBranch},
     ::AbstractDCLineFormulation,
 ) = -1.0
+
 get_variable_multiplier(
     ::FlowActivePowerToFromVariable,
     ::Type{<:PSY.DCBranch},
     ::AbstractDCLineFormulation,
 ) = 1.0
 
-get_variable_lower_bound(::FlowActivePowerVariable, d::PSY.DCBranch, ::HVDCUnbounded) =
+function get_variable_multiplier(::HVDCLosses, d::PSY.DCBranch, ::HVDCP2PDispatch)
+    l1 = PSY.get_loss(d).l1
+    l0 = PSY.get_loss(d).l0
+    if l1 == 0.0 && l0 == 0.0
+        return 0.0
+    else
+        return -1.0
+    end
+end
+
+get_variable_lower_bound(::FlowActivePowerVariable, d::PSY.DCBranch, ::HVDCP2PUnbounded) =
     nothing
 
-get_variable_upper_bound(::FlowActivePowerVariable, d::PSY.DCBranch, ::HVDCUnbounded) =
+get_variable_upper_bound(::FlowActivePowerVariable, d::PSY.DCBranch, ::HVDCP2PUnbounded) =
     nothing
 
 get_variable_lower_bound(
     ::FlowActivePowerVariable,
     d::PSY.DCBranch,
     ::AbstractDCLineFormulation,
-) = max(PSY.get_active_power_limits_from(d).min, PSY.get_active_power_limits_to(d).min)
+) = nothing
 
 get_variable_upper_bound(
     ::FlowActivePowerVariable,
     d::PSY.DCBranch,
     ::AbstractDCLineFormulation,
-) = min(PSY.get_active_power_limits_from(d).max, PSY.get_active_power_limits_to(d).max)
+) = nothing
 
-#! format: on
+get_variable_lower_bound(::HVDCLosses, d::PSY.DCBranch, ::HVDCP2PDispatch) = 0.0
+
+function get_variable_upper_bound(::HVDCLosses, d::PSY.DCBranch, ::HVDCP2PDispatch)
+    l1 = PSY.get_loss(d).l1
+    l0 = PSY.get_loss(d).l0
+    if l1 == 0.0 && l0 == 0.0
+        return 0.0
+    else
+        return nothing
+    end
+end
 
 function get_default_time_series_names(
     ::Type{U},
@@ -51,144 +77,350 @@ end
 
 get_initial_conditions_device_model(
     ::OperationModel,
-    ::DeviceModel{T, <:AbstractDCLineFormulation},
-) where {T <: PSY.HVDCLine} = DeviceModel(T, HVDCDispatch)
+    ::DeviceModel{T, U},
+) where {T <: PSY.HVDCLine, U <: AbstractDCLineFormulation} = DeviceModel(T, U)
 
 #################################### Rate Limits Constraints ##################################################
-function branch_rate_bounds!(
-    container::OptimizationContainer,
-    devices::IS.FlattenIteratorWrapper{B},
-    ::DeviceModel{B, HVDCLossless},
-    ::Type{<:PM.AbstractPowerModel},
-) where {B <: PSY.HVDCLine}
-    var = get_variable(container, FlowActivePowerVariable(), B)
-    for d in devices
-        name = PSY.get_name(d)
-        for t in get_time_steps(container)
-            _var = var[name, t]
-            max_val = max(
-                PSY.get_active_power_limits_to(d).max,
-                PSY.get_active_power_limits_from(d).max,
-            )
-            min_val = min(
-                PSY.get_active_power_limits_to(d).min,
-                PSY.get_active_power_limits_from(d).min,
-            )
-            JuMP.set_upper_bound(_var, max_val)
-            JuMP.set_lower_bound(_var, min_val)
-        end
+function _check_hvdc_line_limits_consistency(d::PSY.HVDCLine)
+    from_min = PSY.get_active_power_limits_from(d).min
+    to_min = PSY.get_active_power_limits_to(d).min
+    from_max = PSY.get_active_power_limits_from(d).max
+    to_max = PSY.get_active_power_limits_to(d).max
+
+    if from_max < from_min || to_max < to_min
+        throw(
+            IS.ConflictingInputsError(
+                "Limits in HVDC Line $(PSY.get_name(d)) are inconsistent",
+            ),
+        )
+    end
+
+    if from_max < to_min
+        throw(
+            IS.ConflictingInputsError(
+                "From Max $(from_max) can't be a smaller value than To Min $(to_min)",
+            ),
+        )
+    elseif to_max < from_min
+        throw(
+            IS.ConflictingInputsError(
+                "To Max $(to_max) can't be a smaller value than From Min $(from_min)",
+            ),
+        )
     end
     return
 end
+function _get_flow_bounds(d::PSY.HVDCLine)
+    _check_hvdc_line_limits_consistency(d)
+    from_min = PSY.get_active_power_limits_from(d).min
+    to_min = PSY.get_active_power_limits_to(d).min
+    from_max = PSY.get_active_power_limits_from(d).max
+    to_max = PSY.get_active_power_limits_to(d).max
 
-function branch_rate_bounds!(
-    container::OptimizationContainer,
-    devices::IS.FlattenIteratorWrapper{B},
-    ::DeviceModel{B, <:AbstractDCLineFormulation},
-    ::Type{<:PM.AbstractPowerModel},
-) where {B <: PSY.HVDCLine}
-    vars = [
-        get_variable(container, FlowActivePowerVariable(), B),
-        get_variable(container, HVDCTotalPowerDeliveredVariable(), B),
-    ]
-    for d in devices
-        name = PSY.get_name(d)
-        for t in get_time_steps(container)
-            JuMP.set_upper_bound(vars[1][name, t], PSY.get_active_power_limits_from(d).max)
-            JuMP.set_lower_bound(vars[1][name, t], PSY.get_active_power_limits_from(d).min)
-            JuMP.set_upper_bound(vars[2][name, t], PSY.get_active_power_limits_to(d).max)
-            JuMP.set_lower_bound(vars[2][name, t], PSY.get_reactive_power_limits_to(d).min)
-        end
+    if from_min >= 0.0 && to_min >= 0.0
+        min_rate = min(from_min, to_min)
+    elseif from_min <= 0.0 && to_min <= 0.0
+        min_rate = max(from_min, to_min)
+    elseif from_min <= 0.0 && to_min >= 0.0
+        min_rate = from_min
+    elseif to_min <= 0.0 && from_min >= 0.0
+        min_rate = to_min
     end
-    return
-end
 
-function add_constraints!(
-    container::OptimizationContainer,
-    cons_type::Type{FlowRateConstraint},
-    devices::IS.FlattenIteratorWrapper{B},
-    ::DeviceModel{B, HVDCLossless},
-    ::Type{<:PM.AbstractDCPModel},
-) where {B <: PSY.DCBranch}
-    var = get_variable(container, FlowActivePowerVariable(), B)
-    time_steps = get_time_steps(container)
-    names = [PSY.get_name(d) for d in devices]
-    constraint = add_constraints_container!(container, cons_type(), B, names, time_steps)
-    for t in time_steps, d in devices
-        min_rate = max(
-            PSY.get_active_power_limits_from(d).min,
-            PSY.get_active_power_limits_to(d).min,
-        )
-        max_rate = min(
-            PSY.get_active_power_limits_from(d).max,
-            PSY.get_active_power_limits_to(d).max,
-        )
-        constraint[PSY.get_name(d), t] = JuMP.@constraint(
-            container.JuMPmodel,
-            min_rate <= var[PSY.get_name(d), t] <= max_rate
-        )
+    if from_max >= 0.0 && to_max >= 0.0
+        max_rate = min(from_max, to_max)
+    elseif from_max <= 0.0 && to_max <= 0.0
+        max_rate = max(from_max, to_max)
+    elseif from_max <= 0.0 && to_max >= 0.0
+        max_rate = from_max
+    elseif from_max >= 0.0 && to_max <= 0.0
+        max_rate = to_max
     end
-    return
+
+    return min_rate, max_rate
 end
 
 add_constraints!(
     ::OptimizationContainer,
-    ::Type{<:Union{FlowRateConstraintFromTo, FlowRateConstraintToFrom, FlowRateConstraint}},
+    ::Type{<:Union{FlowRateConstraintFromTo, FlowRateConstraintToFrom}},
     ::IS.FlattenIteratorWrapper{<:PSY.DCBranch},
-    ::DeviceModel{<:PSY.DCBranch, HVDCUnbounded},
+    ::DeviceModel{<:PSY.DCBranch, HVDCP2PUnbounded},
+    ::Type{<:PM.AbstractPowerModel},
+) = nothing
+
+add_constraints!(
+    ::OptimizationContainer,
+    ::Type{FlowRateConstraint},
+    ::IS.FlattenIteratorWrapper{<:PSY.DCBranch},
+    ::DeviceModel{<:PSY.DCBranch, HVDCP2PUnbounded},
     ::Type{<:PM.AbstractPowerModel},
 ) = nothing
 
 function add_constraints!(
     container::OptimizationContainer,
-    cons_type::Type{
-        <:Union{FlowRateConstraintFromTo, FlowRateConstraintToFrom, FlowRateConstraint},
-    },
-    devices::IS.FlattenIteratorWrapper{B},
-    ::DeviceModel{B, <:AbstractDCLineFormulation},
+    ::Type{T},
+    devices::IS.FlattenIteratorWrapper{U},
+    ::DeviceModel{U, <:AbstractDCLineFormulation},
     ::Type{<:PM.AbstractPowerModel},
-) where {B <: PSY.DCBranch}
+) where {T <: FlowRateConstraint, U <: PSY.DCBranch}
     time_steps = get_time_steps(container)
     names = [PSY.get_name(d) for d in devices]
 
-    var = get_variable(container, FlowActivePowerVariable(), B)
-    constraint = add_constraints_container!(container, cons_type(), B, names, time_steps)
-    for t in time_steps, d in devices
-        min_rate = max(
-            PSY.get_active_power_limits_from(d).min,
-            PSY.get_active_power_limits_to(d).min,
-        )
-        max_rate = min(
-            PSY.get_active_power_limits_from(d).max,
-            PSY.get_active_power_limits_to(d).max,
-        )
-        constraint[PSY.get_name(d), t] = JuMP.@constraint(
-            container.JuMPmodel,
-            min_rate <= var[PSY.get_name(d), t] <= max_rate
-        )
+    var = get_variable(container, FlowActivePowerVariable(), U)
+    constraint_ub =
+        add_constraints_container!(container, T(), U, names, time_steps; meta="ub")
+    constraint_lb =
+        add_constraints_container!(container, T(), U, names, time_steps; meta="lb")
+    for d in devices
+        min_rate, max_rate = _get_flow_bounds(d)
+        for t in time_steps
+            constraint_ub[PSY.get_name(d), t] = JuMP.@constraint(
+                get_jump_model(container),
+                var[PSY.get_name(d), t] <= max_rate
+            )
+            constraint_lb[PSY.get_name(d), t] = JuMP.@constraint(
+                get_jump_model(container),
+                min_rate <= var[PSY.get_name(d), t]
+            )
+        end
     end
     return
 end
 
 function add_constraints!(
     container::OptimizationContainer,
-    cons_type::Type{HVDCPowerBalance},
-    devices::IS.FlattenIteratorWrapper{B},
-    ::DeviceModel{B, <:AbstractDCLineFormulation},
+    ::Type{T},
+    devices::IS.FlattenIteratorWrapper{U},
+    ::DeviceModel{U, HVDCP2PDispatch},
     ::Type{<:PM.AbstractPowerModel},
-) where {B <: PSY.DCBranch}
+) where {T <: FlowRateConstraintFromTo, U <: PSY.DCBranch}
     time_steps = get_time_steps(container)
     names = [PSY.get_name(d) for d in devices]
 
-    delivered_power_var = get_variable(container, HVDCTotalPowerDeliveredVariable(), B)
-    flow_var = get_variable(container, FlowActivePowerVariable(), B)
-    constraint = add_constraints_container!(container, cons_type(), B, names, time_steps)
-    for t in get_time_steps(container), d in devices
-        constraint[PSY.get_name(d), t] = JuMP.@constraint(
-            container.JuMPmodel,
-            delivered_power_var[PSY.get_name(d), t] ==
-            -PSY.get_loss(d).l1 * flow_var[PSY.get_name(d), t] - PSY.get_loss(d).l0,
-        )
+    var = get_variable(container, FlowActivePowerFromToVariable(), U)
+    constraint_ub =
+        add_constraints_container!(container, T(), U, names, time_steps; meta="ub")
+    constraint_lb =
+        add_constraints_container!(container, T(), U, names, time_steps; meta="lb")
+    for d in devices
+        min_rate, max_rate = PSY.get_active_power_limits_from(d)
+        for t in time_steps
+            constraint_ub[PSY.get_name(d), t] = JuMP.@constraint(
+                get_jump_model(container),
+                var[PSY.get_name(d), t] <= max_rate
+            )
+            constraint_lb[PSY.get_name(d), t] = JuMP.@constraint(
+                get_jump_model(container),
+                min_rate <= var[PSY.get_name(d), t]
+            )
+        end
+    end
+    return
+end
+
+function add_constraints!(
+    container::OptimizationContainer,
+    ::Type{T},
+    devices::IS.FlattenIteratorWrapper{U},
+    ::DeviceModel{U, HVDCP2PDispatch},
+    ::Type{<:PM.AbstractPowerModel},
+) where {T <: FlowRateConstraintToFrom, U <: PSY.DCBranch}
+    time_steps = get_time_steps(container)
+    names = [PSY.get_name(d) for d in devices]
+
+    var = get_variable(container, FlowActivePowerToFromVariable(), U)
+    constraint_ub =
+        add_constraints_container!(container, T(), U, names, time_steps; meta="ub")
+    constraint_lb =
+        add_constraints_container!(container, T(), U, names, time_steps; meta="lb")
+    for d in devices
+        min_rate, max_rate = PSY.get_active_power_limits_to(d)
+        for t in time_steps
+            constraint_ub[PSY.get_name(d), t] = JuMP.@constraint(
+                get_jump_model(container),
+                var[PSY.get_name(d), t] <= max_rate
+            )
+            constraint_lb[PSY.get_name(d), t] = JuMP.@constraint(
+                get_jump_model(container),
+                min_rate <= var[PSY.get_name(d), t]
+            )
+        end
+    end
+    return
+end
+
+function add_constraints!(
+    container::OptimizationContainer,
+    ::Type{T},
+    devices::IS.FlattenIteratorWrapper{U},
+    ::DeviceModel{U, HVDCP2PDispatch},
+    ::Type{<:PM.AbstractPowerModel},
+) where {T <: HVDCDirection, U <: PSY.DCBranch}
+    time_steps = get_time_steps(container)
+    names = [PSY.get_name(d) for d in devices]
+
+    tf_var = get_variable(container, FlowActivePowerToFromVariable(), U)
+    ft_var = get_variable(container, FlowActivePowerFromToVariable(), U)
+    direction_var = get_variable(container, HVDCFlowDirectionVariable(), U)
+
+    constraint_ft_ub =
+        add_constraints_container!(container, T(), U, names, time_steps; meta="ft_ub")
+    constraint_tf_ub =
+        add_constraints_container!(container, T(), U, names, time_steps; meta="tf_ub")
+    constraint_ft_lb =
+        add_constraints_container!(container, T(), U, names, time_steps; meta="ft_lb")
+    constraint_tf_lb =
+        add_constraints_container!(container, T(), U, names, time_steps; meta="tf_lb")
+    for d in devices
+        min_rate_to, max_rate_to = PSY.get_active_power_limits_to(d)
+        min_rate_from, max_rate_from = PSY.get_active_power_limits_to(d)
+        name = PSY.get_name(d)
+        for t in time_steps
+            constraint_tf_ub[name, t] = JuMP.@constraint(
+                get_jump_model(container),
+                tf_var[name, t] <= max_rate_to * (1 - direction_var[name, t])
+            )
+            constraint_ft_ub[name, t] = JuMP.@constraint(
+                get_jump_model(container),
+                ft_var[name, t] <= max_rate_from * (1 - direction_var[name, t])
+            )
+            constraint_tf_lb[name, t] = JuMP.@constraint(
+                get_jump_model(container),
+                direction_var[name, t] * min_rate_to <= tf_var[name, t]
+            )
+            constraint_ft_lb[name, t] = JuMP.@constraint(
+                get_jump_model(container),
+                direction_var[name, t] * min_rate_from <= tf_var[name, t]
+            )
+        end
+    end
+    return
+end
+
+function add_constraints!(
+    container::OptimizationContainer,
+    ::Type{HVDCPowerBalance},
+    devices::IS.FlattenIteratorWrapper{T},
+    ::DeviceModel{T, <:AbstractDCLineFormulation},
+    ::Type{<:PM.AbstractPowerModel},
+) where {T <: PSY.DCBranch}
+    time_steps = get_time_steps(container)
+    names = [PSY.get_name(d) for d in devices]
+    tf_var = get_variable(container, FlowActivePowerToFromVariable(), T)
+    ft_var = get_variable(container, FlowActivePowerFromToVariable(), T)
+    direction_var = get_variable(container, HVDCFlowDirectionVariable(), T)
+
+    constraint_ft_ub = add_constraints_container!(
+        container,
+        HVDCPowerBalance(),
+        T,
+        names,
+        time_steps;
+        meta="ft_ub",
+    )
+    constraint_tf_ub = add_constraints_container!(
+        container,
+        HVDCPowerBalance(),
+        T,
+        names,
+        time_steps;
+        meta="tf_ub",
+    )
+    constraint_ft_lb = add_constraints_container!(
+        container,
+        HVDCPowerBalance(),
+        T,
+        names,
+        time_steps;
+        meta="tf_lb",
+    )
+    constraint_tf_lb = add_constraints_container!(
+        container,
+        HVDCPowerBalance(),
+        T,
+        names,
+        time_steps;
+        meta="ft_lb",
+    )
+    for d in devices
+        l1 = PSY.get_loss(d).l1
+        l0 = PSY.get_loss(d).l0
+        name = PSY.get_name(d)
+
+        for t in get_time_steps(container)
+            if l1 == 0.0 && l0 == 0.0
+                constraint_tf_ub[PSY.get_name(d), t] = JuMP.@constraint(
+                    get_jump_model(container),
+                    tf_var[name, t] - ft_var[name, t] == 0.0
+                )
+                constraint_ft_ub[PSY.get_name(d), t] = JuMP.@constraint(
+                    get_jump_model(container),
+                    ft_var[name, t] - tf_var[name, t] == 0.0
+                )
+            else
+                constraint_tf_ub[PSY.get_name(d), t] = JuMP.@constraint(
+                    get_jump_model(container),
+                    tf_var[name, t] - ft_var[name, t] <= l1 * tf_var[name, t] - l0
+                )
+                constraint_ft_ub[PSY.get_name(d), t] = JuMP.@constraint(
+                    get_jump_model(container),
+                    ft_var[name, t] - tf_var[name, t] >= l1 * ft_var[name, t] + l0
+                )
+            end
+            constraint_tf_lb[PSY.get_name(d), t] = JuMP.@constraint(
+                get_jump_model(container),
+                ft_var[name, t] - tf_var[name, t] >=
+                -M_VALUE * (1 - direction_var[name, t])
+            )
+            constraint_ft_lb[PSY.get_name(d), t] = JuMP.@constraint(
+                get_jump_model(container),
+                tf_var[name, t] - ft_var[name, t] >= -M_VALUE * (direction_var[name, t])
+            )
+        end
+    end
+    return
+end
+
+function add_constraints!(
+    container::OptimizationContainer,
+    ::Type{HVDCLossesAbsoluteValue},
+    devices::IS.FlattenIteratorWrapper{T},
+    ::DeviceModel{T, <:AbstractDCLineFormulation},
+    ::Type{<:PM.AbstractPowerModel},
+) where {T <: PSY.DCBranch}
+    time_steps = get_time_steps(container)
+    names = [PSY.get_name(d) for d in devices]
+    losses = get_variable(container, HVDCLosses(), T)
+    tf_var = get_variable(container, FlowActivePowerToFromVariable(), T)
+    ft_var = get_variable(container, FlowActivePowerFromToVariable(), T)
+    constraint_tf = add_constraints_container!(
+        container,
+        HVDCLossesAbsoluteValue(),
+        T,
+        names,
+        time_steps;
+        meta="tf",
+    )
+    constraint_ft = add_constraints_container!(
+        container,
+        HVDCLossesAbsoluteValue(),
+        T,
+        names,
+        time_steps;
+        meta="ft",
+    )
+    for d in devices
+        name = PSY.get_name(d)
+        for t in get_time_steps(container)
+            constraint_tf[PSY.get_name(d), t] = JuMP.@constraint(
+                get_jump_model(container),
+                tf_var[name, t] - ft_var[name, t] <= losses[name, t]
+            )
+            constraint_ft[PSY.get_name(d), t] = JuMP.@constraint(
+                get_jump_model(container),
+                -tf_var[name, t] + ft_var[name, t] <= losses[name, t]
+            )
+        end
     end
     return
 end

--- a/src/devices_models/devices/common/add_to_expression.jl
+++ b/src/devices_models/devices/common/add_to_expression.jl
@@ -157,7 +157,7 @@ function add_to_expression!(
 end
 
 """
-Default implementation to add variables to SystemBalanceExpressions
+Default implementation to add device variables to SystemBalanceExpressions
 """
 function add_to_expression!(
     container::OptimizationContainer,
@@ -169,7 +169,7 @@ function add_to_expression!(
 ) where {
     T <: SystemBalanceExpressions,
     U <: VariableType,
-    V <: PSY.Device,
+    V <: PSY.StaticInjection,
     W <: AbstractDeviceFormulation,
     X <: PM.AbstractPowerModel,
 }
@@ -183,6 +183,98 @@ function add_to_expression!(
             variable[name, t],
             get_variable_multiplier(U(), V, W()),
         )
+    end
+    return
+end
+
+"""
+Default implementation to add branch variables to SystemBalanceExpressions
+"""
+function add_to_expression!(
+    container::OptimizationContainer,
+    ::Type{T},
+    ::Type{U},
+    devices::IS.FlattenIteratorWrapper{V},
+    ::DeviceModel{V, W},
+    ::Type{StandardPTDFModel},
+) where {T <: ActivePowerBalance, U <: HVDCLosses, V <: PSY.HVDCLine, W <: HVDCP2PDispatch}
+    variable = get_variable(container, U(), V)
+    expression = get_expression(container, T(), PSY.System)
+    for d in devices
+        name = PSY.get_name(d)
+        for t in get_time_steps(container)
+            _add_to_jump_expression!(
+                expression[t],
+                variable[name, t],
+                get_variable_multiplier(U(), d, W()),
+            )
+        end
+    end
+    return
+end
+
+"""
+Default implementation to add branch variables to SystemBalanceExpressions
+"""
+function add_to_expression!(
+    container::OptimizationContainer,
+    ::Type{T},
+    ::Type{U},
+    devices::IS.FlattenIteratorWrapper{V},
+    ::DeviceModel{V, W},
+    ::Type{X},
+) where {
+    T <: ActivePowerBalance,
+    U <: FlowActivePowerFromToVariable,
+    V <: PSY.Branch,
+    W <: AbstractDeviceFormulation,
+    X <: PM.AbstractPowerModel,
+}
+    variable = get_variable(container, U(), V)
+    expression = get_expression(container, T(), X)
+    for d in devices
+        name = PSY.get_name(d)
+        bus_number = PSY.get_number(PSY.get_arc(d).from)
+        for t in get_time_steps(container)
+            _add_to_jump_expression!(
+                expression[bus_number, t],
+                variable[name, t],
+                get_variable_multiplier(U(), V, W()),
+            )
+        end
+    end
+    return
+end
+
+"""
+Default implementation to add branch variables to SystemBalanceExpressions
+"""
+function add_to_expression!(
+    container::OptimizationContainer,
+    ::Type{T},
+    ::Type{U},
+    devices::IS.FlattenIteratorWrapper{V},
+    ::DeviceModel{V, W},
+    ::Type{X},
+) where {
+    T <: ActivePowerBalance,
+    U <: FlowActivePowerToFromVariable,
+    V <: PSY.Branch,
+    W <: AbstractDeviceFormulation,
+    X <: PM.AbstractPowerModel,
+}
+    variable = get_variable(container, U(), V)
+    expression = get_expression(container, T(), X)
+    for d in devices
+        name = PSY.get_name(d)
+        bus_number = PSY.get_number(PSY.get_arc(d).to)
+        for t in get_time_steps(container)
+            _add_to_jump_expression!(
+                expression[bus_number, t],
+                variable[name, t],
+                get_variable_multiplier(U(), V, W()),
+            )
+        end
     end
     return
 end
@@ -532,34 +624,6 @@ function add_to_expression!(
         end
     end
     return
-end
-
-function add_to_expression!(
-    container::OptimizationContainer,
-    ::Type{T},
-    ::Type{U},
-    devices::IS.FlattenIteratorWrapper{V},
-    ::DeviceModel{V, W},
-    ::Type{X},
-) where {
-    T <: ActivePowerBalance,
-    U <: HVDCTotalPowerDeliveredVariable,
-    V <: PSY.DCBranch,
-    W <: AbstractBranchFormulation,
-    X <: PM.AbstractPowerModel,
-}
-    var = get_variable(container, U(), V)
-    expression = get_expression(container, T(), X)
-    for d in devices
-        for t in get_time_steps(container)
-            flow_variable = var[PSY.get_name(d), t]
-            _add_to_jump_expression!(
-                expression[PSY.get_number(PSY.get_arc(d).to), t],
-                flow_variable,
-                1.0,
-            )
-        end
-    end
 end
 
 function add_to_expression!(

--- a/src/devices_models/devices/common/add_to_expression.jl
+++ b/src/devices_models/devices/common/add_to_expression.jl
@@ -495,6 +495,43 @@ function add_to_expression!(
             )
         end
     end
+    return
+end
+
+"""
+Implementation of add_to_expression! for lossless branch/network models
+"""
+function add_to_expression!(
+    container::OptimizationContainer,
+    ::Type{T},
+    ::Type{U},
+    devices::IS.FlattenIteratorWrapper{PSY.PhaseShiftingTransformer},
+    ::DeviceModel{PSY.PhaseShiftingTransformer, V},
+    ::Type{W},
+) where {
+    T <: ActivePowerBalance,
+    U <: PhaseShifterAngle,
+    V <: PhaseAngleControl,
+    W <: StandardPTDFModel,
+}
+    var = get_variable(container, U(), PSY.PhaseShiftingTransformer)
+    expression = get_expression(container, T(), PSY.Bus)
+    for d in devices
+        for t in get_time_steps(container)
+            flow_variable = var[PSY.get_name(d), t]
+            _add_to_jump_expression!(
+                expression[PSY.get_number(PSY.get_arc(d).from), t],
+                flow_variable,
+                -get_variable_multiplier(U(), d, V()),
+            )
+            _add_to_jump_expression!(
+                expression[PSY.get_number(PSY.get_arc(d).to), t],
+                flow_variable,
+                get_variable_multiplier(U(), d, V()),
+            )
+        end
+    end
+    return
 end
 
 function add_to_expression!(

--- a/src/devices_models/devices/common/range_constraint.jl
+++ b/src/devices_models/devices/common/range_constraint.jl
@@ -9,14 +9,6 @@ function get_startup_shutdown(
     nothing
 end
 
-function get_min_max_limits(
-    device,
-    ::Type{<:VariableType},
-    ::Type{<:AbstractDeviceFormulation},
-) #  -> Union{Nothing, NamedTuple{(:min, :max), Tuple{Float64, Float64}}}
-    return (min=0.0, max=0.0)
-end
-
 @doc raw"""
 Constructs min/max range constraint from device variable.
 

--- a/src/devices_models/devices/thermal_generation.jl
+++ b/src/devices_models/devices/thermal_generation.jl
@@ -117,7 +117,8 @@ no_load_cost(cost::PSY.VariableCost{Float64}, ::OnVariable, ::PSY.ThermalGen, ::
 function no_load_cost(cost::PSY.VariableCost{Tuple{Float64, Float64}}, ::OnVariable, d::PSY.ThermalGen, ::AbstractThermalFormulation)
     return (PSY.get_cost(cost)[1] * (PSY.get_active_power_limits(d).min)^2 + PSY.get_cost(cost)[2] * PSY.get_active_power_limits(d).min)* PSY.get_base_power(d)
 end
-    #! format: on
+
+#! format: on
 function get_initial_conditions_device_model(
     model::OperationModel,
     ::DeviceModel{T, D},

--- a/src/network_models/pm_translator.jl
+++ b/src/network_models/pm_translator.jl
@@ -66,7 +66,7 @@ end
 function get_branch_to_pm(
     ix::Int,
     branch::PSY.PhaseShiftingTransformer,
-    device_formulation::Type{StaticBranchUnbounded},
+    ::Type{StaticBranchUnbounded},
 )
     PM_branch = Dict{String, Any}(
         "br_r" => PSY.get_r(branch),
@@ -91,7 +91,7 @@ end
 function get_branch_to_pm(
     ix::Int,
     branch::PSY.Transformer2W,
-    device_formulation::Type{D},
+    ::Type{D},
 ) where {D <: AbstractBranchFormulation}
     PM_branch = Dict{String, Any}(
         "br_r" => PSY.get_r(branch),
@@ -116,11 +116,7 @@ function get_branch_to_pm(
     return PM_branch
 end
 
-function get_branch_to_pm(
-    ix::Int,
-    branch::PSY.Transformer2W,
-    device_formulation::Type{StaticBranchUnbounded},
-)
+function get_branch_to_pm(ix::Int, branch::PSY.Transformer2W, ::Type{StaticBranchUnbounded})
     PM_branch = Dict{String, Any}(
         "br_r" => PSY.get_r(branch),
         "shift" => 0.0,
@@ -144,7 +140,7 @@ end
 function get_branch_to_pm(
     ix::Int,
     branch::PSY.TapTransformer,
-    device_formulation::Type{D},
+    ::Type{D},
 ) where {D <: AbstractBranchFormulation}
     PM_branch = Dict{String, Any}(
         "br_r" => PSY.get_r(branch),
@@ -172,7 +168,7 @@ end
 function get_branch_to_pm(
     ix::Int,
     branch::PSY.TapTransformer,
-    device_formulation::Type{StaticBranchUnbounded},
+    ::Type{StaticBranchUnbounded},
 )
     PM_branch = Dict{String, Any}(
         "br_r" => PSY.get_r(branch),
@@ -197,7 +193,7 @@ end
 function get_branch_to_pm(
     ix::Int,
     branch::PSY.ACBranch,
-    device_formulation::Type{D},
+    ::Type{D},
 ) where {D <: AbstractBranchFormulation}
     PM_branch = Dict{String, Any}(
         "br_r" => PSY.get_r(branch),
@@ -222,11 +218,7 @@ function get_branch_to_pm(
     return PM_branch
 end
 
-function get_branch_to_pm(
-    ix::Int,
-    branch::PSY.ACBranch,
-    device_formulation::Type{StaticBranchUnbounded},
-)
+function get_branch_to_pm(ix::Int, branch::PSY.ACBranch, ::Type{StaticBranchUnbounded})
     PM_branch = Dict{String, Any}(
         "br_r" => PSY.get_r(branch),
         "shift" => 0.0,
@@ -243,6 +235,39 @@ function get_branch_to_pm(
         "angmax" => PSY.get_angle_limits(branch).max,
         "transformer" => false,
         "tap" => 1.0,
+    )
+    return PM_branch
+end
+
+function get_branch_to_pm(ix::Int, branch::PSY.HVDCLine, ::Type{HVDCP2PDispatch})
+    PM_branch = Dict{String, Any}(
+        "loss1" => PSY.get_loss(branch).l1,
+        "mp_pmax" => PSY.get_reactive_power_limits_from(branch).max,
+        "model" => 2,
+        "shutdown" => 0.0,
+        "pmaxt" => PSY.get_active_power_limits_to(branch).max,
+        "pmaxf" => PSY.get_active_power_limits_from(branch).max,
+        "startup" => 0.0,
+        "loss0" => PSY.get_loss(branch).l1,
+        "pt" => 0.0,
+        "vt" => PSY.get_magnitude(PSY.get_arc(branch).to),
+        "qmaxf" => PSY.get_reactive_power_limits_from(branch).max,
+        "pmint" => PSY.get_active_power_limits_to(branch).min,
+        "f_bus" => PSY.get_number(PSY.get_arc(branch).from),
+        "mp_pmin" => PSY.get_reactive_power_limits_from(branch).min,
+        "br_status" => 0.0,
+        "t_bus" => PSY.get_number(PSY.get_arc(branch).to),
+        "index" => ix,
+        "qmint" => PSY.get_reactive_power_limits_to(branch).min,
+        "qf" => 0.0,
+        "cost" => 0.0,
+        "pminf" => PSY.get_active_power_limits_from(branch).min,
+        "qt" => 0.0,
+        "qminf" => PSY.get_reactive_power_limits_from(branch).min,
+        "vf" => PSY.get_magnitude(PSY.get_arc(branch).from),
+        "qmaxt" => PSY.get_reactive_power_limits_to(branch).max,
+        "ncost" => 0,
+        "pf" => 0.0,
     )
     return PM_branch
 end
@@ -250,7 +275,7 @@ end
 function get_branch_to_pm(
     ix::Int,
     branch::PSY.HVDCLine,
-    device_formulation::Type{D},
+    ::Type{D},
 ) where {D <: AbstractBranchFormulation}
     PM_branch = Dict{String, Any}(
         "loss1" => PSY.get_loss(branch).l1,

--- a/src/network_models/pm_translator.jl
+++ b/src/network_models/pm_translator.jl
@@ -65,34 +65,6 @@ end
 function get_branch_to_pm(
     ix::Int,
     branch::PSY.PhaseShiftingTransformer,
-    device_formulation::Type{D},
-) where {D <: AbstractBranchFormulation}
-    PM_branch = Dict{String, Any}(
-        "br_r" => PSY.get_r(branch),
-        "rate_a" => PSY.get_rate(branch),
-        "shift" => PSY.get_α(branch),
-        "rate_b" => PSY.get_rate(branch),
-        "br_x" => PSY.get_x(branch),
-        "rate_c" => PSY.get_rate(branch),
-        "g_to" => 0.0,
-        "g_fr" => 0.0,
-        "b_fr" => PSY.get_primary_shunt(branch) / 2,
-        "f_bus" => PSY.get_number(PSY.get_arc(branch).from),
-        "br_status" => Float64(PSY.get_available(branch)),
-        "t_bus" => PSY.get_number(PSY.get_arc(branch).to),
-        "b_to" => PSY.get_primary_shunt(branch) / 2,
-        "index" => ix,
-        "angmin" => -π / 2,
-        "angmax" => π / 2,
-        "transformer" => true,
-        "tap" => PSY.get_tap(branch),
-    )
-    return PM_branch
-end
-
-function get_branch_to_pm(
-    ix::Int,
-    branch::PSY.PhaseShiftingTransformer,
     device_formulation::Type{StaticBranchUnbounded},
 )
     PM_branch = Dict{String, Any}(

--- a/src/network_models/pm_translator.jl
+++ b/src/network_models/pm_translator.jl
@@ -1,15 +1,16 @@
-const PM_MAP_TUPLE = NamedTuple{(:from_to, :to_from), Tuple{Tuple{Int, Int, Int}, Tuple{Int, Int, Int}}}
+const PM_MAP_TUPLE =
+    NamedTuple{(:from_to, :to_from), Tuple{Tuple{Int, Int, Int}, Tuple{Int, Int, Int}}}
 
 struct PMmap
     bus::Dict{Int, PSY.Bus}
-    arcs::Dict{PM_MAP_TUPLE, <: PSY.ACBranch}
-    arcs_dc::Dict{PM_MAP_TUPLE, <: PSY.DCBranch}
+    arcs::Dict{PM_MAP_TUPLE, <:PSY.ACBranch}
+    arcs_dc::Dict{PM_MAP_TUPLE, <:PSY.DCBranch}
 end
 
 function get_branch_to_pm(
     ix::Int,
     branch::PSY.PhaseShiftingTransformer,
-    ::Type{PhaseControl},
+    ::Type{PhaseAngleControl},
 )
     PM_branch = Dict{String, Any}(
         "br_r" => PSY.get_r(branch),

--- a/src/network_models/pm_translator.jl
+++ b/src/network_models/pm_translator.jl
@@ -11,6 +11,7 @@ function get_branch_to_pm(
     ix::Int,
     branch::PSY.PhaseShiftingTransformer,
     ::Type{PhaseAngleControl},
+    ::Type{<:PM.AbstractDCPModel},
 )
     PM_branch = Dict{String, Any}(
         "br_r" => PSY.get_r(branch),
@@ -39,6 +40,7 @@ function get_branch_to_pm(
     ix::Int,
     branch::PSY.PhaseShiftingTransformer,
     ::Type{D},
+    ::Type{<:PM.AbstractPowerModel},
 ) where {D <: AbstractBranchFormulation}
     PM_branch = Dict{String, Any}(
         "br_r" => PSY.get_r(branch),
@@ -67,6 +69,7 @@ function get_branch_to_pm(
     ix::Int,
     branch::PSY.PhaseShiftingTransformer,
     ::Type{StaticBranchUnbounded},
+    ::Type{<:PM.AbstractPowerModel},
 )
     PM_branch = Dict{String, Any}(
         "br_r" => PSY.get_r(branch),
@@ -91,8 +94,9 @@ end
 function get_branch_to_pm(
     ix::Int,
     branch::PSY.Transformer2W,
-    ::Type{D},
-) where {D <: AbstractBranchFormulation}
+    ::Type{<:AbstractBranchFormulation},
+    ::Type{<:PM.AbstractPowerModel},
+)
     PM_branch = Dict{String, Any}(
         "br_r" => PSY.get_r(branch),
         "rate_a" => PSY.get_rate(branch),
@@ -116,7 +120,12 @@ function get_branch_to_pm(
     return PM_branch
 end
 
-function get_branch_to_pm(ix::Int, branch::PSY.Transformer2W, ::Type{StaticBranchUnbounded})
+function get_branch_to_pm(
+    ix::Int,
+    branch::PSY.Transformer2W,
+    ::Type{StaticBranchUnbounded},
+    ::Type{<:PM.AbstractPowerModel},
+)
     PM_branch = Dict{String, Any}(
         "br_r" => PSY.get_r(branch),
         "shift" => 0.0,
@@ -140,8 +149,9 @@ end
 function get_branch_to_pm(
     ix::Int,
     branch::PSY.TapTransformer,
-    ::Type{D},
-) where {D <: AbstractBranchFormulation}
+    ::Type{<:AbstractBranchFormulation},
+    ::Type{<:PM.AbstractPowerModel},
+)
     PM_branch = Dict{String, Any}(
         "br_r" => PSY.get_r(branch),
         "rate_a" => PSY.get_rate(branch),
@@ -169,6 +179,7 @@ function get_branch_to_pm(
     ix::Int,
     branch::PSY.TapTransformer,
     ::Type{StaticBranchUnbounded},
+    ::Type{<:PM.AbstractPowerModel},
 )
     PM_branch = Dict{String, Any}(
         "br_r" => PSY.get_r(branch),
@@ -193,8 +204,9 @@ end
 function get_branch_to_pm(
     ix::Int,
     branch::PSY.ACBranch,
-    ::Type{D},
-) where {D <: AbstractBranchFormulation}
+    ::Type{<:AbstractBranchFormulation},
+    ::Type{<:PM.AbstractPowerModel},
+)
     PM_branch = Dict{String, Any}(
         "br_r" => PSY.get_r(branch),
         "rate_a" => PSY.get_rate(branch),
@@ -218,7 +230,12 @@ function get_branch_to_pm(
     return PM_branch
 end
 
-function get_branch_to_pm(ix::Int, branch::PSY.ACBranch, ::Type{StaticBranchUnbounded})
+function get_branch_to_pm(
+    ix::Int,
+    branch::PSY.ACBranch,
+    ::Type{StaticBranchUnbounded},
+    ::Type{<:PM.AbstractPowerModel},
+)
     PM_branch = Dict{String, Any}(
         "br_r" => PSY.get_r(branch),
         "shift" => 0.0,
@@ -239,7 +256,12 @@ function get_branch_to_pm(ix::Int, branch::PSY.ACBranch, ::Type{StaticBranchUnbo
     return PM_branch
 end
 
-function get_branch_to_pm(ix::Int, branch::PSY.HVDCLine, ::Type{HVDCP2PDispatch})
+function get_branch_to_pm(
+    ix::Int,
+    branch::PSY.HVDCLine,
+    ::Type{HVDCP2PDispatch},
+    ::Type{<:PM.AbstractDCPModel},
+)
     PM_branch = Dict{String, Any}(
         "loss1" => PSY.get_loss(branch).l1,
         "mp_pmax" => PSY.get_reactive_power_limits_from(branch).max,
@@ -248,7 +270,7 @@ function get_branch_to_pm(ix::Int, branch::PSY.HVDCLine, ::Type{HVDCP2PDispatch}
         "pmaxt" => PSY.get_active_power_limits_to(branch).max,
         "pmaxf" => PSY.get_active_power_limits_from(branch).max,
         "startup" => 0.0,
-        "loss0" => PSY.get_loss(branch).l1,
+        "loss0" => PSY.get_loss(branch).l0,
         "pt" => 0.0,
         "vt" => PSY.get_magnitude(PSY.get_arc(branch).to),
         "qmaxf" => PSY.get_reactive_power_limits_from(branch).max,
@@ -275,8 +297,10 @@ end
 function get_branch_to_pm(
     ix::Int,
     branch::PSY.HVDCLine,
-    ::Type{D},
-) where {D <: AbstractBranchFormulation}
+    ::Type{HVDCP2PDispatch},
+    ::Type{<:PM.AbstractPowerModel},
+)
+    check_hvdc_line_limits_unidirectional(branch)
     PM_branch = Dict{String, Any}(
         "loss1" => PSY.get_loss(branch).l1,
         "mp_pmax" => PSY.get_reactive_power_limits_from(branch).max,
@@ -285,7 +309,45 @@ function get_branch_to_pm(
         "pmaxt" => PSY.get_active_power_limits_to(branch).max,
         "pmaxf" => PSY.get_active_power_limits_from(branch).max,
         "startup" => 0.0,
-        "loss0" => PSY.get_loss(branch).l1,
+        "loss0" => PSY.get_loss(branch).l0,
+        "pt" => 0.0,
+        "vt" => PSY.get_magnitude(PSY.get_arc(branch).to),
+        "qmaxf" => PSY.get_reactive_power_limits_from(branch).max,
+        "pmint" => PSY.get_active_power_limits_to(branch).min,
+        "f_bus" => PSY.get_number(PSY.get_arc(branch).from),
+        "mp_pmin" => PSY.get_reactive_power_limits_from(branch).min,
+        "br_status" => Float64(PSY.get_available(branch)),
+        "t_bus" => PSY.get_number(PSY.get_arc(branch).to),
+        "index" => ix,
+        "qmint" => PSY.get_reactive_power_limits_to(branch).min,
+        "qf" => 0.0,
+        "cost" => 0.0,
+        "pminf" => PSY.get_active_power_limits_from(branch).min,
+        "qt" => 0.0,
+        "qminf" => PSY.get_reactive_power_limits_from(branch).min,
+        "vf" => PSY.get_magnitude(PSY.get_arc(branch).from),
+        "qmaxt" => PSY.get_reactive_power_limits_to(branch).max,
+        "ncost" => 0,
+        "pf" => 0.0,
+    )
+    return PM_branch
+end
+
+function get_branch_to_pm(
+    ix::Int,
+    branch::PSY.HVDCLine,
+    ::Type{<:AbstractBranchFormulation},
+    ::Type{<:PM.AbstractPowerModel},
+)
+    PM_branch = Dict{String, Any}(
+        "loss1" => PSY.get_loss(branch).l1,
+        "mp_pmax" => PSY.get_reactive_power_limits_from(branch).max,
+        "model" => 2,
+        "shutdown" => 0.0,
+        "pmaxt" => PSY.get_active_power_limits_to(branch).max,
+        "pmaxf" => PSY.get_active_power_limits_from(branch).max,
+        "startup" => 0.0,
+        "loss0" => PSY.get_loss(branch).l0,
         "pt" => 0.0,
         "vt" => PSY.get_magnitude(PSY.get_arc(branch).to),
         "qmaxf" => PSY.get_reactive_power_limits_from(branch).max,
@@ -326,7 +388,7 @@ function get_branches_to_pm(
             enumerate(get_available_components(get_component_type(device_model), sys))
             ix = i + start_idx
             PM_branches["$(ix)"] =
-                get_branch_to_pm(ix, branch, get_formulation(device_model))
+                get_branch_to_pm(ix, branch, get_formulation(device_model), S)
             if PM_branches["$(ix)"]["br_status"] == true
                 f = PM_branches["$(ix)"]["f_bus"]
                 t = PM_branches["$(ix)"]["t_bus"]

--- a/src/operation/operation_problem_templates.jl
+++ b/src/operation/operation_problem_templates.jl
@@ -15,7 +15,7 @@ function _default_devices_uc()
         DeviceModel(PSY.Line, StaticBranch),
         DeviceModel(PSY.Transformer2W, StaticBranch),
         DeviceModel(PSY.TapTransformer, StaticBranch),
-        DeviceModel(PSY.HVDCLine, HVDCDispatch),
+        DeviceModel(PSY.HVDCLine, HVDCP2PDispatch),
     ]
 end
 

--- a/src/utils/generate_valid_formulations.jl
+++ b/src/utils/generate_valid_formulations.jl
@@ -64,8 +64,7 @@ function write_formulation_combinations(filename::AbstractString, sys=nothing)
     open(filename, "w") do io
         JSON3.pretty(io, serialize_formulation_combinations(sys))
     end
-
-    println("Wrote valid formulations to $filename")
+    @info(" to $filename")
 end
 
 function generate_device_formulation_combinations()

--- a/src/utils/powersystems_utils.jl
+++ b/src/utils/powersystems_utils.jl
@@ -15,3 +15,50 @@ end
 
 make_system_filename(sys::PSY.System) = "system-$(IS.get_uuid(sys)).json"
 make_system_filename(sys_uuid::Union{Base.UUID, AbstractString}) = "system-$(sys_uuid).json"
+
+function check_hvdc_line_limits_consistency(d::PSY.HVDCLine)
+    from_min = PSY.get_active_power_limits_from(d).min
+    to_min = PSY.get_active_power_limits_to(d).min
+    from_max = PSY.get_active_power_limits_from(d).max
+    to_max = PSY.get_active_power_limits_to(d).max
+
+    if from_max < from_min || to_max < to_min
+        throw(
+            IS.ConflictingInputsError(
+                "Limits in HVDC Line $(PSY.get_name(d)) are inconsistent",
+            ),
+        )
+    end
+
+    if from_max < to_min
+        throw(
+            IS.ConflictingInputsError(
+                "From Max $(from_max) can't be a smaller value than To Min $(to_min)",
+            ),
+        )
+    elseif to_max < from_min
+        throw(
+            IS.ConflictingInputsError(
+                "To Max $(to_max) can't be a smaller value than From Min $(from_min)",
+            ),
+        )
+    end
+    return
+end
+
+function check_hvdc_line_limits_unidirectional(d::PSY.HVDCLine)
+    from_min = PSY.get_active_power_limits_from(d).min
+    to_min = PSY.get_active_power_limits_to(d).min
+    from_max = PSY.get_active_power_limits_from(d).max
+    to_max = PSY.get_active_power_limits_to(d).max
+
+    if from_min < 0 || to_min < 0 || from_max < 0 || to_max < 0
+        throw(
+            IS.ConflictingInputsError(
+                "Changing flow direction on HVDC Line $(PSY.get_name(d)) is not compatible with non-linear network formulations. \
+                Bi-directional models with losses are only compatible with linear network models like DCPPowerModel.",
+            ),
+        )
+    end
+    return
+end

--- a/test/test_device_branch_constructors.jl
+++ b/test/test_device_branch_constructors.jl
@@ -440,7 +440,8 @@ end
         PSI.ConstraintKey(RateLimitConstraint, TapTransformer, "ub"),
         PSI.ConstraintKey(RateLimitConstraint, Transformer2W, "lb"),
         PSI.ConstraintKey(RateLimitConstraint, TapTransformer, "lb"),
-        PSI.ConstraintKey(FlowRateConstraint, HVDCLine),
+        PSI.ConstraintKey(FlowRateConstraint, HVDCLine, "ub"),
+        PSI.ConstraintKey(FlowRateConstraint, HVDCLine, "lb"),
     ]
 
     system = PSB.build_system(PSITestSystems, "c_sys14_dc")
@@ -460,11 +461,10 @@ end
     template = get_template_dispatch_with_network(
         NetworkModel(StandardPTDFModel; PTDF=PSY.PTDF(system)),
     )
-    set_device_model!(template, DeviceModel(HVDCLine, HVDCP2PDispatch))
+    set_device_model!(template, DeviceModel(HVDCLine, HVDCP2PLossless))
     model_m = DecisionModel(template, system; optimizer=HiGHS_optimizer)
     @test build!(model_m; output_dir=mktempdir(cleanup=true)) == PSI.BuildStatus.BUILT
 
-    @test check_variable_bounded(model_m, FlowActivePowerVariable, HVDCLine)
     @test !check_variable_bounded(model_m, FlowActivePowerVariable, TapTransformer)
     @test !check_variable_bounded(model_m, FlowActivePowerVariable, Transformer2W)
     @test check_variable_unbounded(model_m, FlowActivePowerVariable, Line)
@@ -496,14 +496,14 @@ end
     )
 end
 
-#=
 @testset "AC Power Flow Models for HVDCLine Flow Constraints and TapTransformer & Transformer2W Unbounded" begin
     ratelimit_constraint_keys = [
         PSI.ConstraintKey(RateLimitConstraintFromTo, Transformer2W),
         PSI.ConstraintKey(RateLimitConstraintToFrom, Transformer2W),
         PSI.ConstraintKey(RateLimitConstraintFromTo, TapTransformer),
         PSI.ConstraintKey(RateLimitConstraintToFrom, TapTransformer),
-        PSI.ConstraintKey(FlowRateConstraint, HVDCLine),
+        PSI.ConstraintKey(FlowRateConstraint, HVDCLine, "ub"),
+        PSI.ConstraintKey(FlowRateConstraint, HVDCLine, "lb"),
     ]
 
     system = PSB.build_system(PSITestSystems, "c_sys14_dc")
@@ -525,8 +525,6 @@ end
     model_m = DecisionModel(template, system; optimizer=ipopt_optimizer)
     @test build!(model_m; output_dir=mktempdir(cleanup=true)) == PSI.BuildStatus.BUILT
 
-    check_variable_bounded(model_m, FlowReactivePowerToFromVariable, HVDCLine)
-    check_variable_bounded(model_m, FlowActivePowerVariable, HVDCLine)
     @test check_variable_bounded(model_m, FlowActivePowerFromToVariable, TapTransformer)
     @test check_variable_unbounded(model_m, FlowReactivePowerFromToVariable, TapTransformer)
     @test check_variable_bounded(model_m, FlowActivePowerToFromVariable, Transformer2W)
@@ -561,4 +559,3 @@ end
         rate_limit2w,
     )
 end
-=#

--- a/test/test_device_branch_constructors.jl
+++ b/test/test_device_branch_constructors.jl
@@ -21,27 +21,6 @@
     end
 end
 
-@testset "DC Power Flow Models Monitored Line Flow Constraints and Static with Bounds" begin
-    system = PSB.build_system(PSITestSystems, "c_sys5_ml")
-    set_rate!(PSY.get_component(Line, system, "2"), 1.5)
-    for model in [DCPPowerModel, StandardPTDFModel]
-        template = get_thermal_dispatch_template_network(
-            NetworkModel(model; PTDF=PSY.PTDF(system)),
-        )
-        set_device_model!(template, DeviceModel(Line, StaticBranch))
-        set_device_model!(template, DeviceModel(MonitoredLine, StaticBranchUnbounded))
-        model_m = DecisionModel(template, system; optimizer=HiGHS_optimizer)
-        @test build!(model_m; output_dir=mktempdir(cleanup=true)) == PSI.BuildStatus.BUILT
-
-        @test check_variable_unbounded(model_m, FlowActivePowerVariable, MonitoredLine)
-        # Broken
-        # @test check_variable_bounded(model_m, FlowActivePowerVariable, Line)
-
-        @test solve!(model_m) == RunStatus.SUCCESSFUL
-        @test check_flow_variable_values(model_m, FlowActivePowerVariable, Line, "2", 1.5)
-    end
-end
-
 @testset "AC Power Flow Monitored Line Flow Constraints" begin
     system = PSB.build_system(PSITestSystems, "c_sys5_ml")
     limits = PSY.get_flow_limits(PSY.get_component(MonitoredLine, system, "1"))
@@ -62,6 +41,44 @@ end
         0.0,
         limits.from_to,
     )
+end
+
+@testset "DC Power Flow Models Monitored Line Flow Constraints and Static with inequalities" begin
+    system = PSB.build_system(PSITestSystems, "c_sys5_ml")
+    set_rate!(PSY.get_component(Line, system, "2"), 1.5)
+    for model in [DCPPowerModel, StandardPTDFModel]
+        template = get_thermal_dispatch_template_network(
+            NetworkModel(model; PTDF=PSY.PTDF(system)),
+        )
+        set_device_model!(template, DeviceModel(Line, StaticBranch))
+        set_device_model!(template, DeviceModel(MonitoredLine, StaticBranchUnbounded))
+        model_m = DecisionModel(template, system; optimizer=HiGHS_optimizer)
+        @test build!(model_m; output_dir=mktempdir(cleanup=true)) == PSI.BuildStatus.BUILT
+
+        @test check_variable_unbounded(model_m, FlowActivePowerVariable, MonitoredLine)
+
+        @test solve!(model_m) == RunStatus.SUCCESSFUL
+        @test check_flow_variable_values(model_m, FlowActivePowerVariable, Line, "2", 1.5)
+    end
+end
+@testset "DC Power Flow Models Monitored Line Flow Constraints and Static with Bounds" begin
+    system = PSB.build_system(PSITestSystems, "c_sys5_ml")
+    set_rate!(PSY.get_component(Line, system, "2"), 1.5)
+    for model in [DCPPowerModel, StandardPTDFModel]
+        template = get_thermal_dispatch_template_network(
+            NetworkModel(model; PTDF=PSY.PTDF(system)),
+        )
+        set_device_model!(template, DeviceModel(Line, StaticBranchBounds))
+        set_device_model!(template, DeviceModel(MonitoredLine, StaticBranchUnbounded))
+        model_m = DecisionModel(template, system; optimizer=HiGHS_optimizer)
+        @test build!(model_m; output_dir=mktempdir(cleanup=true)) == PSI.BuildStatus.BUILT
+
+        @test check_variable_unbounded(model_m, FlowActivePowerVariable, MonitoredLine)
+        @test check_variable_bounded(model_m, FlowActivePowerVariable, Line)
+
+        @test solve!(model_m) == RunStatus.SUCCESSFUL
+        @test check_flow_variable_values(model_m, FlowActivePowerVariable, Line, "2", 1.5)
+    end
 end
 
 @testset "DC Power Flow Models for HVDCLine with with Line Flow Constraints, TapTransformer & Transformer2W Unbounded" begin
@@ -85,16 +102,13 @@ end
     transformer = PSY.get_component(Transformer2W, system, "Trans4")
     rate_limit2w = PSY.get_rate(tap_transformer)
 
-    for model in [DCPPowerModel, StandardPTDFModel],
-        hvdc_model in [HVDCDispatch, HVDCLossless]
-
+    for model in [DCPPowerModel, StandardPTDFModel]
         template =
             get_template_dispatch_with_network(NetworkModel(model; PTDF=PSY.PTDF(system)))
-        set_device_model!(template, HVDCLine, hvdc_model)
+        set_device_model!(template, HVDCLine, HVDCP2PLossless)
         model_m = DecisionModel(template, system; optimizer=ipopt_optimizer)
         @test build!(model_m; output_dir=mktempdir(cleanup=true)) == PSI.BuildStatus.BUILT
 
-        @test check_variable_bounded(model_m, FlowActivePowerVariable, HVDCLine)
         @test check_variable_unbounded(model_m, FlowActivePowerVariable, TapTransformer)
         @test check_variable_unbounded(model_m, FlowActivePowerVariable, Transformer2W)
 
@@ -146,17 +160,15 @@ end
     for model in [DCPPowerModel, StandardPTDFModel]
         template =
             get_template_dispatch_with_network(NetworkModel(model; PTDF=PSY.PTDF(system)))
-        set_device_model!(template, DeviceModel(HVDCLine, HVDCUnbounded))
+        set_device_model!(template, DeviceModel(HVDCLine, HVDCP2PUnbounded))
         set_device_model!(template, DeviceModel(TapTransformer, StaticBranchBounds))
         set_device_model!(template, DeviceModel(Transformer2W, StaticBranchBounds))
         model_m = DecisionModel(template, system; optimizer=ipopt_optimizer)
         @test build!(model_m; output_dir=mktempdir(cleanup=true)) == PSI.BuildStatus.BUILT
 
-        if model == DCPPowerModel
-            @test check_variable_unbounded(model_m, FlowActivePowerVariable, HVDCLine)
-            @test check_variable_bounded(model_m, FlowActivePowerVariable, TapTransformer)
-            @test check_variable_bounded(model_m, FlowActivePowerVariable, TapTransformer)
-        end
+        @test check_variable_unbounded(model_m, FlowActivePowerVariable, HVDCLine)
+        @test check_variable_bounded(model_m, FlowActivePowerVariable, TapTransformer)
+        @test check_variable_bounded(model_m, FlowActivePowerVariable, TapTransformer)
 
         @test solve!(model_m) == RunStatus.SUCCESSFUL
 
@@ -187,15 +199,311 @@ end
     end
 end
 
+@testset "HVDCP2PLossless values check between network models" begin
+    # Test to compare lossless models with lossless formulation
+    sys_5 = build_system(PSITestSystems, "c_sys5_uc")
+
+    line = get_component(Line, sys_5, "1")
+    remove_component!(sys_5, line)
+
+    hvdc = HVDCLine(
+        name=get_name(line),
+        available=true,
+        active_power_flow=0.0,
+        # Force the flow in the opposite direction for testing purposes
+        active_power_limits_from=(min=-0.5, max=-0.5),
+        active_power_limits_to=(min=-3.0, max=2.0),
+        reactive_power_limits_from=(min=-1.0, max=1.0),
+        reactive_power_limits_to=(min=-1.0, max=1.0),
+        arc=get_arc(line),
+        loss=(l0=0.00, l1=0.00),
+    )
+
+    add_component!(sys_5, hvdc)
+
+    template_uc = ProblemTemplate(NetworkModel(StandardPTDFModel, PTDF=PTDF(sys_5)))
+
+    set_device_model!(template_uc, ThermalStandard, ThermalCompactUnitCommitment)
+    set_device_model!(template_uc, RenewableDispatch, FixedOutput)
+    set_device_model!(template_uc, PowerLoad, StaticPowerLoad)
+    set_device_model!(template_uc, DeviceModel(Line, StaticBranch))
+    set_device_model!(template_uc, DeviceModel(HVDCLine, HVDCP2PLossless))
+
+    model = DecisionModel(
+        template_uc,
+        sys_5;
+        name="UC",
+        optimizer=HiGHS_optimizer,
+        system_to_file=false,
+    )
+
+    solve!(model; output_dir=mktempdir())
+    ptdf_vars = get_variable_values(ProblemResults(model))
+    ptdf_values =
+        ptdf_vars[PowerSimulations.VariableKey{FlowActivePowerVariable, HVDCLine}("")]
+    ptdf_objective = model.internal.container.optimizer_stats.objective_value
+
+    set_network_model!(template_uc, NetworkModel(DCPPowerModel))
+
+    model = DecisionModel(
+        template_uc,
+        sys_5;
+        name="UC",
+        optimizer=HiGHS_optimizer,
+        system_to_file=false,
+    )
+
+    solve!(model; output_dir=mktempdir())
+    dcp_vars = get_variable_values(ProblemResults(model))
+    dcp_values =
+        dcp_vars[PowerSimulations.VariableKey{FlowActivePowerVariable, HVDCLine}("")]
+    dcp_objective = model.internal.container.optimizer_stats.objective_value
+
+    @test isapprox(dcp_objective, ptdf_objective; atol=0.1)
+    @test all(isapprox.(ptdf_values[!, "1"], dcp_values[!, "1"]; atol=0.1))
+end
+
+@testset "HVDCDispatch Model Tests" begin
+    # Test to compare lossless models with lossless formulation
+    sys_5 = build_system(PSITestSystems, "c_sys5_uc")
+
+    line = get_component(Line, sys_5, "1")
+    remove_component!(sys_5, line)
+
+    hvdc = HVDCLine(
+        name=get_name(line),
+        available=true,
+        active_power_flow=0.0,
+        # Force the flow in the opposite direction for testing purposes
+        active_power_limits_from=(min=-2.0, max=-2.0),
+        active_power_limits_to=(min=-3.0, max=2.0),
+        reactive_power_limits_from=(min=-1.0, max=1.0),
+        reactive_power_limits_to=(min=-1.0, max=1.0),
+        arc=get_arc(line),
+        loss=(l0=0.00, l1=0.00),
+    )
+
+    add_component!(sys_5, hvdc)
+    for net_model in [DCPPowerModel, StandardPTDFModel]
+        @testset "$net_model" begin
+            PSY.set_loss!(hvdc, (l0=0.0, l1=0.0))
+            template_uc =
+                ProblemTemplate(NetworkModel(net_model, PTDF=PTDF(sys_5), use_slacks=true))
+
+            set_device_model!(template_uc, ThermalStandard, ThermalStandardUnitCommitment)
+            set_device_model!(template_uc, RenewableDispatch, FixedOutput)
+            set_device_model!(template_uc, PowerLoad, StaticPowerLoad)
+            set_device_model!(template_uc, DeviceModel(Line, StaticBranchUnbounded))
+            set_device_model!(template_uc, DeviceModel(HVDCLine, HVDCP2PLossless))
+
+            model_ref = DecisionModel(
+                template_uc,
+                sys_5;
+                name="UC",
+                optimizer=HiGHS_optimizer,
+                system_to_file=false,
+            )
+
+            solve!(model_ref; output_dir=mktempdir())
+            ref_vars = get_variable_values(ProblemResults(model_ref))
+            ref_values =
+                ref_vars[PowerSimulations.VariableKey{FlowActivePowerVariable, Line}("")]
+            hvdc_ref_values =
+                ref_vars[PowerSimulations.VariableKey{FlowActivePowerVariable, HVDCLine}(
+                    "",
+                )]
+            ref_objective = model_ref.internal.container.optimizer_stats.objective_value
+            ref_total_gen = sum(
+                sum.(
+                    eachrow(
+                        ref_vars[PowerSimulations.VariableKey{
+                            ActivePowerVariable,
+                            ThermalStandard,
+                        }(
+                            "",
+                        )],
+                    )
+                ),
+            )
+            set_device_model!(template_uc, DeviceModel(HVDCLine, HVDCP2PDispatch))
+
+            model = DecisionModel(
+                template_uc,
+                sys_5;
+                name="UC",
+                optimizer=HiGHS_optimizer,
+                system_to_file=false,
+            )
+
+            solve!(model; output_dir=mktempdir())
+            no_loss_vars = get_variable_values(ProblemResults(model))
+            no_loss_values =
+                no_loss_vars[PowerSimulations.VariableKey{FlowActivePowerVariable, Line}(
+                    "",
+                )]
+            hvdc_ft_no_loss_values = no_loss_vars[PowerSimulations.VariableKey{
+                FlowActivePowerFromToVariable,
+                HVDCLine,
+            }(
+                "",
+            )]
+            hvdc_tf_no_loss_values = no_loss_vars[PowerSimulations.VariableKey{
+                FlowActivePowerToFromVariable,
+                HVDCLine,
+            }(
+                "",
+            )]
+            no_loss_objective = model.internal.container.optimizer_stats.objective_value
+            no_loss_total_gen = sum(
+                sum.(
+                    eachrow(
+                        no_loss_vars[PowerSimulations.VariableKey{
+                            ActivePowerVariable,
+                            ThermalStandard,
+                        }(
+                            "",
+                        )],
+                    )
+                ),
+            )
+
+            @test isapprox(no_loss_objective, ref_objective; atol=0.1)
+
+            for col in names(ref_values)
+                @test all(isapprox.(ref_values[!, col], no_loss_values[!, col]; atol=0.1))
+            end
+
+            @test all(
+                isapprox.(
+                    hvdc_ft_no_loss_values[!, "1"],
+                    hvdc_tf_no_loss_values[!, "1"];
+                    atol=1e-3,
+                ),
+            )
+
+            @test isapprox(no_loss_total_gen, ref_total_gen; atol=0.1)
+
+            PSY.set_loss!(hvdc, (l0=0.1, l1=0.005))
+
+            model_wl = DecisionModel(
+                template_uc,
+                sys_5;
+                name="UC",
+                optimizer=HiGHS_optimizer,
+                system_to_file=false,
+            )
+
+            solve!(model_wl; output_dir=mktempdir())
+            dispatch_vars = get_variable_values(ProblemResults(model_wl))
+            #dispatch_values = dispatch_vars[PowerSimulations.VariableKey{HVDCLosses, HVDCLine}("")]
+            # dispatch_values = dispatch_vars[PowerSimulations.VariableKey{FlowActivePowerVariable, Line}("")]
+            dispatch_values_ft = dispatch_vars[PowerSimulations.VariableKey{
+                FlowActivePowerFromToVariable,
+                HVDCLine,
+            }(
+                "",
+            )]
+            dispatch_values_tf = dispatch_vars[PowerSimulations.VariableKey{
+                FlowActivePowerToFromVariable,
+                HVDCLine,
+            }(
+                "",
+            )]
+            wl_total_gen = sum(
+                sum.(
+                    eachrow(
+                        dispatch_vars[PowerSimulations.VariableKey{
+                            ActivePowerVariable,
+                            ThermalStandard,
+                        }(
+                            "",
+                        )],
+                    )
+                ),
+            )
+            dispatch_objective = model_wl.internal.container.optimizer_stats.objective_value
+
+            @test wl_total_gen > no_loss_total_gen
+
+            for col in names(dispatch_values_tf)
+                @test all(dispatch_values_tf[!, col] .<= dispatch_values_ft[!, col])
+            end
+        end
+    end
+end
+
+@testset "DC Power Flow Models for HVDCLine Dispatch and TapTransformer & Transformer2W Unbounded" begin
+    ratelimit_constraint_keys = [
+        PSI.ConstraintKey(RateLimitConstraint, Transformer2W, "ub"),
+        PSI.ConstraintKey(RateLimitConstraint, Line, "ub"),
+        PSI.ConstraintKey(RateLimitConstraint, Line, "lb"),
+        PSI.ConstraintKey(RateLimitConstraint, TapTransformer, "ub"),
+        PSI.ConstraintKey(RateLimitConstraint, Transformer2W, "lb"),
+        PSI.ConstraintKey(RateLimitConstraint, TapTransformer, "lb"),
+        PSI.ConstraintKey(FlowRateConstraint, HVDCLine),
+    ]
+
+    system = PSB.build_system(PSITestSystems, "c_sys14_dc")
+
+    hvdc_line = PSY.get_component(HVDCLine, system, "DCLine3")
+    limits_from = PSY.get_active_power_limits_from(hvdc_line)
+    limits_to = PSY.get_active_power_limits_to(hvdc_line)
+    limits_min = min(limits_from.min, limits_to.min)
+    limits_max = min(limits_from.max, limits_to.max)
+
+    tap_transformer = PSY.get_component(TapTransformer, system, "Trans3")
+    rate_limit = PSY.get_rate(tap_transformer)
+
+    transformer = PSY.get_component(Transformer2W, system, "Trans4")
+    rate_limit2w = PSY.get_rate(tap_transformer)
+
+    template = get_template_dispatch_with_network(
+        NetworkModel(StandardPTDFModel; PTDF=PSY.PTDF(system)),
+    )
+    set_device_model!(template, DeviceModel(HVDCLine, HVDCP2PDispatch))
+    model_m = DecisionModel(template, system; optimizer=HiGHS_optimizer)
+    @test build!(model_m; output_dir=mktempdir(cleanup=true)) == PSI.BuildStatus.BUILT
+
+    @test check_variable_bounded(model_m, FlowActivePowerVariable, HVDCLine)
+    @test !check_variable_bounded(model_m, FlowActivePowerVariable, TapTransformer)
+    @test !check_variable_bounded(model_m, FlowActivePowerVariable, Transformer2W)
+    @test check_variable_unbounded(model_m, FlowActivePowerVariable, Line)
+
+    psi_constraint_test(model_m, ratelimit_constraint_keys)
+
+    @test solve!(model_m) == RunStatus.SUCCESSFUL
+
+    @test check_flow_variable_values(
+        model_m,
+        FlowActivePowerVariable,
+        HVDCLine,
+        "DCLine3",
+        limits_max,
+    )
+    @test check_flow_variable_values(
+        model_m,
+        FlowActivePowerVariable,
+        TapTransformer,
+        "Trans3",
+        rate_limit,
+    )
+    @test check_flow_variable_values(
+        model_m,
+        FlowActivePowerVariable,
+        Transformer2W,
+        "Trans4",
+        rate_limit2w,
+    )
+end
+
+#=
 @testset "AC Power Flow Models for HVDCLine Flow Constraints and TapTransformer & Transformer2W Unbounded" begin
     ratelimit_constraint_keys = [
         PSI.ConstraintKey(RateLimitConstraintFromTo, Transformer2W),
         PSI.ConstraintKey(RateLimitConstraintToFrom, Transformer2W),
         PSI.ConstraintKey(RateLimitConstraintFromTo, TapTransformer),
         PSI.ConstraintKey(RateLimitConstraintToFrom, TapTransformer),
-        PSI.ConstraintKey(FlowRateConstraintFromTo, HVDCLine),
-        PSI.ConstraintKey(FlowRateConstraintToFrom, HVDCLine),
-        PSI.ConstraintKey(HVDCPowerBalance, HVDCLine),
+        PSI.ConstraintKey(FlowRateConstraint, HVDCLine),
     ]
 
     system = PSB.build_system(PSITestSystems, "c_sys14_dc")
@@ -213,7 +521,7 @@ end
     rate_limit2w = PSY.get_rate(tap_transformer)
 
     template = get_template_dispatch_with_network(ACPPowerModel)
-    set_device_model!(template, DeviceModel(HVDCLine, HVDCDispatch))
+    set_device_model!(template, DeviceModel(HVDCLine, HVDCP2PLossless))
     model_m = DecisionModel(template, system; optimizer=ipopt_optimizer)
     @test build!(model_m; output_dir=mktempdir(cleanup=true)) == PSI.BuildStatus.BUILT
 
@@ -253,67 +561,4 @@ end
         rate_limit2w,
     )
 end
-
-@testset "DC Power Flow Models for HVDCLine Dispatch and TapTransformer & Transformer2W Unbounded" begin
-    ratelimit_constraint_keys = [
-        PSI.ConstraintKey(RateLimitConstraint, Transformer2W, "ub"),
-        PSI.ConstraintKey(RateLimitConstraint, Line, "ub"),
-        PSI.ConstraintKey(RateLimitConstraint, Line, "lb"),
-        PSI.ConstraintKey(RateLimitConstraint, TapTransformer, "ub"),
-        PSI.ConstraintKey(RateLimitConstraint, Transformer2W, "lb"),
-        PSI.ConstraintKey(RateLimitConstraint, TapTransformer, "lb"),
-        PSI.ConstraintKey(FlowRateConstraint, HVDCLine),
-    ]
-
-    system = PSB.build_system(PSITestSystems, "c_sys14_dc")
-
-    hvdc_line = PSY.get_component(HVDCLine, system, "DCLine3")
-    limits_from = PSY.get_active_power_limits_from(hvdc_line)
-    limits_to = PSY.get_active_power_limits_to(hvdc_line)
-    limits_min = min(limits_from.min, limits_to.min)
-    limits_max = min(limits_from.max, limits_to.max)
-
-    tap_transformer = PSY.get_component(TapTransformer, system, "Trans3")
-    rate_limit = PSY.get_rate(tap_transformer)
-
-    transformer = PSY.get_component(Transformer2W, system, "Trans4")
-    rate_limit2w = PSY.get_rate(tap_transformer)
-
-    template = get_template_dispatch_with_network(
-        NetworkModel(StandardPTDFModel; PTDF=PSY.PTDF(system)),
-    )
-    set_device_model!(template, DeviceModel(HVDCLine, HVDCDispatch))
-    model_m = DecisionModel(template, system; optimizer=ipopt_optimizer)
-    @test build!(model_m; output_dir=mktempdir(cleanup=true)) == PSI.BuildStatus.BUILT
-
-    @test check_variable_bounded(model_m, FlowActivePowerVariable, HVDCLine)
-    @test !check_variable_bounded(model_m, FlowActivePowerVariable, TapTransformer)
-    @test !check_variable_bounded(model_m, FlowActivePowerVariable, Transformer2W)
-    @test check_variable_unbounded(model_m, FlowActivePowerVariable, Line)
-
-    psi_constraint_test(model_m, ratelimit_constraint_keys)
-
-    @test solve!(model_m) == RunStatus.SUCCESSFUL
-
-    @test check_flow_variable_values(
-        model_m,
-        FlowActivePowerVariable,
-        HVDCLine,
-        "DCLine3",
-        limits_max,
-    )
-    @test check_flow_variable_values(
-        model_m,
-        FlowActivePowerVariable,
-        TapTransformer,
-        "Trans3",
-        rate_limit,
-    )
-    @test check_flow_variable_values(
-        model_m,
-        FlowActivePowerVariable,
-        Transformer2W,
-        "Trans4",
-        rate_limit2w,
-    )
-end
+=#

--- a/test/test_network_constructors.jl
+++ b/test/test_network_constructors.jl
@@ -104,7 +104,7 @@ end
     test_results = IdDict{System, Vector{Int}}(
         c_sys5 => [264, 0, 264, 264, 168],
         c_sys14 => [600, 0, 600, 600, 504],
-        c_sys14_dc => [600, 48, 552, 552, 456],
+        c_sys14_dc => [600, 0, 648, 552, 456],
     )
     test_obj_values = IdDict{System, Float64}(
         c_sys5 => 340000.0,
@@ -161,7 +161,7 @@ end
     test_results = IdDict{System, Vector{Int}}(
         c_sys5 => [264, 0, 264, 264, 168],
         c_sys14 => [600, 0, 600, 600, 504],
-        c_sys14_dc => [600, 48, 552, 552, 456],
+        c_sys14_dc => [600, 0, 648, 552, 456],
     )
     test_obj_values = IdDict{System, Float64}(
         c_sys5 => 340000.0,
@@ -207,12 +207,12 @@ end
     test_results = IdDict{System, Vector{Int}}(
         c_sys5 => [384, 0, 408, 408, 288],
         c_sys14 => [936, 0, 1080, 1080, 840],
-        c_sys14_dc => [984, 96, 984, 984, 840],
+        c_sys14_dc => [984, 0, 1080, 984, 840],
     )
     test_obj_values = IdDict{System, Float64}(
         c_sys5 => 342000.0,
         c_sys14 => 142000.0,
-        c_sys14_dc => 142000.0,
+        c_sys14_dc => 143000.0,
     )
     for (ix, sys) in enumerate(systems)
         ps_model = DecisionModel(template, sys; optimizer=ipopt_optimizer)
@@ -254,7 +254,7 @@ end
     test_results = IdDict{System, Vector{Int}}(
         c_sys5 => [1056, 0, 384, 384, 264],
         c_sys14 => [2832, 0, 720, 720, 696],
-        c_sys14_dc => [2832, 96, 672, 672, 744],
+        c_sys14_dc => [2832, 0, 768, 672, 744],
     )
     test_obj_values = IdDict{System, Float64}(
         c_sys5 => 340000.0,
@@ -284,7 +284,6 @@ end
     end
 end
 
-# TODO: Add constraint tests for these models, other is redundant with first test
 @testset "Network Solve AC-PF PowerModels NFAPowerModel" begin
     template = get_thermal_dispatch_template_network(NFAPowerModel)
     c_sys5 = PSB.build_system(PSITestSystems, "c_sys5")
@@ -296,7 +295,7 @@ end
     test_results = Dict{System, Vector{Int}}(
         c_sys5 => [264, 0, 264, 264, 120],
         c_sys14 => [600, 0, 600, 600, 336],
-        c_sys14_dc => [648, 96, 552, 552, 384],
+        c_sys14_dc => [648, 0, 648, 552, 384],
     )
     test_obj_values = IdDict{System, Float64}(
         c_sys5 => 300000.0,
@@ -326,7 +325,6 @@ end
     end
 end
 
-# TODO: Add constraint tests for these models, other is redundant with first test
 @testset "Other Network AC PowerModels models" begin
     networks = [#ACPPowerModel, Already tested
         ACRPowerModel,
@@ -344,12 +342,12 @@ end
     ACR_test_results = Dict{System, Vector{Int}}(
         c_sys5 => [1056, 0, 240, 240, 264],
         c_sys14 => [2832, 0, 240, 240, 696],
-        c_sys14_dc => [2832, 96, 240, 240, 744],
+        c_sys14_dc => [2832, 0, 336, 240, 744],
     )
     ACT_test_results = Dict{System, Vector{Int}}(
         c_sys5 => [1344, 0, 384, 384, 840],
         c_sys14 => [3792, 0, 720, 720, 2616],
-        c_sys14_dc => [3696, 96, 672, 672, 2472],
+        c_sys14_dc => [3696, 0, 768, 672, 2472],
     )
     test_results = Dict(zip(networks, [ACR_test_results, ACT_test_results]))
     for network in networks, sys in systems
@@ -387,12 +385,12 @@ end
     DCPLL_test_results = Dict{System, Vector{Int}}(
         c_sys5 => [528, 0, 408, 408, 288],
         c_sys14 => [1416, 0, 1080, 1080, 840],
-        c_sys14_dc => [1416, 96, 984, 984, 840],
+        c_sys14_dc => [1416, 0, 1080, 984, 840],
     )
     LPACC_test_results = Dict{System, Vector{Int}}(
         c_sys5 => [1200, 0, 384, 384, 840],
         c_sys14 => [3312, 0, 720, 720, 2616],
-        c_sys14_dc => [3264, 96, 672, 672, 2472],
+        c_sys14_dc => [3264, 0, 768, 672, 2472],
     )
     test_results = Dict(zip(networks, [DCPLL_test_results, LPACC_test_results]))
     for network in networks, (ix, sys) in enumerate(systems)

--- a/test/test_utils/model_checks.jl
+++ b/test/test_utils/model_checks.jl
@@ -155,6 +155,7 @@ function check_flow_variable_values(
     variable = PSI.get_variable(psi_cont, T(), U)
     for var in variable[device_name, :]
         if !(PSI.jump_value(var) <= (limit + 1e-2))
+            @error "$device_name out of bounds $(PSI.jump_value(var))"
             return false
         end
     end

--- a/test/test_utils/model_checks.jl
+++ b/test/test_utils/model_checks.jl
@@ -28,7 +28,12 @@ function psi_constraint_test(
 )
     constraints = PSI.get_constraints(model)
     for con in constraint_keys
-        @test get(constraints, con, nothing) !== nothing
+        if get(constraints, con, nothing) !== nothing
+            @test true
+        else
+            @error con
+            @test false
+        end
     end
     return
 end

--- a/test/test_utils/operations_problem_templates.jl
+++ b/test/test_utils/operations_problem_templates.jl
@@ -13,7 +13,7 @@ function get_thermal_dispatch_template_network(network=CopperPlatePowerModel)
     set_device_model!(template, Line, StaticBranch)
     set_device_model!(template, Transformer2W, StaticBranch)
     set_device_model!(template, TapTransformer, StaticBranch)
-    set_device_model!(template, HVDCLine, HVDCLossless)
+    set_device_model!(template, HVDCLine, HVDCP2PLossless)
     return template
 end
 
@@ -70,6 +70,6 @@ function get_template_dispatch_with_network(network=StandardPTDFModel)
     set_device_model!(template, Line, StaticBranch)
     set_device_model!(template, Transformer2W, StaticBranch)
     set_device_model!(template, TapTransformer, StaticBranch)
-    set_device_model!(template, HVDCLine, HVDCLossless)
+    set_device_model!(template, HVDCLine, HVDCP2PLossless)
     return template
 end


### PR DESCRIPTION
closes #894 

This PR adds a formulation compatible with StandardPTDF and DCPPowerFlow for the phase control in phase shifters. Note that there is no need to implement PDF matrices here.  