### PR TITLE
Fix check_conflict_status on undefined constraints

### DIFF
--- a/src/utils/jump_utils.jl
+++ b/src/utils/jump_utils.jl
@@ -336,7 +336,8 @@ function check_conflict_status(
     conflict_indices = Vector()
     dims = axes(constraint_container)
     for index in Iterators.product(dims...)
-        if MOI.get(
+        if isassigned(constraint_container, index...) &&
+           MOI.get(
             jump_model,
             MOI.ConstraintConflictStatus(),
             constraint_container[index...],
@@ -353,7 +354,8 @@ function check_conflict_status(
 )
     conflict_indices = Vector()
     for (index, constraint) in constraint_container
-        if MOI.get(jump_model, MOI.ConstraintConflictStatus(), constraint) !=
+        if isassigned(constraint_container, index...) &&
+           MOI.get(jump_model, MOI.ConstraintConflictStatus(), constraint) !=
            MOI.NOT_IN_CONFLICT
             push!(conflict_indices, index)
         end


### PR DESCRIPTION
When a generator uses quadratic heat rates, the corresponding row is undefined in the constraint `DenseAxisArray` under `PSI.ConstraintKey{PSI.PieceWiseLinearCostConstraint, PSY.ThermalStandard}("")`.

This causes an error when compute_conflict! is called

```
┌ Error: Can't compute conflict
│   exception =
│    UndefRefError: access to undefined reference
│    Stacktrace:
│      [1] getindex
│        @ ./array.jl:925 [inlined]│      [2] getindex
│        @ ~/.julia/packages/JuMP/Xw2ck/src/Containers/DenseAxisArray.jl:348 [inlined]
│      [3] check_conflict_status(jump_model::JuMP.Model, constraint_container::JuMP.Containers.DenseAxisArray{JuMP.ConstraintRef, 2, Tuple{Vector{String}, UnitRange{Int6$
}}, Tuple{JuMP.Containers._AxisLookup{Dict{String, Int64}}, JuMP.Containers._AxisLookup{Tuple{Int64, Int64}}}})
│        @ PowerSimulations ~/.julia/packages/PowerSimulations/UWK7W/src/utils/jump_utils.jl:339
│      [4] compute_conflict!(container::PowerSimulations.OptimizationContainer)
│        @ PowerSimulations ~/.julia/packages/PowerSimulations/UWK7W/src/core/optimization_container.jl:635
```
The solution is to add a check for `isassigned(constraint_matrix, indices...)` in the `check_conflict_status` function.