### PR TITLE
fix p2p hvdc

### DIFF
--- a/docs/src/formulation_library/Branch.md
+++ b/docs/src/formulation_library/Branch.md
@@ -44,24 +44,24 @@ StaticBranchUnbounded
 
 ---
 
-## `HVDCLossless`
+## `HVDCP2PLossless`
 
 ```@docs
-HVDCLossless
+HVDCP2PLossless
 ```
 
 ---
 
-## `HVDCDispatch`
+## `HVDCP2PDispatch`
 
 ```@docs
-HVDCDispatch
+HVDCP2PDispatch
 ```
 
 ---
 
-## `HVDCUnbounded`
+## `HVDCP2PUnbounded`
 
 ```@docs
-HVDCUnbounded
+HVDCP2PUnbounded
 ```

--- a/src/PowerSimulations.jl
+++ b/src/PowerSimulations.jl
@@ -39,9 +39,9 @@ export GroupReserve
 export StaticBranch
 export StaticBranchBounds
 export StaticBranchUnbounded
-export HVDCLossless
-export HVDCDispatch
-export HVDCUnbounded
+export HVDCP2PLossless
+export HVDCP2PDispatch
+export HVDCP2PUnbounded
 # export VoltageSourceDC
 ######## Load Models ########
 export StaticPowerLoad

--- a/src/PowerSimulations.jl
+++ b/src/PowerSimulations.jl
@@ -295,7 +295,7 @@ export FlowReactivePowerFromToConstraint
 export FlowReactivePowerToFromConstraint
 export FrequencyResponseConstraint
 export HVDCPowerBalance
-export HVDCTotalPowerDeliveredVariable
+export HVDCLosses
 export InflowRangeConstraint
 export InputActivePowerVariableLimitsConstraint
 export InputPowerRangeConstraint

--- a/src/core/constraints.jl
+++ b/src/core/constraints.jl
@@ -92,6 +92,7 @@ struct StartTypeConstraint <: ConstraintType end
 struct StartupInitialConditionConstraint <: ConstraintType end
 struct StartupTimeLimitTemperatureConstraint <: ConstraintType end
 struct PhaseAngleControlLimit <: ConstraintType end
+struct HVDCLossesAbsoluteValue <: ConstraintType end
 
 abstract type PowerVariableLimitsConstraint <: ConstraintType end
 struct EnergyVariableLimitUpConstraint <: ConstraintType end

--- a/src/core/constraints.jl
+++ b/src/core/constraints.jl
@@ -93,6 +93,7 @@ struct StartupInitialConditionConstraint <: ConstraintType end
 struct StartupTimeLimitTemperatureConstraint <: ConstraintType end
 struct PhaseAngleControlLimit <: ConstraintType end
 struct HVDCLossesAbsoluteValue <: ConstraintType end
+struct HVDCDirection <: ConstraintType end
 
 abstract type PowerVariableLimitsConstraint <: ConstraintType end
 struct EnergyVariableLimitUpConstraint <: ConstraintType end

--- a/src/core/formulations.jl
+++ b/src/core/formulations.jl
@@ -192,15 +192,15 @@ abstract type AbstractDCLineFormulation <: AbstractBranchFormulation end
 """
 Branch type to avoid flow constraints
 """
-struct HVDCUnbounded <: AbstractDCLineFormulation end
+struct HVDCP2PUnbounded <: AbstractDCLineFormulation end
 """
 Branch type to represent lossless power flow on DC lines
 """
-struct HVDCLossless <: AbstractDCLineFormulation end
+struct HVDCP2PLossless <: AbstractDCLineFormulation end
 """
 Branch type to represent lossy power flow on DC lines
 """
-struct HVDCDispatch <: AbstractDCLineFormulation end
+struct HVDCP2PDispatch <: AbstractDCLineFormulation end
 # Not Implemented
 # struct VoltageSourceDC <: AbstractDCLineFormulation end
 

--- a/src/core/optimization_container.jl
+++ b/src/core/optimization_container.jl
@@ -1175,7 +1175,11 @@ end
 function get_expression(container::OptimizationContainer, key::ExpressionKey)
     var = get(container.expressions, key, nothing)
     if var === nothing
-        throw(IS.InvalidValue("constraint $key is not stored"))
+        throw(
+            IS.InvalidValue(
+                "constraint $key is not stored. $(collect(keys(container.expressions)))",
+            ),
+        )
     end
 
     return var

--- a/src/core/variables.jl
+++ b/src/core/variables.jl
@@ -215,7 +215,7 @@ struct ComponentActivePowerReserveUpVariable <: SubComponentVariableType end
 
 struct ComponentActivePowerReserveDownVariable <: SubComponentVariableType end
 
-# Necessary as a work around for HVDC models with losses
+# Necessary as a work around for HVDCP2P models with losses
 struct HVDCTotalPowerDeliveredVariable <: VariableType end
 
 struct PieceWiseLinearCostVariable <: VariableType end

--- a/src/core/variables.jl
+++ b/src/core/variables.jl
@@ -216,7 +216,7 @@ struct ComponentActivePowerReserveUpVariable <: SubComponentVariableType end
 struct ComponentActivePowerReserveDownVariable <: SubComponentVariableType end
 
 # Necessary as a work around for HVDCP2P models with losses
-struct HVDCTotalPowerDeliveredVariable <: VariableType end
+struct HVDCLosses <: VariableType end
 
 struct PieceWiseLinearCostVariable <: VariableType end
 
@@ -258,4 +258,4 @@ convert_result_to_natural_units(::Type{ComponentActivePowerVariable}) = true
 convert_result_to_natural_units(::Type{ComponentReactivePowerVariable}) = true
 convert_result_to_natural_units(::Type{ComponentActivePowerReserveUpVariable}) = true
 convert_result_to_natural_units(::Type{ComponentActivePowerReserveDownVariable}) = true
-convert_result_to_natural_units(::Type{HVDCTotalPowerDeliveredVariable}) = true
+convert_result_to_natural_units(::Type{HVDCLosses}) = true

--- a/src/core/variables.jl
+++ b/src/core/variables.jl
@@ -217,6 +217,7 @@ struct ComponentActivePowerReserveDownVariable <: SubComponentVariableType end
 
 # Necessary as a work around for HVDCP2P models with losses
 struct HVDCLosses <: VariableType end
+struct HVDCFlowDirectionVariable <: VariableType end
 
 struct PieceWiseLinearCostVariable <: VariableType end
 

--- a/src/devices_models/device_constructors/branch_constructor.jl
+++ b/src/devices_models/device_constructors/branch_constructor.jl
@@ -51,7 +51,7 @@ construct_device!(
     ::OptimizationContainer,
     ::PSY.System,
     ::ArgumentConstructStage,
-    ::DeviceModel{<:PSY.DCBranch, HVDCDispatch},
+    ::DeviceModel{<:PSY.DCBranch, HVDCP2PDispatch},
     ::NetworkModel{CopperPlatePowerModel},
 ) = nothing
 
@@ -59,7 +59,7 @@ construct_device!(
     ::OptimizationContainer,
     ::PSY.System,
     ::ModelConstructStage,
-    ::DeviceModel{<:PSY.DCBranch, HVDCDispatch},
+    ::DeviceModel{<:PSY.DCBranch, HVDCP2PDispatch},
     ::NetworkModel{CopperPlatePowerModel},
 ) = nothing
 
@@ -67,7 +67,7 @@ construct_device!(
     ::OptimizationContainer,
     ::PSY.System,
     ::ArgumentConstructStage,
-    ::DeviceModel{<:PSY.DCBranch, HVDCLossless},
+    ::DeviceModel{<:PSY.DCBranch, HVDCP2PLossless},
     ::NetworkModel{CopperPlatePowerModel},
 ) = nothing
 
@@ -75,7 +75,7 @@ construct_device!(
     ::OptimizationContainer,
     ::PSY.System,
     ::ModelConstructStage,
-    ::DeviceModel{<:PSY.DCBranch, HVDCLossless},
+    ::DeviceModel{<:PSY.DCBranch, HVDCP2PLossless},
     ::NetworkModel{CopperPlatePowerModel},
 ) = nothing
 
