### PR TITLE
Bug fix in Parameter updates

### DIFF
--- a/src/parameters/update_parameters.jl
+++ b/src/parameters/update_parameters.jl
@@ -170,13 +170,7 @@ function _update_parameter_values!(
         end
         for name in component_names
             # Pass indices in this way since JuMP DenseAxisArray don't support view()
-            _set_param_value!(
-                get_jump_model(model),
-                param_array,
-                state_values[state_data_index, name],
-                name,
-                t,
-            )
+            _set_param_value!(param_array, state_values[state_data_index, name], name, t)
         end
     end
     return


### PR DESCRIPTION
This should Fixes #932, at least for the part of the issue  I had, Wasn't able to reproduce  @claytonpbarrows error but it could be caused from the fact that the MT horizon doesn't cover the UC horizon in the last run. 
This would leave the variable value as NaNs in the simulation state since MT doesn't update those values,  we don't have error handling around that we should throw an error in the update process if Simulation State has NaN. Probably also have a test or something  