@@ -254,7 +254,7 @@ function construct_device!(
     ::ArgumentConstructStage,
     model::DeviceModel{B, F},
     ::NetworkModel{S},
-) where {B <: PSY.DCBranch, F <: HVDCLossless, S <: PM.AbstractPowerModel} end
+) where {B <: PSY.DCBranch, F <: HVDCP2PLossless, S <: PM.AbstractPowerModel} end
 
 function construct_device!(
     container::OptimizationContainer,
@@ -262,7 +262,7 @@ function construct_device!(
     ::ArgumentConstructStage,
     model::DeviceModel{B, F},
     ::NetworkModel{S},
-) where {B <: PSY.DCBranch, F <: HVDCUnbounded, S <: PM.AbstractPowerModel} end
+) where {B <: PSY.DCBranch, F <: HVDCP2PUnbounded, S <: PM.AbstractPowerModel} end
 
 function construct_device!(
     container::OptimizationContainer,
@@ -270,7 +270,7 @@ function construct_device!(
     ::ArgumentConstructStage,
     model::DeviceModel{B, F},
     ::NetworkModel{S},
-) where {B <: PSY.DCBranch, F <: HVDCDispatch, S <: PM.AbstractPowerModel}
+) where {B <: PSY.DCBranch, F <: HVDCP2PDispatch, S <: PM.AbstractPowerModel}
     devices = get_available_components(B, sys)
     add_variables!(container, HVDCTotalPowerDeliveredVariable, devices, F())
     add_to_expression!(
@@ -290,7 +290,7 @@ function construct_device!(
     ::ModelConstructStage,
     model::DeviceModel{B, F},
     ::NetworkModel{S},
-) where {B <: PSY.DCBranch, F <: HVDCDispatch, S <: PM.AbstractPowerModel}
+) where {B <: PSY.DCBranch, F <: HVDCP2PDispatch, S <: PM.AbstractPowerModel}
     devices = get_available_components(B, sys)
     branch_rate_bounds!(container, devices, model, S)
     add_constraints!(container, FlowRateConstraintFromTo, devices, model, S)
@@ -300,7 +300,7 @@ function construct_device!(
     return
 end
 
-# Repeated method to avoid ambiguity between HVDCUnbounded and HVDCLossless
+# Repeated method to avoid ambiguity between HVDCP2PUnbounded and HVDCP2PLossless
 function construct_device!(
     container::OptimizationContainer,
     sys::PSY.System,
@@ -309,7 +309,7 @@ function construct_device!(
     ::NetworkModel{S},
 ) where {
     B <: PSY.DCBranch,
-    U <: HVDCLossless,
+    U <: HVDCP2PLossless,
     S <: Union{StandardPTDFModel, PTDFPowerModel},
 }
     devices = get_available_components(B, sys)
@@ -326,7 +326,7 @@ function construct_device!(
     return
 end
 
-# Repeated method to avoid ambiguity between HVDCUnbounded and HVDCLossless
+# Repeated method to avoid ambiguity between HVDCP2PUnbounded and HVDCP2PLossless
 function construct_device!(
     container::OptimizationContainer,
     sys::PSY.System,
@@ -335,7 +335,7 @@ function construct_device!(
     ::NetworkModel{S},
 ) where {
     B <: PSY.DCBranch,
-    U <: HVDCUnbounded,
+    U <: HVDCP2PUnbounded,
     S <: Union{StandardPTDFModel, PTDFPowerModel},
 }
     devices = get_available_components(B, sys)
@@ -352,7 +352,7 @@ function construct_device!(
     return
 end
 
-# Repeated method to avoid ambiguity between HVDCUnbounded and HVDCLossless
+# Repeated method to avoid ambiguity between HVDCP2PUnbounded and HVDCP2PP2PLossless
 function construct_device!(
     container::OptimizationContainer,
     sys::PSY.System,
@@ -361,7 +361,7 @@ function construct_device!(
     ::NetworkModel{S},
 ) where {
     B <: PSY.DCBranch,
-    U <: HVDCUnbounded,
+    U <: HVDCP2PUnbounded,
     S <: Union{StandardPTDFModel, PTDFPowerModel},
 }
     devices = get_available_components(B, sys)
@@ -371,7 +371,7 @@ function construct_device!(
     return
 end
 
-# Repeated method to avoid ambiguity between HVDCUnbounded and HVDCLossless
+# Repeated method to avoid ambiguity between HVDCP2PUnbounded and HVDCP2PLossless
 function construct_device!(
     container::OptimizationContainer,
     sys::PSY.System,
@@ -380,7 +380,7 @@ function construct_device!(
     ::NetworkModel{S},
 ) where {
     B <: PSY.DCBranch,
-    U <: HVDCLossless,
+    U <: HVDCP2PLossless,
     S <: Union{StandardPTDFModel, PTDFPowerModel},
 }
     devices = get_available_components(B, sys)
@@ -396,7 +396,7 @@ function construct_device!(
     ::ModelConstructStage,
     model::DeviceModel{B, U},
     ::NetworkModel{S},
-) where {B <: PSY.DCBranch, U <: HVDCLossless, S <: PM.AbstractPowerModel}
+) where {B <: PSY.DCBranch, U <: HVDCP2PLossless, S <: PM.AbstractPowerModel}
     devices = get_available_components(B, sys)
     branch_rate_bounds!(container, devices, model, S)
     add_constraints!(container, FlowRateConstraintFromTo, devices, model, S)
@@ -411,7 +411,7 @@ function construct_device!(
     ::ModelConstructStage,
     model::DeviceModel{B, U},
     ::NetworkModel{S},
-) where {B <: PSY.DCBranch, U <: HVDCUnbounded, S <: PM.AbstractPowerModel}
+) where {B <: PSY.DCBranch, U <: HVDCP2PUnbounded, S <: PM.AbstractPowerModel}
     devices = get_available_components(B, sys)
     add_constraints!(container, FlowRateConstraintFromTo, devices, model, S)
     add_constraints!(container, FlowRateConstraintToFrom, devices, model, S)
@@ -427,7 +427,7 @@ function construct_device!(
     ::NetworkModel{S},
 ) where {
     B <: PSY.DCBranch,
-    U <: HVDCDispatch,
+    U <: HVDCP2PDispatch,
     S <: Union{StandardPTDFModel, PTDFPowerModel},
 }
     devices = get_available_components(B, sys)
@@ -446,7 +446,7 @@ function construct_device!(
     ::NetworkModel{S},
 ) where {
     B <: PSY.DCBranch,
-    U <: HVDCDispatch,
+    U <: HVDCP2PDispatch,
     S <: Union{StandardPTDFModel, PTDFPowerModel},
 }
     devices = get_available_components(B, sys)

--- a/src/devices_models/device_constructors/branch_constructor.jl
+++ b/src/devices_models/device_constructors/branch_constructor.jl
@@ -384,6 +384,7 @@ function construct_device!(
     add_variables!(container, FlowActivePowerToFromVariable, devices, F())
     add_variables!(container, FlowActivePowerFromToVariable, devices, F())
     add_variables!(container, HVDCLosses, devices, F())
+    add_variables!(container, HVDCFlowDirectionVariable, devices, F())
     add_to_expression!(
         container,
         ActivePowerBalance,
@@ -428,10 +429,9 @@ function construct_device!(
     ::NetworkModel{S},
 ) where {B <: PSY.DCBranch, F <: HVDCP2PDispatch, S <: PM.AbstractPowerModel}
     devices = get_available_components(B, sys)
-    @show "here"
     add_variables!(container, FlowActivePowerToFromVariable, devices, F())
     add_variables!(container, FlowActivePowerFromToVariable, devices, F())
-    add_variables!(container, HVDCLosses, devices, F())
+    add_variables!(container, HVDCFlowDirectionVariable, devices, F())
     add_to_expression!(
         container,
         ActivePowerBalance,
@@ -462,7 +462,7 @@ function construct_device!(
     add_constraints!(container, FlowRateConstraintFromTo, devices, model, S)
     add_constraints!(container, FlowRateConstraintToFrom, devices, model, S)
     add_constraints!(container, HVDCPowerBalance, devices, model, S)
-    add_constraints!(container, HVDCLossesAbsoluteValue, devices, model, S)
+    add_constraints!(container, HVDCDirection, devices, model, S)
     add_constraint_dual!(container, sys, model)
     return
 end

--- a/src/devices_models/devices/AC_branches.jl
+++ b/src/devices_models/devices/AC_branches.jl
@@ -215,6 +215,7 @@ function add_constraints!(
     )
     nodal_balance_expressions =
         get_expression(container, ActivePowerBalance(), StandardPTDFModel)
+
     flow_variables = get_variable(container, FlowActivePowerVariable(), B)
     jump_model = get_jump_model(container)
     for br in devices

--- a/src/devices_models/devices/DC_branches.jl
+++ b/src/devices_models/devices/DC_branches.jl
@@ -287,14 +287,25 @@ function add_constraints!(
         l0 = PSY.get_loss(d).l0
         name = PSY.get_name(d)
         for t in get_time_steps(container)
-            constraint_ub[PSY.get_name(d), t] = JuMP.@constraint(
+            if l1 == 0.0 && l0 == 0.0
+                constraint_ub[PSY.get_name(d), t] = JuMP.@constraint(
                 get_jump_model(container),
-                l1 * ft_var[name, t] + l0 <= losses[name, t]
-            )
-            constraint_lb[PSY.get_name(d), t] = JuMP.@constraint(
-                get_jump_model(container),
-                losses[name, t] >= -l1 * tf_var[name, t] + l0
-            )
+                ft_var[name, t] - tf_var[name, t] <= 0.0
+                )
+                constraint_lb[PSY.get_name(d), t] = JuMP.@constraint(
+                    get_jump_model(container),
+                    0.0 >= tf_var[name, t] - ft_var[name, t]
+                )
+            else
+                constraint_ub[PSY.get_name(d), t] = JuMP.@constraint(
+                    get_jump_model(container),
+                    ft_var[name, t] - tf_var[name, t] <= losses[name, t]
+                )
+                constraint_lb[PSY.get_name(d), t] = JuMP.@constraint(
+                    get_jump_model(container),
+                    losses[name, t] >= -tf_var[name, t] + ft_var[name, t]
+                )
+            end
         end
     end
     return

--- a/src/devices_models/devices/DC_branches.jl
+++ b/src/devices_models/devices/DC_branches.jl
@@ -414,11 +414,11 @@ function add_constraints!(
             else
                 constraint_tf[PSY.get_name(d), t] = JuMP.@constraint(
                     get_jump_model(container),
-                    -l1 * tf_var[name, t] + l0 <= losses[name, t]
+                    tf_var[name, t] - ft_var[name, t] <= losses[name, t]
                 )
                 constraint_ft[PSY.get_name(d), t] = JuMP.@constraint(
                     get_jump_model(container),
-                    l1 * ft_var[name, t] + l0 <= losses[name, t]
+                    - tf_var[name, t] + ft_var[name, t] <= losses[name, t]
                 )
             end
         end

--- a/src/devices_models/devices/DC_branches.jl
+++ b/src/devices_models/devices/DC_branches.jl
@@ -15,10 +15,10 @@ get_variable_multiplier(
     ::AbstractDCLineFormulation,
 ) = 1.0
 
-get_variable_lower_bound(::FlowActivePowerVariable, d::PSY.DCBranch, ::HVDCUnbounded) =
+get_variable_lower_bound(::FlowActivePowerVariable, d::PSY.DCBranch, ::HVDCP2PUnbounded) =
     nothing
 
-get_variable_upper_bound(::FlowActivePowerVariable, d::PSY.DCBranch, ::HVDCUnbounded) =
+get_variable_upper_bound(::FlowActivePowerVariable, d::PSY.DCBranch, ::HVDCP2PUnbounded) =
     nothing
 
 get_variable_lower_bound(
@@ -52,13 +52,13 @@ end
 get_initial_conditions_device_model(
     ::OperationModel,
     ::DeviceModel{T, <:AbstractDCLineFormulation},
-) where {T <: PSY.HVDCLine} = DeviceModel(T, HVDCDispatch)
+) where {T <: PSY.HVDCLine} = DeviceModel(T, HVDCP2PDispatch)
 
 #################################### Rate Limits Constraints ##################################################
 function branch_rate_bounds!(
     container::OptimizationContainer,
     devices::IS.FlattenIteratorWrapper{B},
-    ::DeviceModel{B, HVDCLossless},
+    ::DeviceModel{B, HVDCP2PLossless},
     ::Type{<:PM.AbstractPowerModel},
 ) where {B <: PSY.HVDCLine}
     var = get_variable(container, FlowActivePowerVariable(), B)
@@ -107,7 +107,7 @@ function add_constraints!(
     container::OptimizationContainer,
     cons_type::Type{FlowRateConstraint},
     devices::IS.FlattenIteratorWrapper{B},
-    ::DeviceModel{B, HVDCLossless},
+    ::DeviceModel{B, HVDCP2PLossless},
     ::Type{<:PM.AbstractDCPModel},
 ) where {B <: PSY.DCBranch}
     var = get_variable(container, FlowActivePowerVariable(), B)
@@ -135,7 +135,7 @@ add_constraints!(
     ::OptimizationContainer,
     ::Type{<:Union{FlowRateConstraintFromTo, FlowRateConstraintToFrom, FlowRateConstraint}},
     ::IS.FlattenIteratorWrapper{<:PSY.DCBranch},
-    ::DeviceModel{<:PSY.DCBranch, HVDCUnbounded},
+    ::DeviceModel{<:PSY.DCBranch, HVDCP2PUnbounded},
     ::Type{<:PM.AbstractPowerModel},
 ) = nothing
 

--- a/src/devices_models/devices/DC_branches.jl
+++ b/src/devices_models/devices/DC_branches.jl
@@ -1,7 +1,11 @@
 #################################### Branch Variables ##################################################
 get_variable_binary(_, ::Type{<:PSY.DCBranch}, ::AbstractDCLineFormulation) = false
 
-get_variable_binary(::HVDCFlowDirectionVariable, ::Type{<:PSY.DCBranch}, ::AbstractDCLineFormulation) = true
+get_variable_binary(
+    ::HVDCFlowDirectionVariable,
+    ::Type{<:PSY.DCBranch},
+    ::AbstractDCLineFormulation,
+) = true
 
 get_variable_multiplier(::FlowActivePowerVariable, ::Type{<:PSY.DCBranch}, _) = NaN
 
@@ -56,7 +60,6 @@ function get_variable_upper_bound(::HVDCLosses, d::PSY.DCBranch, ::HVDCP2PDispat
         return nothing
     end
 end
-
 
 function get_default_time_series_names(
     ::Type{U},
@@ -274,19 +277,19 @@ function add_constraints!(
         for t in time_steps
             constraint_tf_ub[name, t] = JuMP.@constraint(
                 get_jump_model(container),
-                tf_var[name, t] <= max_rate*(1 - direction_var[name, t])
+                tf_var[name, t] <= max_rate * (1 - direction_var[name, t])
             )
             constraint_ft_ub[name, t] = JuMP.@constraint(
                 get_jump_model(container),
-                ft_var[name, t] <= max_rate*(1 - direction_var[name, t])
+                ft_var[name, t] <= max_rate * (1 - direction_var[name, t])
             )
             constraint_tf_lb[name, t] = JuMP.@constraint(
                 get_jump_model(container),
-                direction_var[name, t]*min_rate <= tf_var[name, t]
+                direction_var[name, t] * min_rate <= tf_var[name, t]
             )
             constraint_ft_lb[name, t] = JuMP.@constraint(
                 get_jump_model(container),
-                direction_var[name, t]*min_rate <= tf_var[name, t]
+                direction_var[name, t] * min_rate <= tf_var[name, t]
             )
         end
     end
@@ -354,11 +357,12 @@ function add_constraints!(
             )
             constraint_tf_lb[PSY.get_name(d), t] = JuMP.@constraint(
                 get_jump_model(container),
-                ft_var[name, t] - tf_var[name, t] >= -M_VALUE*(1-direction_var[name, t])
+                ft_var[name, t] - tf_var[name, t] >=
+                -M_VALUE * (1 - direction_var[name, t])
             )
             constraint_ft_lb[PSY.get_name(d), t] = JuMP.@constraint(
                 get_jump_model(container),
-                tf_var[name, t] - ft_var[name, t] >= -M_VALUE*(direction_var[name, t])
+                tf_var[name, t] - ft_var[name, t] >= -M_VALUE * (direction_var[name, t])
             )
         end
     end

--- a/src/devices_models/devices/DC_branches.jl
+++ b/src/devices_models/devices/DC_branches.jl
@@ -1,21 +1,31 @@
 #################################### Branch Variables ##################################################
 get_variable_binary(_, ::Type{<:PSY.DCBranch}, ::AbstractDCLineFormulation) = false
 
+get_variable_binary(::HVDCFlowDirectionVariable, ::Type{<:PSY.DCBranch}, ::AbstractDCLineFormulation) = true
+
 get_variable_multiplier(::FlowActivePowerVariable, ::Type{<:PSY.DCBranch}, _) = NaN
 
 get_variable_multiplier(
     ::FlowActivePowerFromToVariable,
     ::Type{<:PSY.DCBranch},
     ::AbstractDCLineFormulation,
-) = 1.0
+) = -1.0
 
 get_variable_multiplier(
     ::FlowActivePowerToFromVariable,
     ::Type{<:PSY.DCBranch},
     ::AbstractDCLineFormulation,
-) = -1.0
+) = 1.0
 
-get_variable_multiplier(::HVDCLosses, ::Type{<:PSY.DCBranch}, ::HVDCP2PDispatch) = -1.0
+function get_variable_multiplier(::HVDCLosses, d::PSY.DCBranch, ::HVDCP2PDispatch)
+    l1 = PSY.get_loss(d).l1
+    l0 = PSY.get_loss(d).l0
+    if l1 == 0.0 && l0 == 0.0
+        return 0.0
+    else
+        return -1.0
+    end
+end
 
 get_variable_lower_bound(::FlowActivePowerVariable, d::PSY.DCBranch, ::HVDCP2PUnbounded) =
     nothing
@@ -35,7 +45,18 @@ get_variable_upper_bound(
     ::AbstractDCLineFormulation,
 ) = nothing
 
-get_variable_lower_bound(::HVDCLosses, d::PSY.DCBranch, ::AbstractDCLineFormulation) = 0.0
+get_variable_lower_bound(::HVDCLosses, d::PSY.DCBranch, ::HVDCP2PDispatch) = 0.0
+
+function get_variable_upper_bound(::HVDCLosses, d::PSY.DCBranch, ::HVDCP2PDispatch)
+    l1 = PSY.get_loss(d).l1
+    l0 = PSY.get_loss(d).l0
+    if l1 == 0.0 && l0 == 0.0
+        return 0.0
+    else
+        return nothing
+    end
+end
+
 
 function get_default_time_series_names(
     ::Type{U},
@@ -57,7 +78,7 @@ get_initial_conditions_device_model(
 ) where {T <: PSY.HVDCLine, U <: AbstractDCLineFormulation} = DeviceModel(T, U)
 
 #################################### Rate Limits Constraints ##################################################
-function _get_flow_bounds(d::PSY.HVDCLine)
+function _check_hvdc_line_limits_consistency(d::PSY.HVDCLine)
     from_min = PSY.get_active_power_limits_from(d).min
     to_min = PSY.get_active_power_limits_to(d).min
     from_max = PSY.get_active_power_limits_from(d).max
@@ -84,6 +105,14 @@ function _get_flow_bounds(d::PSY.HVDCLine)
             ),
         )
     end
+    return
+end
+function _get_flow_bounds(d::PSY.HVDCLine)
+    _check_hvdc_line_limits_consistency(d)
+    from_min = PSY.get_active_power_limits_from(d).min
+    to_min = PSY.get_active_power_limits_to(d).min
+    from_max = PSY.get_active_power_limits_from(d).max
+    to_max = PSY.get_active_power_limits_to(d).max
 
     if from_max <= to_max && from_min <= to_min
         # Case bounds dominated by from side of HVDC Line
@@ -140,7 +169,7 @@ function add_constraints!(
     constraint_lb =
         add_constraints_container!(container, T(), U, names, time_steps; meta="lb")
     for d in devices
-        min_rate, max_rate = PSY.get_active_power_limits_from(d)
+        min_rate, max_rate = _get_flow_bounds(d)
         for t in time_steps
             constraint_ub[PSY.get_name(d), t] = JuMP.@constraint(
                 get_jump_model(container),
@@ -171,7 +200,7 @@ function add_constraints!(
     constraint_lb =
         add_constraints_container!(container, T(), U, names, time_steps; meta="lb")
     for d in devices
-        min_rate, max_rate = PSY.get_active_power_limits_to(d)
+        min_rate, max_rate = PSY.get_active_power_limits_from(d)
         for t in time_steps
             constraint_ub[PSY.get_name(d), t] = JuMP.@constraint(
                 get_jump_model(container),
@@ -202,7 +231,7 @@ function add_constraints!(
     constraint_lb =
         add_constraints_container!(container, T(), U, names, time_steps; meta="lb")
     for d in devices
-        min_rate, max_rate = _get_flow_bounds(d)
+        min_rate, max_rate = PSY.get_active_power_limits_to(d)
         for t in time_steps
             constraint_ub[PSY.get_name(d), t] = JuMP.@constraint(
                 get_jump_model(container),
@@ -211,6 +240,53 @@ function add_constraints!(
             constraint_lb[PSY.get_name(d), t] = JuMP.@constraint(
                 get_jump_model(container),
                 min_rate <= var[PSY.get_name(d), t]
+            )
+        end
+    end
+    return
+end
+
+function add_constraints!(
+    container::OptimizationContainer,
+    ::Type{T},
+    devices::IS.FlattenIteratorWrapper{U},
+    ::DeviceModel{U, HVDCP2PDispatch},
+    ::Type{<:PM.AbstractPowerModel},
+) where {T <: HVDCDirection, U <: PSY.DCBranch}
+    time_steps = get_time_steps(container)
+    names = [PSY.get_name(d) for d in devices]
+
+    tf_var = get_variable(container, FlowActivePowerToFromVariable(), U)
+    ft_var = get_variable(container, FlowActivePowerFromToVariable(), U)
+    direction_var = get_variable(container, HVDCFlowDirectionVariable(), U)
+
+    constraint_ft_ub =
+        add_constraints_container!(container, T(), U, names, time_steps; meta="ft_ub")
+    constraint_tf_ub =
+        add_constraints_container!(container, T(), U, names, time_steps; meta="tf_ub")
+    constraint_ft_lb =
+        add_constraints_container!(container, T(), U, names, time_steps; meta="ft_lb")
+    constraint_tf_lb =
+        add_constraints_container!(container, T(), U, names, time_steps; meta="tf_lb")
+    for d in devices
+        min_rate, max_rate = _get_flow_bounds(d)
+        name = PSY.get_name(d)
+        for t in time_steps
+            constraint_tf_ub[name, t] = JuMP.@constraint(
+                get_jump_model(container),
+                tf_var[name, t] <= max_rate*(1 - direction_var[name, t])
+            )
+            constraint_ft_ub[name, t] = JuMP.@constraint(
+                get_jump_model(container),
+                ft_var[name, t] <= max_rate*(1 - direction_var[name, t])
+            )
+            constraint_tf_lb[name, t] = JuMP.@constraint(
+                get_jump_model(container),
+                direction_var[name, t]*min_rate <= tf_var[name, t]
+            )
+            constraint_ft_lb[name, t] = JuMP.@constraint(
+                get_jump_model(container),
+                direction_var[name, t]*min_rate <= tf_var[name, t]
             )
         end
     end
@@ -228,34 +304,61 @@ function add_constraints!(
     names = [PSY.get_name(d) for d in devices]
     tf_var = get_variable(container, FlowActivePowerToFromVariable(), T)
     ft_var = get_variable(container, FlowActivePowerFromToVariable(), T)
-    constraint_ub = add_constraints_container!(
+    direction_var = get_variable(container, HVDCFlowDirectionVariable(), T)
+
+    constraint_ft_ub = add_constraints_container!(
         container,
         HVDCPowerBalance(),
         T,
         names,
         time_steps;
-        meta="ub",
+        meta="ft_ub",
     )
-    constraint_lb = add_constraints_container!(
+    constraint_tf_ub = add_constraints_container!(
         container,
         HVDCPowerBalance(),
         T,
         names,
         time_steps;
-        meta="lb",
+        meta="tf_ub",
+    )
+    constraint_ft_lb = add_constraints_container!(
+        container,
+        HVDCPowerBalance(),
+        T,
+        names,
+        time_steps;
+        meta="tf_lb",
+    )
+    constraint_tf_lb = add_constraints_container!(
+        container,
+        HVDCPowerBalance(),
+        T,
+        names,
+        time_steps;
+        meta="ft_lb",
     )
     for d in devices
         l1 = PSY.get_loss(d).l1
         l0 = PSY.get_loss(d).l0
         name = PSY.get_name(d)
+
         for t in get_time_steps(container)
-            constraint_ub[PSY.get_name(d), t] = JuMP.@constraint(
+            constraint_tf_ub[PSY.get_name(d), t] = JuMP.@constraint(
+                get_jump_model(container),
+                tf_var[name, t] - ft_var[name, t] <= l1 * tf_var[name, t] - l0
+            )
+            constraint_ft_ub[PSY.get_name(d), t] = JuMP.@constraint(
                 get_jump_model(container),
                 ft_var[name, t] - tf_var[name, t] >= l1 * ft_var[name, t] + l0
             )
-            constraint_lb[PSY.get_name(d), t] = JuMP.@constraint(
+            constraint_tf_lb[PSY.get_name(d), t] = JuMP.@constraint(
                 get_jump_model(container),
-                tf_var[name, t] - ft_var[name, t] <= l1 * tf_var[name, t] - l0
+                ft_var[name, t] - tf_var[name, t] >= -M_VALUE*(1-direction_var[name, t])
+            )
+            constraint_ft_lb[PSY.get_name(d), t] = JuMP.@constraint(
+                get_jump_model(container),
+                tf_var[name, t] - ft_var[name, t] >= -M_VALUE*(direction_var[name, t])
             )
         end
     end
@@ -274,21 +377,21 @@ function add_constraints!(
     losses = get_variable(container, HVDCLosses(), T)
     tf_var = get_variable(container, FlowActivePowerToFromVariable(), T)
     ft_var = get_variable(container, FlowActivePowerFromToVariable(), T)
-    constraint_ub = add_constraints_container!(
+    constraint_tf = add_constraints_container!(
         container,
         HVDCLossesAbsoluteValue(),
         T,
         names,
         time_steps;
-        meta="ub",
+        meta="tf",
     )
-    constraint_lb = add_constraints_container!(
+    constraint_ft = add_constraints_container!(
         container,
         HVDCLossesAbsoluteValue(),
         T,
         names,
         time_steps;
-        meta="lb",
+        meta="ft",
     )
     for d in devices
         l1 = PSY.get_loss(d).l1
@@ -296,22 +399,22 @@ function add_constraints!(
         name = PSY.get_name(d)
         for t in get_time_steps(container)
             if l1 == 0.0 && l0 == 0.0
-                constraint_ub[PSY.get_name(d), t] = JuMP.@constraint(
-                get_jump_model(container),
-                ft_var[name, t] - tf_var[name, t] <= 0.0
-                )
-                constraint_lb[PSY.get_name(d), t] = JuMP.@constraint(
+                constraint_ft[PSY.get_name(d), t] = JuMP.@constraint(
                     get_jump_model(container),
-                    0.0 >= tf_var[name, t] - ft_var[name, t]
+                    -ft_var[name, t] + tf_var[name, t] == 0.0
+                )
+                constraint_tf[PSY.get_name(d), t] = JuMP.@constraint(
+                    get_jump_model(container),
+                    ft_var[name, t] - tf_var[name, t] == 0.0
                 )
             else
-                constraint_ub[PSY.get_name(d), t] = JuMP.@constraint(
+                constraint_tf[PSY.get_name(d), t] = JuMP.@constraint(
                     get_jump_model(container),
-                    ft_var[name, t] - tf_var[name, t] <= losses[name, t]
+                    -l1 * tf_var[name, t] + l0 <= losses[name, t]
                 )
-                constraint_lb[PSY.get_name(d), t] = JuMP.@constraint(
+                constraint_ft[PSY.get_name(d), t] = JuMP.@constraint(
                     get_jump_model(container),
-                    losses[name, t] >= -tf_var[name, t] + ft_var[name, t]
+                    l1 * ft_var[name, t] + l0 <= losses[name, t]
                 )
             end
         end

--- a/src/devices_models/devices/DC_branches.jl
+++ b/src/devices_models/devices/DC_branches.jl
@@ -110,7 +110,15 @@ end
 
 add_constraints!(
     ::OptimizationContainer,
-    ::Type{<:Union{FlowRateConstraintFromTo, FlowRateConstraintToFrom, FlowRateConstraint}},
+    ::Type{<:Union{FlowRateConstraintFromTo, FlowRateConstraintToFrom}},
+    ::IS.FlattenIteratorWrapper{<:PSY.DCBranch},
+    ::DeviceModel{<:PSY.DCBranch, HVDCP2PUnbounded},
+    ::Type{<:PM.AbstractPowerModel},
+) = nothing
+
+add_constraints!(
+    ::OptimizationContainer,
+    ::Type{FlowRateConstraint},
     ::IS.FlattenIteratorWrapper{<:PSY.DCBranch},
     ::DeviceModel{<:PSY.DCBranch, HVDCP2PUnbounded},
     ::Type{<:PM.AbstractPowerModel},
@@ -151,7 +159,7 @@ function add_constraints!(
     container::OptimizationContainer,
     ::Type{T},
     devices::IS.FlattenIteratorWrapper{U},
-    ::DeviceModel{U, <:AbstractDCLineFormulation},
+    ::DeviceModel{U, HVDCP2PDispatch},
     ::Type{<:PM.AbstractPowerModel},
 ) where {T <: FlowRateConstraintFromTo, U <: PSY.DCBranch}
     time_steps = get_time_steps(container)
@@ -182,7 +190,7 @@ function add_constraints!(
     container::OptimizationContainer,
     ::Type{T},
     devices::IS.FlattenIteratorWrapper{U},
-    ::DeviceModel{U, <:AbstractDCLineFormulation},
+    ::DeviceModel{U, HVDCP2PDispatch},
     ::Type{<:PM.AbstractPowerModel},
 ) where {T <: FlowRateConstraintToFrom, U <: PSY.DCBranch}
     time_steps = get_time_steps(container)

--- a/src/devices_models/devices/common/add_to_expression.jl
+++ b/src/devices_models/devices/common/add_to_expression.jl
@@ -157,7 +157,7 @@ function add_to_expression!(
 end
 
 """
-Default implementation to add variables to SystemBalanceExpressions
+Default implementation to add device variables to SystemBalanceExpressions
 """
 function add_to_expression!(
     container::OptimizationContainer,
@@ -169,7 +169,7 @@ function add_to_expression!(
 ) where {
     T <: SystemBalanceExpressions,
     U <: VariableType,
-    V <: PSY.Device,
+    V <: PSY.StaticInjection,
     W <: AbstractDeviceFormulation,
     X <: PM.AbstractPowerModel,
 }
@@ -183,6 +183,98 @@ function add_to_expression!(
             variable[name, t],
             get_variable_multiplier(U(), V, W()),
         )
+    end
+    return
+end
+
+"""
+Default implementation to add branch variables to SystemBalanceExpressions
+"""
+function add_to_expression!(
+    container::OptimizationContainer,
+    ::Type{T},
+    ::Type{U},
+    devices::IS.FlattenIteratorWrapper{V},
+    ::DeviceModel{V, W},
+    ::Type{X},
+) where {
+    T <: ActivePowerBalance,
+    U <: FlowActivePowerToFromVariable,
+    V <: PSY.Branch,
+    W <: AbstractDeviceFormulation,
+    X <: PM.AbstractPowerModel,
+}
+    variable = get_variable(container, U(), V)
+    expression = get_expression(container, T(), X)
+    for d in devices
+        name = PSY.get_name(d)
+        bus_number = PSY.get_number(PSY.get_arc(d).to)
+        for t in get_time_steps(container)
+            _add_to_jump_expression!(
+                expression[bus_number, t],
+                variable[name, t],
+                get_variable_multiplier(U(), V, W()),
+            )
+        end
+    end
+    return
+end
+
+"""
+Default implementation to add branch variables to SystemBalanceExpressions
+"""
+function add_to_expression!(
+    container::OptimizationContainer,
+    ::Type{T},
+    ::Type{U},
+    devices::IS.FlattenIteratorWrapper{V},
+    ::DeviceModel{V, W},
+    ::Type{StandardPTDFModel},
+) where {T <: ActivePowerBalance, U <: HVDCLosses, V <: PSY.HVDCLine, W <: HVDCP2PDispatch}
+    variable = get_variable(container, U(), V)
+    expression = get_expression(container, T(), PSY.System)
+    for d in devices
+        name = PSY.get_name(d)
+        for t in get_time_steps(container)
+            _add_to_jump_expression!(
+                expression[t],
+                variable[name, t],
+                get_variable_multiplier(U(), V, W()),
+            )
+        end
+    end
+    return
+end
+
+"""
+Default implementation to add branch variables to SystemBalanceExpressions
+"""
+function add_to_expression!(
+    container::OptimizationContainer,
+    ::Type{T},
+    ::Type{U},
+    devices::IS.FlattenIteratorWrapper{V},
+    ::DeviceModel{V, W},
+    ::Type{X},
+) where {
+    T <: ActivePowerBalance,
+    U <: FlowActivePowerFromToVariable,
+    V <: PSY.Branch,
+    W <: AbstractDeviceFormulation,
+    X <: PM.AbstractPowerModel,
+}
+    variable = get_variable(container, U(), V)
+    expression = get_expression(container, T(), X)
+    for d in devices
+        name = PSY.get_name(d)
+        bus_number = PSY.get_number(PSY.get_arc(d).from)
+        for t in get_time_steps(container)
+            _add_to_jump_expression!(
+                expression[bus_number, t],
+                variable[name, t],
+                get_variable_multiplier(U(), V, W()),
+            )
+        end
     end
     return
 end
@@ -505,6 +597,43 @@ function add_to_expression!(
     container::OptimizationContainer,
     ::Type{T},
     ::Type{U},
+    devices::IS.FlattenIteratorWrapper{V},
+    ::DeviceModel{V, HVDCP2PDispatch},
+    ::Type{X},
+) where {
+    T <: ActivePowerBalance,
+    U <: FlowActivePowerVariable,
+    V <: PSY.DCBranch,
+    X <: PM.AbstractActivePowerModel,
+}
+    @error "broken"
+    var = get_variable(container, U(), V)
+    expression = get_expression(container, T(), X)
+    for d in devices
+        for t in get_time_steps(container)
+            flow_variable = var[PSY.get_name(d), t]
+            _add_to_jump_expression!(
+                expression[PSY.get_number(PSY.get_arc(d).from), t],
+                flow_variable,
+                -1.0,
+            )
+            _add_to_jump_expression!(
+                expression[PSY.get_number(PSY.get_arc(d).to), t],
+                flow_variable,
+                1.0,
+            )
+        end
+    end
+    return
+end
+
+"""
+Implementation of add_to_expression! for lossless branch/network models
+"""
+function add_to_expression!(
+    container::OptimizationContainer,
+    ::Type{T},
+    ::Type{U},
     devices::IS.FlattenIteratorWrapper{PSY.PhaseShiftingTransformer},
     ::DeviceModel{PSY.PhaseShiftingTransformer, V},
     ::Type{W},
@@ -532,34 +661,6 @@ function add_to_expression!(
         end
     end
     return
-end
-
-function add_to_expression!(
-    container::OptimizationContainer,
-    ::Type{T},
-    ::Type{U},
-    devices::IS.FlattenIteratorWrapper{V},
-    ::DeviceModel{V, W},
-    ::Type{X},
-) where {
-    T <: ActivePowerBalance,
-    U <: HVDCTotalPowerDeliveredVariable,
-    V <: PSY.DCBranch,
-    W <: AbstractBranchFormulation,
-    X <: PM.AbstractPowerModel,
-}
-    var = get_variable(container, U(), V)
-    expression = get_expression(container, T(), X)
-    for d in devices
-        for t in get_time_steps(container)
-            flow_variable = var[PSY.get_name(d), t]
-            _add_to_jump_expression!(
-                expression[PSY.get_number(PSY.get_arc(d).to), t],
-                flow_variable,
-                1.0,
-            )
-        end
-    end
 end
 
 function add_to_expression!(

--- a/src/network_models/pm_translator.jl
+++ b/src/network_models/pm_translator.jl
@@ -66,7 +66,7 @@ end
 function get_branch_to_pm(
     ix::Int,
     branch::PSY.PhaseShiftingTransformer,
-    device_formulation::Type{StaticBranchUnbounded},
+    ::Type{StaticBranchUnbounded},
 )
     PM_branch = Dict{String, Any}(
         "br_r" => PSY.get_r(branch),
@@ -91,7 +91,7 @@ end
 function get_branch_to_pm(
     ix::Int,
     branch::PSY.Transformer2W,
-    device_formulation::Type{D},
+    ::Type{D},
 ) where {D <: AbstractBranchFormulation}
     PM_branch = Dict{String, Any}(
         "br_r" => PSY.get_r(branch),
@@ -119,7 +119,7 @@ end
 function get_branch_to_pm(
     ix::Int,
     branch::PSY.Transformer2W,
-    device_formulation::Type{StaticBranchUnbounded},
+    ::Type{StaticBranchUnbounded},
 )
     PM_branch = Dict{String, Any}(
         "br_r" => PSY.get_r(branch),
@@ -144,7 +144,7 @@ end
 function get_branch_to_pm(
     ix::Int,
     branch::PSY.TapTransformer,
-    device_formulation::Type{D},
+    ::Type{D},
 ) where {D <: AbstractBranchFormulation}
     PM_branch = Dict{String, Any}(
         "br_r" => PSY.get_r(branch),
@@ -172,7 +172,7 @@ end
 function get_branch_to_pm(
     ix::Int,
     branch::PSY.TapTransformer,
-    device_formulation::Type{StaticBranchUnbounded},
+    ::Type{StaticBranchUnbounded},
 )
     PM_branch = Dict{String, Any}(
         "br_r" => PSY.get_r(branch),
@@ -197,7 +197,7 @@ end
 function get_branch_to_pm(
     ix::Int,
     branch::PSY.ACBranch,
-    device_formulation::Type{D},
+    ::Type{D},
 ) where {D <: AbstractBranchFormulation}
     PM_branch = Dict{String, Any}(
         "br_r" => PSY.get_r(branch),
@@ -225,7 +225,7 @@ end
 function get_branch_to_pm(
     ix::Int,
     branch::PSY.ACBranch,
-    device_formulation::Type{StaticBranchUnbounded},
+    ::Type{StaticBranchUnbounded},
 )
     PM_branch = Dict{String, Any}(
         "br_r" => PSY.get_r(branch),
@@ -243,6 +243,44 @@ function get_branch_to_pm(
         "angmax" => PSY.get_angle_limits(branch).max,
         "transformer" => false,
         "tap" => 1.0,
+    )
+    return PM_branch
+end
+
+
+function get_branch_to_pm(
+    ix::Int,
+    branch::PSY.HVDCLine,
+    ::Type{HVDCP2PDispatch},
+)
+    PM_branch = Dict{String, Any}(
+        "loss1" => PSY.get_loss(branch).l1,
+        "mp_pmax" => PSY.get_reactive_power_limits_from(branch).max,
+        "model" => 2,
+        "shutdown" => 0.0,
+        "pmaxt" => PSY.get_active_power_limits_to(branch).max,
+        "pmaxf" => PSY.get_active_power_limits_from(branch).max,
+        "startup" => 0.0,
+        "loss0" => PSY.get_loss(branch).l1,
+        "pt" => 0.0,
+        "vt" => PSY.get_magnitude(PSY.get_arc(branch).to),
+        "qmaxf" => PSY.get_reactive_power_limits_from(branch).max,
+        "pmint" => PSY.get_active_power_limits_to(branch).min,
+        "f_bus" => PSY.get_number(PSY.get_arc(branch).from),
+        "mp_pmin" => PSY.get_reactive_power_limits_from(branch).min,
+        "br_status" => 0.0,
+        "t_bus" => PSY.get_number(PSY.get_arc(branch).to),
+        "index" => ix,
+        "qmint" => PSY.get_reactive_power_limits_to(branch).min,
+        "qf" => 0.0,
+        "cost" => 0.0,
+        "pminf" => PSY.get_active_power_limits_from(branch).min,
+        "qt" => 0.0,
+        "qminf" => PSY.get_reactive_power_limits_from(branch).min,
+        "vf" => PSY.get_magnitude(PSY.get_arc(branch).from),
+        "qmaxt" => PSY.get_reactive_power_limits_to(branch).max,
+        "ncost" => 0,
+        "pf" => 0.0,
     )
     return PM_branch
 end
@@ -250,7 +288,7 @@ end
 function get_branch_to_pm(
     ix::Int,
     branch::PSY.HVDCLine,
-    device_formulation::Type{D},
+    ::Type{D},
 ) where {D <: AbstractBranchFormulation}
     PM_branch = Dict{String, Any}(
         "loss1" => PSY.get_loss(branch).l1,

--- a/src/network_models/pm_translator.jl
+++ b/src/network_models/pm_translator.jl
@@ -116,11 +116,7 @@ function get_branch_to_pm(
     return PM_branch
 end
 
-function get_branch_to_pm(
-    ix::Int,
-    branch::PSY.Transformer2W,
-    ::Type{StaticBranchUnbounded},
-)
+function get_branch_to_pm(ix::Int, branch::PSY.Transformer2W, ::Type{StaticBranchUnbounded})
     PM_branch = Dict{String, Any}(
         "br_r" => PSY.get_r(branch),
         "shift" => 0.0,
@@ -222,11 +218,7 @@ function get_branch_to_pm(
     return PM_branch
 end
 
-function get_branch_to_pm(
-    ix::Int,
-    branch::PSY.ACBranch,
-    ::Type{StaticBranchUnbounded},
-)
+function get_branch_to_pm(ix::Int, branch::PSY.ACBranch, ::Type{StaticBranchUnbounded})
     PM_branch = Dict{String, Any}(
         "br_r" => PSY.get_r(branch),
         "shift" => 0.0,
@@ -247,12 +239,7 @@ function get_branch_to_pm(
     return PM_branch
 end
 
-
-function get_branch_to_pm(
-    ix::Int,
-    branch::PSY.HVDCLine,
-    ::Type{HVDCP2PDispatch},
-)
+function get_branch_to_pm(ix::Int, branch::PSY.HVDCLine, ::Type{HVDCP2PDispatch})
     PM_branch = Dict{String, Any}(
         "loss1" => PSY.get_loss(branch).l1,
         "mp_pmax" => PSY.get_reactive_power_limits_from(branch).max,

--- a/src/operation/operation_problem_templates.jl
+++ b/src/operation/operation_problem_templates.jl
@@ -15,7 +15,7 @@ function _default_devices_uc()
         DeviceModel(PSY.Line, StaticBranch),
         DeviceModel(PSY.Transformer2W, StaticBranch),
         DeviceModel(PSY.TapTransformer, StaticBranch),
-        DeviceModel(PSY.HVDCLine, HVDCDispatch),
+        DeviceModel(PSY.HVDCLine, HVDCP2PDispatch),
     ]
 end
 

--- a/test/test_device_branch_constructors.jl
+++ b/test/test_device_branch_constructors.jl
@@ -86,7 +86,7 @@ end
     rate_limit2w = PSY.get_rate(tap_transformer)
 
     for model in [DCPPowerModel, StandardPTDFModel],
-        hvdc_model in [HVDCDispatch, HVDCLossless]
+        hvdc_model in [HVDCP2PDispatch, HVDCP2PLossless]
 
         template =
             get_template_dispatch_with_network(NetworkModel(model; PTDF=PSY.PTDF(system)))
@@ -146,7 +146,7 @@ end
     for model in [DCPPowerModel, StandardPTDFModel]
         template =
             get_template_dispatch_with_network(NetworkModel(model; PTDF=PSY.PTDF(system)))
-        set_device_model!(template, DeviceModel(HVDCLine, HVDCUnbounded))
+        set_device_model!(template, DeviceModel(HVDCLine, HVDCP2PUnbounded))
         set_device_model!(template, DeviceModel(TapTransformer, StaticBranchBounds))
         set_device_model!(template, DeviceModel(Transformer2W, StaticBranchBounds))
         model_m = DecisionModel(template, system; optimizer=ipopt_optimizer)
@@ -213,7 +213,7 @@ end
     rate_limit2w = PSY.get_rate(tap_transformer)
 
     template = get_template_dispatch_with_network(ACPPowerModel)
-    set_device_model!(template, DeviceModel(HVDCLine, HVDCDispatch))
+    set_device_model!(template, DeviceModel(HVDCLine, HVDCP2PDispatch))
     model_m = DecisionModel(template, system; optimizer=ipopt_optimizer)
     @test build!(model_m; output_dir=mktempdir(cleanup=true)) == PSI.BuildStatus.BUILT
 
@@ -282,7 +282,7 @@ end
     template = get_template_dispatch_with_network(
         NetworkModel(StandardPTDFModel; PTDF=PSY.PTDF(system)),
     )
-    set_device_model!(template, DeviceModel(HVDCLine, HVDCDispatch))
+    set_device_model!(template, DeviceModel(HVDCLine, HVDCP2PDispatch))
     model_m = DecisionModel(template, system; optimizer=ipopt_optimizer)
     @test build!(model_m; output_dir=mktempdir(cleanup=true)) == PSI.BuildStatus.BUILT
 

--- a/test/test_device_branch_constructors.jl
+++ b/test/test_device_branch_constructors.jl
@@ -21,27 +21,6 @@
     end
 end
 
-@testset "DC Power Flow Models Monitored Line Flow Constraints and Static with Bounds" begin
-    system = PSB.build_system(PSITestSystems, "c_sys5_ml")
-    set_rate!(PSY.get_component(Line, system, "2"), 1.5)
-    for model in [DCPPowerModel, StandardPTDFModel]
-        template = get_thermal_dispatch_template_network(
-            NetworkModel(model; PTDF=PSY.PTDF(system)),
-        )
-        set_device_model!(template, DeviceModel(Line, StaticBranch))
-        set_device_model!(template, DeviceModel(MonitoredLine, StaticBranchUnbounded))
-        model_m = DecisionModel(template, system; optimizer=HiGHS_optimizer)
-        @test build!(model_m; output_dir=mktempdir(cleanup=true)) == PSI.BuildStatus.BUILT
-
-        @test check_variable_unbounded(model_m, FlowActivePowerVariable, MonitoredLine)
-        # Broken
-        # @test check_variable_bounded(model_m, FlowActivePowerVariable, Line)
-
-        @test solve!(model_m) == RunStatus.SUCCESSFUL
-        @test check_flow_variable_values(model_m, FlowActivePowerVariable, Line, "2", 1.5)
-    end
-end
-
 @testset "AC Power Flow Monitored Line Flow Constraints" begin
     system = PSB.build_system(PSITestSystems, "c_sys5_ml")
     limits = PSY.get_flow_limits(PSY.get_component(MonitoredLine, system, "1"))
@@ -62,6 +41,44 @@ end
         0.0,
         limits.from_to,
     )
+end
+
+@testset "DC Power Flow Models Monitored Line Flow Constraints and Static with inequalities" begin
+    system = PSB.build_system(PSITestSystems, "c_sys5_ml")
+    set_rate!(PSY.get_component(Line, system, "2"), 1.5)
+    for model in [DCPPowerModel, StandardPTDFModel]
+        template = get_thermal_dispatch_template_network(
+            NetworkModel(model; PTDF=PSY.PTDF(system)),
+        )
+        set_device_model!(template, DeviceModel(Line, StaticBranch))
+        set_device_model!(template, DeviceModel(MonitoredLine, StaticBranchUnbounded))
+        model_m = DecisionModel(template, system; optimizer=HiGHS_optimizer)
+        @test build!(model_m; output_dir=mktempdir(cleanup=true)) == PSI.BuildStatus.BUILT
+
+        @test check_variable_unbounded(model_m, FlowActivePowerVariable, MonitoredLine)
+
+        @test solve!(model_m) == RunStatus.SUCCESSFUL
+        @test check_flow_variable_values(model_m, FlowActivePowerVariable, Line, "2", 1.5)
+    end
+end
+@testset "DC Power Flow Models Monitored Line Flow Constraints and Static with Bounds" begin
+    system = PSB.build_system(PSITestSystems, "c_sys5_ml")
+    set_rate!(PSY.get_component(Line, system, "2"), 1.5)
+    for model in [DCPPowerModel, StandardPTDFModel]
+        template = get_thermal_dispatch_template_network(
+            NetworkModel(model; PTDF=PSY.PTDF(system)),
+        )
+        set_device_model!(template, DeviceModel(Line, StaticBranchBounds))
+        set_device_model!(template, DeviceModel(MonitoredLine, StaticBranchUnbounded))
+        model_m = DecisionModel(template, system; optimizer=HiGHS_optimizer)
+        @test build!(model_m; output_dir=mktempdir(cleanup=true)) == PSI.BuildStatus.BUILT
+
+        @test check_variable_unbounded(model_m, FlowActivePowerVariable, MonitoredLine)
+        @test check_variable_bounded(model_m, FlowActivePowerVariable, Line)
+
+        @test solve!(model_m) == RunStatus.SUCCESSFUL
+        @test check_flow_variable_values(model_m, FlowActivePowerVariable, Line, "2", 1.5)
+    end
 end
 
 @testset "DC Power Flow Models for HVDCLine with with Line Flow Constraints, TapTransformer & Transformer2W Unbounded" begin
@@ -85,16 +102,13 @@ end
     transformer = PSY.get_component(Transformer2W, system, "Trans4")
     rate_limit2w = PSY.get_rate(tap_transformer)
 
-    for model in [DCPPowerModel, StandardPTDFModel],
-        hvdc_model in [HVDCP2PDispatch, HVDCP2PLossless]
-
+    for model in [DCPPowerModel, StandardPTDFModel]
         template =
             get_template_dispatch_with_network(NetworkModel(model; PTDF=PSY.PTDF(system)))
-        set_device_model!(template, HVDCLine, hvdc_model)
+        set_device_model!(template, HVDCLine, HVDCP2PLossless)
         model_m = DecisionModel(template, system; optimizer=ipopt_optimizer)
         @test build!(model_m; output_dir=mktempdir(cleanup=true)) == PSI.BuildStatus.BUILT
 
-        @test check_variable_bounded(model_m, FlowActivePowerVariable, HVDCLine)
         @test check_variable_unbounded(model_m, FlowActivePowerVariable, TapTransformer)
         @test check_variable_unbounded(model_m, FlowActivePowerVariable, Transformer2W)
 
@@ -152,11 +166,9 @@ end
         model_m = DecisionModel(template, system; optimizer=ipopt_optimizer)
         @test build!(model_m; output_dir=mktempdir(cleanup=true)) == PSI.BuildStatus.BUILT
 
-        if model == DCPPowerModel
-            @test check_variable_unbounded(model_m, FlowActivePowerVariable, HVDCLine)
-            @test check_variable_bounded(model_m, FlowActivePowerVariable, TapTransformer)
-            @test check_variable_bounded(model_m, FlowActivePowerVariable, TapTransformer)
-        end
+        @test check_variable_unbounded(model_m, FlowActivePowerVariable, HVDCLine)
+        @test check_variable_bounded(model_m, FlowActivePowerVariable, TapTransformer)
+        @test check_variable_bounded(model_m, FlowActivePowerVariable, TapTransformer)
 
         @test solve!(model_m) == RunStatus.SUCCESSFUL
 
@@ -187,6 +199,192 @@ end
     end
 end
 
+@testset "HVDCP2PLossless values check between network models" begin
+    # Test to compare lossless models with lossless formulation
+    sys_5 = build_system(PSITestSystems, "c_sys5_uc")
+
+    line = get_component(Line, sys_5, "1")
+    remove_component!(sys_5, line)
+
+    hvdc = HVDCLine(
+        name=get_name(line),
+        available=true,
+        active_power_flow=0.0,
+        # Force the flow in the opposite direction for testing purposes
+        active_power_limits_from=(min=-2.0, max=-2.0),
+        active_power_limits_to=(min=-3.0, max=2.0),
+        reactive_power_limits_from=(min=-1.0, max=1.0),
+        reactive_power_limits_to=(min=-1.0, max=1.0),
+        arc=get_arc(line),
+        loss=(l0=0.00, l1=0.00),
+    )
+
+    add_component!(sys_5, hvdc)
+
+    template_uc = ProblemTemplate(NetworkModel(
+        StandardPTDFModel,
+        PTDF=PTDF(sys_5),
+    ))
+
+    set_device_model!(template_uc, ThermalStandard, ThermalCompactUnitCommitment)
+    set_device_model!(template_uc, RenewableDispatch, FixedOutput)
+    set_device_model!(template_uc, PowerLoad, StaticPowerLoad)
+    set_device_model!(template_uc, DeviceModel(
+        Line,
+        StaticBranchUnbounded,
+    ))
+    set_device_model!(template_uc, DeviceModel(
+        HVDCLine,
+        HVDCP2PLossless,
+    ))
+
+    model = DecisionModel(
+        template_uc,
+        sys_5;
+        name="UC",
+        optimizer=HiGHS_optimizer,
+        system_to_file=false,
+    )
+
+    solve!(model; output_dir=mktempdir())
+    ptdf_vars = get_variable_values(ProblemResults(model))
+    ptdf_values = ptdf_vars[PowerSimulations.VariableKey{FlowActivePowerVariable, Line}("")]
+    ptdf_objective = model.internal.container.optimizer_stats.objective_value
+
+    set_network_model!(template_uc, NetworkModel(
+        DCPPowerModel
+    ))
+
+    model = DecisionModel(
+        template_uc,
+        sys_5;
+        name="UC",
+        optimizer=HiGHS_optimizer,
+        system_to_file=false,
+    )
+
+    solve!(model; output_dir=mktempdir())
+    dcp_vars = get_variable_values(ProblemResults(model))
+    dcp_values = dcp_vars[PowerSimulations.VariableKey{FlowActivePowerVariable, Line}("")]
+    dcp_objective = model.internal.container.optimizer_stats.objective_value
+
+    @test isapprox(dcp_objective, ptdf_objective; atol = 0.1)
+    for col in names(ptdf_values)
+        @test all(isapprox.(ptdf_values[!, col], dcp_values[!, col]; atol = 0.1))
+    end
+end
+
+@testset "HVDCDispatch Model Tests" begin
+    # Test to compare lossless models with lossless formulation
+    sys_5 = build_system(PSITestSystems, "c_sys5_uc")
+
+    line = get_component(Line, sys_5, "1")
+    remove_component!(sys_5, line)
+
+    hvdc = HVDCLine(
+        name=get_name(line),
+        available=true,
+        active_power_flow=0.0,
+        # Force the flow in the opposite direction for testing purposes
+        active_power_limits_from=(min=-2.0, max=-2.0),
+        active_power_limits_to=(min=-3.0, max=2.0),
+        reactive_power_limits_from=(min=-1.0, max=1.0),
+        reactive_power_limits_to=(min=-1.0, max=1.0),
+        arc=get_arc(line),
+        loss=(l0=0.00, l1=0.00),
+    )
+
+    add_component!(sys_5, hvdc)
+    for net_model in [DCPPowerModel, StandardPTDFModel]
+        template_uc = ProblemTemplate(NetworkModel(
+            net_model,
+            PTDF=PTDF(sys_5),
+            use_slacks=true
+        ))
+
+        set_device_model!(template_uc, ThermalStandard, ThermalCompactUnitCommitment)
+        set_device_model!(template_uc, RenewableDispatch, FixedOutput)
+        set_device_model!(template_uc, PowerLoad, StaticPowerLoad)
+        set_device_model!(template_uc, DeviceModel(
+            Line,
+            StaticBranchUnbounded,
+        ))
+        set_device_model!(template_uc, DeviceModel(
+            HVDCLine,
+            HVDCP2PLossless,
+        ))
+
+        model_ref = DecisionModel(
+            template_uc,
+            sys_5;
+            name="UC",
+            optimizer=HiGHS_optimizer,
+            system_to_file=false,
+        )
+
+        solve!(model_ref; output_dir=mktempdir())
+        ref_vars = get_variable_values(ProblemResults(model_ref))
+        ref_values = ref_vars[PowerSimulations.VariableKey{FlowActivePowerVariable, Line}("")]
+        hvdc_ref_values = ref_vars[PowerSimulations.VariableKey{FlowActivePowerVariable, HVDCLine}("")]
+        ref_objective = model_ref.internal.container.optimizer_stats.objective_value
+
+        set_device_model!(template_uc, DeviceModel(
+            HVDCLine,
+            HVDCP2PDispatch,
+        ))
+
+        model = DecisionModel(
+            template_uc,
+            sys_5;
+            name="UC",
+            optimizer=HiGHS_optimizer,
+            system_to_file=false,
+        )
+
+        solve!(model; output_dir=mktempdir())
+        no_loss_vars = get_variable_values(ProblemResults(model))
+        no_loss_values = no_loss_vars[PowerSimulations.VariableKey{FlowActivePowerVariable, Line}("")]
+        hvdc_ft_no_loss_values = no_loss_vars[PowerSimulations.VariableKey{FlowActivePowerFromToVariable, HVDCLine}("")]
+        hvdc_tf_no_loss_values = no_loss_vars[PowerSimulations.VariableKey{FlowActivePowerToFromVariable, HVDCLine}("")]
+        no_loss_objective = model.internal.container.optimizer_stats.objective_value
+
+        @test isapprox(no_loss_objective, ref_objective; atol = 0.1)
+        for col in names(ref_values)
+            @test all(isapprox.(ref_values[!, col], no_loss_values[!, col]; atol = 0.1))
+        end
+
+        for col in names(hvdc_ft_no_loss_values)
+            @test all(hvdc_ft_no_loss_values[!, col] .== hvdc_tf_no_loss_values[!, col])
+        end
+
+        PSY.set_loss!(hvdc, (l0=0.1, l1=0.005))
+
+        model_wl = DecisionModel(
+            template_uc,
+            sys_5;
+            name="UC",
+            optimizer=HiGHS_optimizer,
+            system_to_file=false,
+        )
+
+        solve!(model_wl; output_dir=mktempdir())
+        dispatch_vars = get_variable_values(ProblemResults(model_wl))
+        dispatch_values = dispatch_vars[PowerSimulations.VariableKey{HVDCLosses, HVDCLine}("")]
+        # dispatch_values = dispatch_vars[PowerSimulations.VariableKey{FlowActivePowerVariable, Line}("")]
+        dispatch_values_ft = dispatch_vars[PowerSimulations.VariableKey{FlowActivePowerFromToVariable, HVDCLine}("")]
+        dispatch_values_tf = dispatch_vars[PowerSimulations.VariableKey{FlowActivePowerToFromVariable, HVDCLine}("")]
+        dispatch_objective = model_wl.internal.container.optimizer_stats.objective_value
+
+        @test dispatch_objective > no_loss_objective
+
+        for col in names(dispatch_values_tf)
+            @test all(dispatch_values_tf[!, col] .>= dispatch_values_ft[!, col])
+        end
+
+    end
+end
+
+#=
 @testset "AC Power Flow Models for HVDCLine Flow Constraints and TapTransformer & Transformer2W Unbounded" begin
     ratelimit_constraint_keys = [
         PSI.ConstraintKey(RateLimitConstraintFromTo, Transformer2W),
@@ -317,3 +515,4 @@ end
         rate_limit2w,
     )
 end
+=#

--- a/test/test_utils/operations_problem_templates.jl
+++ b/test/test_utils/operations_problem_templates.jl
@@ -13,7 +13,7 @@ function get_thermal_dispatch_template_network(network=CopperPlatePowerModel)
     set_device_model!(template, Line, StaticBranch)
     set_device_model!(template, Transformer2W, StaticBranch)
     set_device_model!(template, TapTransformer, StaticBranch)
-    set_device_model!(template, HVDCLine, HVDCLossless)
+    set_device_model!(template, HVDCLine, HVDCP2PLossless)
     return template
 end
 
@@ -70,6 +70,6 @@ function get_template_dispatch_with_network(network=StandardPTDFModel)
     set_device_model!(template, Line, StaticBranch)
     set_device_model!(template, Transformer2W, StaticBranch)
     set_device_model!(template, TapTransformer, StaticBranch)
-    set_device_model!(template, HVDCLine, HVDCLossless)
+    set_device_model!(template, HVDCLine, HVDCP2PLossless)
     return template
 end


### PR DESCRIPTION
Fixes issue with the incorrect specification of HVDC flow limits. It also renames the existing formulation to P2P. 

Currently, the HVDCDispatch Formulation seems to be implemented incorrectly, given that it isn't really meant to handle bi-directional HVDC with losses.  

I have corroborated that DCPPowerModel and StandardPTDF match the results of the line flows in the system. 

 closes #897 